### PR TITLE
Fail fast semantics in the FirebaseCredentials API

### DIFF
--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -1,5 +1,6 @@
 package com.google.firebase;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
@@ -9,7 +10,6 @@ import com.google.firebase.auth.FirebaseCredentials;
 import com.google.firebase.internal.NonNull;
 import com.google.firebase.internal.Nullable;
 
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -87,7 +87,6 @@ public final class FirebaseOptions {
 
     private String databaseUrl;
     private FirebaseCredential firebaseCredential;
-    private FirebaseCredential serviceAccountCredential;
     private Map<String, Object> databaseAuthVariableOverride = new HashMap<>();
 
     /** Constructs an empty builder. */
@@ -120,26 +119,7 @@ public final class FirebaseOptions {
     }
 
     /**
-     * Sets the service account to use to authenticate the SDK.
-     *
-     * <p>This method is deprecated in favor of the {@link #setCredential} method. Only one of the
-     * <code>setCredential()</code> and <code>setServiceAccount()</code> methods can be used.
-     *
-     * @param stream A stream containing the service account contents as JSON.
-     * @return This <code>Builder</code> instance is returned so subsequent calls can be chained.
-     * @deprecated Use {@link #setCredential} instead and obtain credentials via {@link
-     *     FirebaseCredentials}.
-     */
-    @Deprecated
-    public Builder setServiceAccount(@NonNull InputStream stream) {
-      serviceAccountCredential = FirebaseCredentials.fromCertificate(stream);
-      return this;
-    }
-
-    /**
      * Sets the <code>FirebaseCredential</code> to use to authenticate the SDK.
-     *
-     * <p>This method replaces the deprecated {@link #setServiceAccount} method.
      *
      * <p>See <a href="/docs/admin/setup#initialize_the_sdk">Initialize the SDK</a> for code samples
      * and detailed documentation.
@@ -183,18 +163,8 @@ public final class FirebaseOptions {
      * @return A {@link FirebaseOptions} instance created from the previously set options.
      */
     public FirebaseOptions build() {
-      if (serviceAccountCredential == null && firebaseCredential == null) {
-        throw new IllegalStateException(
-            "FirebaseOptions must be initialized with setCredential().");
-      } else if (serviceAccountCredential != null && firebaseCredential != null) {
-        throw new IllegalStateException(
-            "FirebaseOptions cannot be initialized with both "
-                + "setCredential() and setServiceAccount().");
-      }
-
-      FirebaseCredential firebaseCredential =
-          this.firebaseCredential != null ? this.firebaseCredential : serviceAccountCredential;
-
+      checkArgument(firebaseCredential != null,
+          "FirebaseOptions must be initialized with setCredential().");
       return new FirebaseOptions(databaseUrl, firebaseCredential, databaseAuthVariableOverride);
     }
   }

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -158,7 +158,7 @@ public class FirebaseAuth {
                   + "verifyIdToken()"));
     }
     return ((FirebaseCredentials.CertCredential) credential)
-        .getProjectId(false)
+        .getProjectId()
         .continueWith(
             new Continuation<String, FirebaseToken>() {
               @Override

--- a/src/test/java/com/google/firebase/FirebaseAppTest.java
+++ b/src/test/java/com/google/firebase/FirebaseAppTest.java
@@ -27,6 +27,8 @@ import com.google.firebase.tasks.TaskCompletionSource;
 import com.google.firebase.tasks.Tasks;
 import com.google.firebase.testing.FirebaseAppRule;
 import com.google.firebase.testing.ServiceAccount;
+import com.google.firebase.testing.TestUtils;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -50,7 +52,7 @@ public class FirebaseAppTest {
 
   private static final FirebaseOptions OPTIONS =
       new FirebaseOptions.Builder()
-          .setCredential(FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream()))
+          .setCredential(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
           .build();
   private static final FirebaseOptions MOCK_CREDENTIAL_OPTIONS =
       new Builder().setCredential(new MockFirebaseCredential()).build();
@@ -154,7 +156,7 @@ public class FirebaseAppTest {
   }
 
   @Test
-  public void testToString() {
+  public void testToString() throws IOException {
     FirebaseOptions options =
         new FirebaseOptions.Builder()
             .setCredential(FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream()))

--- a/src/test/java/com/google/firebase/FirebaseOptionsTest.java
+++ b/src/test/java/com/google/firebase/FirebaseOptionsTest.java
@@ -16,6 +16,7 @@ import com.google.firebase.tasks.OnSuccessListener;
 import com.google.firebase.tasks.Task;
 import com.google.firebase.tasks.Tasks;
 import com.google.firebase.testing.ServiceAccount;
+import com.google.firebase.testing.TestUtils;
 import java.io.IOException;
 import java.util.concurrent.Semaphore;
 import org.junit.Test;
@@ -25,12 +26,12 @@ import org.junit.Test;
  */
 public class FirebaseOptionsTest {
 
-  private static final String FIREBASE_DB_URL = "https://ghconfigtest-644f2.firebaseio.com";
+  private static final String FIREBASE_DB_URL = "https://mock-project.firebaseio.com";
 
   private static final FirebaseOptions ALL_VALUES_OPTIONS =
       new FirebaseOptions.Builder()
           .setDatabaseUrl(FIREBASE_DB_URL)
-          .setCredential(FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream()))
+          .setCredential(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
           .build();
 
   @Test
@@ -42,28 +43,6 @@ public class FirebaseOptionsTest {
             .setCredential(FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream()))
             .build();
     assertEquals(FIREBASE_DB_URL, firebaseOptions.getDatabaseUrl());
-    TestOnlyImplFirebaseAuthTrampolines.getCertificate(firebaseOptions.getCredential())
-        .addOnSuccessListener(
-            new OnSuccessListener<GoogleCredential>() {
-              @Override
-              public void onSuccess(GoogleCredential googleCredential) {
-                assertEquals(
-                    ServiceAccount.EDITOR.getEmail(), googleCredential.getServiceAccountId());
-                semaphore.release();
-              }
-            });
-    TestHelpers.waitFor(semaphore);
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void createOptionsWithServiceAccountSet() throws IOException, InterruptedException {
-    final Semaphore semaphore = new Semaphore(0);
-    FirebaseOptions firebaseOptions =
-        new FirebaseOptions.Builder()
-            .setDatabaseUrl(FIREBASE_DB_URL)
-            .setServiceAccount(ServiceAccount.EDITOR.asStream())
-            .build();
     TestOnlyImplFirebaseAuthTrampolines.getCertificate(firebaseOptions.getCredential())
         .addOnSuccessListener(
             new OnSuccessListener<GoogleCredential>() {
@@ -114,18 +93,9 @@ public class FirebaseOptionsTest {
     assertEquals("mock-project-id", Tasks.await(projectId));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void createOptionsWithCredentialMissing() {
     new FirebaseOptions.Builder().build();
-  }
-
-  @Test(expected = IllegalStateException.class)
-  @SuppressWarnings("deprecation")
-  public void createOptionsWithServiceAccountAndCredential() {
-    new FirebaseOptions.Builder()
-        .setServiceAccount(ServiceAccount.EDITOR.asStream())
-        .setCredential(FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream()))
-        .build();
   }
 
   @Test
@@ -136,7 +106,7 @@ public class FirebaseOptionsTest {
   }
 
   @Test
-  public void testEquals() {
+  public void testEquals() throws IOException {
     FirebaseCredential credential = FirebaseCredentials
         .fromCertificate(ServiceAccount.EDITOR.asStream());
     FirebaseOptions options1 =
@@ -151,7 +121,7 @@ public class FirebaseOptionsTest {
   }
 
   @Test
-  public void testNotEquals() {
+  public void testNotEquals() throws IOException {
     FirebaseCredential credential = FirebaseCredentials
         .fromCertificate(ServiceAccount.EDITOR.asStream());
     FirebaseOptions options1 =
@@ -167,7 +137,7 @@ public class FirebaseOptionsTest {
   }
 
   @Test
-  public void testHashCode() {
+  public void testHashCode() throws IOException {
     FirebaseCredential credential = FirebaseCredentials
         .fromCertificate(ServiceAccount.EDITOR.asStream());
     FirebaseOptions options1 =

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
@@ -108,7 +108,7 @@ public class FirebaseAuthTest {
   }
 
   private static FirebaseCredential createRefreshTokenCredential()
-      throws JSONException, UnsupportedEncodingException {
+      throws JSONException, IOException {
 
     MockTokenServerTransport transport = new MockTokenServerTransport();
     transport.addClient(CLIENT_ID, CLIENT_SECRET);
@@ -126,7 +126,7 @@ public class FirebaseAuthTest {
         refreshTokenStream, transport, Utils.getDefaultJsonFactory());
   }
 
-  private static FirebaseCredential createCertificateCredential() {
+  private static FirebaseCredential createCertificateCredential() throws IOException {
     MockTokenServerTransport transport = new MockTokenServerTransport();
     transport.addServiceAccount(ServiceAccount.EDITOR.getEmail(), ACCESS_TOKEN);
 

--- a/src/test/java/com/google/firebase/auth/TestOnlyImplFirebaseAuthTrampolines.java
+++ b/src/test/java/com/google/firebase/auth/TestOnlyImplFirebaseAuthTrampolines.java
@@ -42,7 +42,7 @@ public final class TestOnlyImplFirebaseAuthTrampolines {
 
   /* FirebaseCredentials */
   public static Task<String> getProjectId(FirebaseCredential credential) {
-    return ((FirebaseCredentials.CertCredential) credential).getProjectId(false);
+    return ((FirebaseCredentials.CertCredential) credential).getProjectId();
   }
 
   /* FirebaseAuth */

--- a/src/test/java/com/google/firebase/database/DataSnapshotTest.java
+++ b/src/test/java/com/google/firebase/database/DataSnapshotTest.java
@@ -13,6 +13,7 @@ import com.google.firebase.database.snapshot.IndexedNode;
 import com.google.firebase.database.snapshot.Node;
 import com.google.firebase.database.snapshot.NodeUtilities;
 import com.google.firebase.testing.ServiceAccount;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import org.junit.AfterClass;
@@ -25,7 +26,7 @@ public class DataSnapshotTest {
   private static DatabaseConfig config;
 
   @BeforeClass
-  public static void setUpClass() {
+  public static void setUpClass() throws IOException {
     testApp = FirebaseApp.initializeApp(
         new FirebaseOptions.Builder()
             .setCredential(FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream()))

--- a/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
+++ b/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
@@ -12,6 +12,7 @@ import com.google.firebase.auth.FirebaseCredential;
 import com.google.firebase.auth.FirebaseCredentials;
 import com.google.firebase.testing.ServiceAccount;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -32,7 +33,11 @@ public class FirebaseDatabaseTest {
   }
 
   private static FirebaseCredential createCertificateCredential() {
-    return FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream());
+    try {
+      return FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Test

--- a/src/test/java/com/google/firebase/database/core/SyncPointTest.java
+++ b/src/test/java/com/google/firebase/database/core/SyncPointTest.java
@@ -50,7 +50,7 @@ public class SyncPointTest {
   private static FirebaseApp testApp;
 
   @BeforeClass
-  public static void setUpClass() {
+  public static void setUpClass() throws IOException {
     testApp = FirebaseApp.initializeApp(
         new FirebaseOptions.Builder()
             .setCredential(FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream()))

--- a/src/test/java/com/google/firebase/database/core/persistence/DefaultPersistenceManagerTest.java
+++ b/src/test/java/com/google/firebase/database/core/persistence/DefaultPersistenceManagerTest.java
@@ -24,6 +24,7 @@ import com.google.firebase.database.snapshot.Index;
 import com.google.firebase.database.snapshot.Node;
 import com.google.firebase.database.snapshot.PathIndex;
 import com.google.firebase.testing.ServiceAccount;
+import java.io.IOException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -37,7 +38,7 @@ public class DefaultPersistenceManagerTest {
   private static FirebaseApp testApp;
 
   @BeforeClass
-  public static void setUpClass() {
+  public static void setUpClass() throws IOException {
     testApp = FirebaseApp.initializeApp(
         new FirebaseOptions.Builder()
             .setCredential(FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream()))

--- a/src/test/java/com/google/firebase/database/core/persistence/RandomPersistenceTest.java
+++ b/src/test/java/com/google/firebase/database/core/persistence/RandomPersistenceTest.java
@@ -31,6 +31,7 @@ import com.google.firebase.database.core.view.QueryParams;
 import com.google.firebase.database.core.view.QuerySpec;
 import com.google.firebase.database.snapshot.Node;
 import com.google.firebase.testing.ServiceAccount;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -54,7 +55,7 @@ public class RandomPersistenceTest {
   private static FirebaseApp testApp;
 
   @BeforeClass
-  public static void setUpClass() {
+  public static void setUpClass() throws IOException {
     testApp = FirebaseApp.initializeApp(
         new FirebaseOptions.Builder()
             .setCredential(FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream()))

--- a/src/test/java/com/google/firebase/database/integration/FirebaseDatabaseAuthTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/FirebaseDatabaseAuthTestIT.java
@@ -59,7 +59,7 @@ public class FirebaseDatabaseAuthTestIT {
   }
   
   @Test
-  public void testAuthWithInvalidCertificateCredential() throws InterruptedException {
+  public void testAuthWithInvalidCertificateCredential() throws InterruptedException, IOException {
     FirebaseOptions options =
         new FirebaseOptions.Builder()
             .setDatabaseUrl(IntegrationTestUtils.getDatabaseUrl())

--- a/src/test/java/com/google/firebase/database/integration/FirebaseDatabaseTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/FirebaseDatabaseTestIT.java
@@ -21,6 +21,7 @@ import com.google.firebase.tasks.Tasks;
 import com.google.firebase.testing.IntegrationTestUtils;
 import com.google.firebase.testing.TestUtils;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -239,19 +240,27 @@ public class FirebaseDatabaseTestIT {
   }
   
   private static FirebaseApp appWithDbUrl(String dbUrl, String name) {
-    FirebaseOptions options = new FirebaseOptions.Builder()
-        .setDatabaseUrl(dbUrl)
-        .setCredential(FirebaseCredentials.fromCertificate(
-            IntegrationTestUtils.getServiceAccountCertificate()))
-        .build();
-    return FirebaseApp.initializeApp(options, name);
+    try {
+      FirebaseOptions options = new FirebaseOptions.Builder()
+          .setDatabaseUrl(dbUrl)
+          .setCredential(FirebaseCredentials.fromCertificate(
+              IntegrationTestUtils.getServiceAccountCertificate()))
+          .build();
+      return FirebaseApp.initializeApp(options, name);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
   
   private static FirebaseApp appWithoutDbUrl(String name) {
-    FirebaseOptions options = new FirebaseOptions.Builder()
-        .setCredential(FirebaseCredentials.fromCertificate(
-            IntegrationTestUtils.getServiceAccountCertificate()))
-        .build();
-    return FirebaseApp.initializeApp(options, name);
+    try {
+      FirebaseOptions options = new FirebaseOptions.Builder()
+          .setCredential(FirebaseCredentials.fromCertificate(
+              IntegrationTestUtils.getServiceAccountCertificate()))
+          .build();
+      return FirebaseApp.initializeApp(options, name);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/test/java/com/google/firebase/internal/FirebaseAppStoreTest.java
+++ b/src/test/java/com/google/firebase/internal/FirebaseAppStoreTest.java
@@ -8,6 +8,8 @@ import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.auth.FirebaseCredentials;
 import com.google.firebase.testing.FirebaseAppRule;
 import com.google.firebase.testing.ServiceAccount;
+import com.google.firebase.testing.TestUtils;
+import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -18,7 +20,7 @@ public class FirebaseAppStoreTest {
   private static final FirebaseOptions ALL_VALUES_OPTIONS =
       new FirebaseOptions.Builder()
           .setDatabaseUrl(FIREBASE_DB_URL)
-          .setCredential(FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream()))
+          .setCredential(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
           .build();
 
   @Rule public FirebaseAppRule firebaseAppRule = new FirebaseAppRule();
@@ -32,7 +34,7 @@ public class FirebaseAppStoreTest {
   }
 
   @Test
-  public void incompatibleAppInitializedDoesntThrow() {
+  public void incompatibleAppInitializedDoesntThrow() throws IOException {
     String name = "myApp";
     FirebaseApp.initializeApp(ALL_VALUES_OPTIONS, name);
     TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
@@ -44,7 +46,7 @@ public class FirebaseAppStoreTest {
   }
 
   @Test
-  public void incompatibleDefaultAppInitializedDoesntThrow() {
+  public void incompatibleDefaultAppInitializedDoesntThrow() throws IOException {
     FirebaseApp.initializeApp(ALL_VALUES_OPTIONS);
     TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
     FirebaseOptions options =

--- a/src/test/java/com/google/firebase/testing/IntegrationTestUtils.java
+++ b/src/test/java/com/google/firebase/testing/IntegrationTestUtils.java
@@ -9,7 +9,6 @@ import com.google.common.io.CharStreams;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
-import com.google.firebase.auth.FirebaseCredentials;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.internal.GetTokenResult;
@@ -76,7 +75,7 @@ public class IntegrationTestUtils {
       FirebaseOptions options =
           new FirebaseOptions.Builder()
               .setDatabaseUrl(getDatabaseUrl())
-              .setCredential(FirebaseCredentials.fromCertificate(getServiceAccountCertificate()))
+              .setCredential(TestUtils.getCertCredential(getServiceAccountCertificate()))
               .build();
       masterApp = FirebaseApp.initializeApp(options);
     }
@@ -87,7 +86,7 @@ public class IntegrationTestUtils {
     FirebaseOptions options =
         new FirebaseOptions.Builder()
             .setDatabaseUrl(getDatabaseUrl())
-            .setCredential(FirebaseCredentials.fromCertificate(getServiceAccountCertificate()))
+            .setCredential(TestUtils.getCertCredential(getServiceAccountCertificate()))
             .build();
     return FirebaseApp.initializeApp(options, name);
   }

--- a/src/test/java/com/google/firebase/testing/TestUtils.java
+++ b/src/test/java/com/google/firebase/testing/TestUtils.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.common.io.CharStreams;
+import com.google.firebase.auth.FirebaseCredential;
+import com.google.firebase.auth.FirebaseCredentials;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -57,6 +59,14 @@ public class TestUtils {
     checkNotNull(stream, "Failed to load resource: %s", path);
     try (InputStreamReader reader = new InputStreamReader(stream)) {
       return CharStreams.toString(reader);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static FirebaseCredential getCertCredential(InputStream stream) {
+    try {
+      return FirebaseCredentials.fromCertificate(stream);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Throwing IOExceptions from the factory methods in `FirebaseCredentials` class. These methods used to hold on to the exception, and then throw it at a later time which resulted in confusing error handling semantics. Instead this PR changes the API to throw any encountered exceptions immediately thereby providing much simpler fail fast semantics. This is a breaking change and the PR is drawn against a special io2017 branch.