### PR TITLE
Fixing a Thread Leak in Database Client Code (Related to #29)

### DIFF
--- a/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
+++ b/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
@@ -139,7 +139,7 @@ public class PersistentConnectionImpl implements Connection.Delegate, Persistent
             .withMinDelayAfterFailure(1000)
             .withRetryExponent(1.3)
             .withMaxDelay(30 * 1000)
-            .withJitterFactor(0.7)
+            .withJitterFactor(0.25)
             .build();
 
     long connId = connectionIds++;

--- a/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
+++ b/src/main/java/com/google/firebase/database/connection/PersistentConnectionImpl.java
@@ -139,7 +139,7 @@ public class PersistentConnectionImpl implements Connection.Delegate, Persistent
             .withMinDelayAfterFailure(1000)
             .withRetryExponent(1.3)
             .withMaxDelay(30 * 1000)
-            .withJitterFactor(0.25)
+            .withJitterFactor(0.7)
             .build();
 
     long connId = connectionIds++;

--- a/src/main/java/com/google/firebase/database/tubesock/WebSocketReceiver.java
+++ b/src/main/java/com/google/firebase/database/tubesock/WebSocketReceiver.java
@@ -47,6 +47,9 @@ class WebSocketReceiver {
     this.eventHandler = websocket.getEventHandler();
     while (!stop) {
       try {
+        if (Thread.interrupted()) {
+          throw new InterruptedException();
+        }
         int offset = 0;
         offset += read(inputHeader, offset, 1);
         boolean fin = (inputHeader[0] & 0x80) != 0;
@@ -94,6 +97,8 @@ class WebSocketReceiver {
         continue;
       } catch (IOException ioe) {
         handleError(new WebSocketException("IO Error", ioe));
+      } catch (InterruptedException e) {
+        handleError(new WebSocketException("Receiver interrupted", e));
       } catch (WebSocketException e) {
         handleError(e);
       }

--- a/src/main/java/com/google/firebase/database/tubesock/WebSocketWriter.java
+++ b/src/main/java/com/google/firebase/database/tubesock/WebSocketWriter.java
@@ -16,6 +16,8 @@
 
 package com.google.firebase.database.tubesock;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
@@ -32,7 +34,10 @@ import java.util.concurrent.LinkedBlockingQueue;
 class WebSocketWriter {
 
   private final Random random = new Random();
-  private final Thread innerThread;
+  private final String threadBaseName;
+  private final int clientId;
+
+  private Thread innerThread;
   private BlockingQueue<ByteBuffer> pendingBuffers;
   private volatile boolean stop = false;
   private boolean closeSent = false;
@@ -40,18 +45,9 @@ class WebSocketWriter {
   private WritableByteChannel channel;
 
   WebSocketWriter(WebSocket websocket, String threadBaseName, int clientId) {
-    innerThread =
-        WebSocket.getThreadFactory()
-            .newThread(
-                new Runnable() {
-                  @Override
-                  public void run() {
-                    runWriter();
-                  }
-                });
-
-    WebSocket.getIntializer().setName(getInnerThread(), threadBaseName + "Writer-" + clientId);
     this.websocket = websocket;
+    this.threadBaseName = threadBaseName;
+    this.clientId = clientId;
     pendingBuffers = new LinkedBlockingQueue<>();
   }
 
@@ -166,7 +162,31 @@ class WebSocketWriter {
     }
   }
 
-  Thread getInnerThread() {
-    return innerThread;
+  synchronized void start() {
+    checkState(innerThread == null, "Inner thread already started");
+    innerThread =
+        WebSocket.getThreadFactory()
+            .newThread(
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    runWriter();
+                  }
+                });
+    WebSocket.getIntializer().setName(innerThread, threadBaseName + "Writer-" + clientId);
+    innerThread.start();
+  }
+
+  void waitFor() throws InterruptedException {
+    // If the thread is null, it will never be instantiated, since we closed the connection
+    // before we actually connected.
+    Thread thread;
+    synchronized (this) {
+      if (innerThread == null) {
+        return;
+      }
+      thread = innerThread;
+    }
+    thread.join();
   }
 }

--- a/src/main/java/com/google/firebase/database/tubesock/WebSocketWriter.java
+++ b/src/main/java/com/google/firebase/database/tubesock/WebSocketWriter.java
@@ -34,8 +34,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 class WebSocketWriter {
 
   private final Random random = new Random();
-  private final String threadBaseName;
-  private final int clientId;
+  private final String threadName;
 
   private Thread innerThread;
   private BlockingQueue<ByteBuffer> pendingBuffers;
@@ -46,8 +45,7 @@ class WebSocketWriter {
 
   WebSocketWriter(WebSocket websocket, String threadBaseName, int clientId) {
     this.websocket = websocket;
-    this.threadBaseName = threadBaseName;
-    this.clientId = clientId;
+    this.threadName = threadBaseName + "Writer-" + clientId;
     pendingBuffers = new LinkedBlockingQueue<>();
   }
 
@@ -173,11 +171,11 @@ class WebSocketWriter {
                     runWriter();
                   }
                 });
-    WebSocket.getIntializer().setName(innerThread, threadBaseName + "Writer-" + clientId);
+    WebSocket.getIntializer().setName(innerThread, threadName);
     innerThread.start();
   }
 
-  void waitFor() throws InterruptedException {
+  void waitForTermination() throws InterruptedException {
     // If the thread is null, it will never be instantiated, since we closed the connection
     // before we actually connected.
     Thread thread;


### PR DESCRIPTION
Creating Websocket reader and writer threads lazily to avoid the thread leak described in #29; Handling thread interrupts from Websocket receiver thread (not comprehensive due to the blocking nature of IO calls; Reducing the default jitter factor to 25%
