### PR TITLE
Minor Updates to pom.xml

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -128,7 +128,7 @@ The above command invokes both unit and integration test suites. To execute only
 tests, run the command as follows:
 
 ```
-mvn verify -Dfirebase.it.certificate=path/to/your/serviceAccount.json -Dskip.surefire.tests=true
+mvn verify -Dfirebase.it.certificate=path/to/your/serviceAccount.json -DskipUTs
 ```
 
 ### Generating API Docs

--- a/pom.xml
+++ b/pom.xml
@@ -42,14 +42,15 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <skipUTs>${skipTests}</skipUTs>
     </properties>
 
     <scm>
         <connection>scm:git:https://github.com/firebase/firebase-admin-java.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/firebase/firebase-admin-java.git</developerConnection>
         <url>http://github.com/firebase/firebase-admin-java</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <distributionManagement>
         <snapshotRepository>
@@ -80,7 +81,6 @@
                 <plugins>
                     <plugin>
                         <!-- Generate API docs using Doclava for the developer site -->
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <executions>
                             <execution>
@@ -137,11 +137,13 @@
         </profile>
         <profile>
             <id>release</id>
+            <properties>
+                <!-- Prevent executing integration tests twice during a release -->
+                <skipITs>true</skipITs>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
-                        <!-- Generate API docs using Doclava for the developer site -->
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <executions>
                             <execution>
@@ -167,11 +169,11 @@
                         </configuration>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <version>2.2.1</version>
                         <configuration>
                             <excludes>
+                                <!-- Exclude all files until we go open source -->
                                 <exclude>com/**</exclude>
                             </excludes>
                         </configuration>
@@ -185,7 +187,6 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>1.5</version>
                         <executions>
@@ -243,17 +244,12 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
                 <configuration>
-                  <skipTests>${skip.surefire.tests}</skipTests>
+                    <skipTests>${skipUTs}</skipTests>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.19.1</version>
-                <configuration>
-                    <includes>
-                        <include>**/*IT.java</include>
-                    </includes>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -264,12 +260,10 @@
                 </executions>                
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.4</version>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5.3</version>
                 <configuration>


### PR DESCRIPTION
Some minor changes to pom.xml based on today's release experience.

Adding a flag to disable unit tests and integration tests separately
==================================
* `-DskipITs` (skips integration tests; flag provided by maven failsafe plugin)
* `-DskipUTs` (skips unit tests; custom flag added to pom.xml)

Also the failsafe plugin knows to look for *IT.java tests. We don't have to explicitly mention it in the pom.

Skipping integration tests in the release profile
==================================
Maven-based release is conducted in 2 main steps:
* `mvn release:prepare`
* `mvn release:perform`

The `prepare` step builds and runs all tests (both unit and integration) before tagging the source in GitHub. The `perform` step grabs the source from the tag, and proceeds to build and test it again. Therefore we end up running the integration test suite twice during the release process which is redundant and takes time. This PR sets the `skipITs` flag in the release profile which essentially skips integration tests during `release:perform`.
