### PR TITLE
Refactoring the User Management API

### DIFF
--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -30,7 +30,8 @@ import com.google.common.base.Strings;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseException;
 import com.google.firebase.ImplFirebaseTrampolines;
-import com.google.firebase.auth.UserRecord.Update;
+import com.google.firebase.auth.UserRecord.CreateRequest;
+import com.google.firebase.auth.UserRecord.UpdateRequest;
 import com.google.firebase.auth.internal.FirebaseTokenFactory;
 import com.google.firebase.auth.internal.FirebaseTokenVerifier;
 import com.google.firebase.internal.FirebaseService;
@@ -246,15 +247,15 @@ public class FirebaseAuth {
 
   /**
    * Creates a new user account with the attributes contained in the specified
-   * {@link UserRecord.NewUser}.
+   * {@link CreateRequest}.
    *
-   * @param user A non-null {@link UserRecord.NewUser} instance.
+   * @param user A non-null {@link CreateRequest} instance.
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance
    *     corresponding to the newly created account. If an error occurs while creating the user
    *     account, the task fails with a FirebaseAuthException.
    * @throws NullPointerException if the provided user is null.
    */
-  public Task<UserRecord> createUser(final UserRecord.NewUser user) {
+  public Task<UserRecord> createUser(final CreateRequest user) {
     checkNotNull(user, "user must not be null");
     return ImplFirebaseTrampolines.getToken(firebaseApp, false).continueWith(
         new Continuation<GetTokenResult, UserRecord>() {
@@ -268,22 +269,22 @@ public class FirebaseAuth {
 
   /**
    * Updates an existing user account with the attributes contained in the specified
-   * {@link Update}.
+   * {@link UpdateRequest}.
    *
-   * @param update A non-null {@link Update} instance.
+   * @param request A non-null {@link UpdateRequest} instance.
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance
    *     corresponding to the updated user account. If an error occurs while updating the user
    *     account, the task fails with a FirebaseAuthException.
    * @throws NullPointerException if the provided update is null.
    */
-  public Task<UserRecord> updateUser(final Update update) {
-    checkNotNull(update, "update must not be null");
+  public Task<UserRecord> updateUser(final UpdateRequest request) {
+    checkNotNull(request, "update must not be null");
     return ImplFirebaseTrampolines.getToken(firebaseApp, false).continueWith(
         new Continuation<GetTokenResult, UserRecord>() {
           @Override
           public UserRecord then(Task<GetTokenResult> task) throws Exception {
-            userManager.updateUser(update, task.getResult().getToken());
-            return userManager.getUserById(update.getUid(), task.getResult().getToken());
+            userManager.updateUser(request, task.getResult().getToken());
+            return userManager.getUserById(request.getUid(), task.getResult().getToken());
           }
         });
   }

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -249,19 +249,19 @@ public class FirebaseAuth {
    * Creates a new user account with the attributes contained in the specified
    * {@link CreateRequest}.
    *
-   * @param user A non-null {@link CreateRequest} instance.
+   * @param request A non-null {@link CreateRequest} instance.
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance
    *     corresponding to the newly created account. If an error occurs while creating the user
    *     account, the task fails with a FirebaseAuthException.
    * @throws NullPointerException if the provided user is null.
    */
-  public Task<UserRecord> createUser(final CreateRequest user) {
-    checkNotNull(user, "user must not be null");
+  public Task<UserRecord> createUser(final CreateRequest request) {
+    checkNotNull(request, "create request must not be null");
     return ImplFirebaseTrampolines.getToken(firebaseApp, false).continueWith(
         new Continuation<GetTokenResult, UserRecord>() {
           @Override
           public UserRecord then(Task<GetTokenResult> task) throws Exception {
-            String uid = userManager.createUser(user, task.getResult().getToken());
+            String uid = userManager.createUser(request, task.getResult().getToken());
             return userManager.getUserById(uid, task.getResult().getToken());
           }
         });
@@ -278,7 +278,7 @@ public class FirebaseAuth {
    * @throws NullPointerException if the provided update is null.
    */
   public Task<UserRecord> updateUser(final UpdateRequest request) {
-    checkNotNull(request, "update must not be null");
+    checkNotNull(request, "update request must not be null");
     return ImplFirebaseTrampolines.getToken(firebaseApp, false).continueWith(
         new Continuation<GetTokenResult, UserRecord>() {
           @Override

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -252,10 +252,10 @@ public class FirebaseAuth {
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance
    *     corresponding to the newly created account. If an error occurs while creating the user
    *     account, the task fails with a FirebaseAuthException.
-   * @throws NullPointerException if the provided builder is null.
+   * @throws NullPointerException if the provided user is null.
    */
   public Task<UserRecord> createUser(final UserRecord.NewUser user) {
-    checkNotNull(user, "builder must not be null");
+    checkNotNull(user, "user must not be null");
     return ImplFirebaseTrampolines.getToken(firebaseApp, false).continueWith(
         new Continuation<GetTokenResult, UserRecord>() {
           @Override
@@ -274,10 +274,10 @@ public class FirebaseAuth {
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance
    *     corresponding to the updated user account. If an error occurs while updating the user
    *     account, the task fails with a FirebaseAuthException.
-   * @throws NullPointerException if the provided getProperties is null.
+   * @throws NullPointerException if the provided update is null.
    */
   public Task<UserRecord> updateUser(final Update update) {
-    checkNotNull(update, "getProperties must not be null");
+    checkNotNull(update, "update must not be null");
     return ImplFirebaseTrampolines.getToken(firebaseApp, false).continueWith(
         new Continuation<GetTokenResult, UserRecord>() {
           @Override

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -30,6 +30,7 @@ import com.google.common.base.Strings;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseException;
 import com.google.firebase.ImplFirebaseTrampolines;
+import com.google.firebase.auth.UserRecord.Update;
 import com.google.firebase.auth.internal.FirebaseTokenFactory;
 import com.google.firebase.auth.internal.FirebaseTokenVerifier;
 import com.google.firebase.internal.FirebaseService;
@@ -245,21 +246,21 @@ public class FirebaseAuth {
 
   /**
    * Creates a new user account with the attributes contained in the specified
-   * {@link UserRecord.Builder}.
+   * {@link UserRecord.NewUser}.
    *
-   * @param builder A non-null {@link UserRecord.Builder} instance.
+   * @param user A non-null {@link UserRecord.NewUser} instance.
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance
    *     corresponding to the newly created account. If an error occurs while creating the user
    *     account, the task fails with a FirebaseAuthException.
    * @throws NullPointerException if the provided builder is null.
    */
-  public Task<UserRecord> createUser(final UserRecord.Builder builder) {
-    checkNotNull(builder, "builder must not be null");
+  public Task<UserRecord> createUser(final UserRecord.NewUser user) {
+    checkNotNull(user, "builder must not be null");
     return ImplFirebaseTrampolines.getToken(firebaseApp, false).continueWith(
         new Continuation<GetTokenResult, UserRecord>() {
           @Override
           public UserRecord then(Task<GetTokenResult> task) throws Exception {
-            String uid = userManager.createUser(builder, task.getResult().getToken());
+            String uid = userManager.createUser(user, task.getResult().getToken());
             return userManager.getUserById(uid, task.getResult().getToken());
           }
         });
@@ -267,22 +268,22 @@ public class FirebaseAuth {
 
   /**
    * Updates an existing user account with the attributes contained in the specified
-   * {@link UserRecord.Updater}.
+   * {@link Update}.
    *
-   * @param updater A non-null {@link UserRecord.Updater} instance.
+   * @param update A non-null {@link Update} instance.
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance
    *     corresponding to the updated user account. If an error occurs while updating the user
    *     account, the task fails with a FirebaseAuthException.
-   * @throws NullPointerException if the provided updater is null.
+   * @throws NullPointerException if the provided getProperties is null.
    */
-  public Task<UserRecord> updateUser(final UserRecord.Updater updater) {
-    checkNotNull(updater, "updater must not be null");
+  public Task<UserRecord> updateUser(final Update update) {
+    checkNotNull(update, "getProperties must not be null");
     return ImplFirebaseTrampolines.getToken(firebaseApp, false).continueWith(
         new Continuation<GetTokenResult, UserRecord>() {
           @Override
           public UserRecord then(Task<GetTokenResult> task) throws Exception {
-            userManager.updateUser(updater, task.getResult().getToken());
-            return userManager.getUserById(updater.getUid(), task.getResult().getToken());
+            userManager.updateUser(update, task.getResult().getToken());
+            return userManager.getUserById(update.getUid(), task.getResult().getToken());
           }
         });
   }

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -207,17 +207,17 @@ public class FirebaseAuth {
    * Gets the user data corresponding to the specified user ID.
    *
    * @param uid A user ID string.
-   * @return A {@link Task} which will complete successfully with a {@link User} instance.
+   * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance.
    *     If an error occurs while retrieving user data or if the specified user ID does not exist,
    *     the task fails with a FirebaseAuthException.
    * @throws IllegalArgumentException If the user ID string is null or empty.
    */
-  public Task<User> getUser(final String uid) {
+  public Task<UserRecord> getUser(final String uid) {
     checkArgument(!Strings.isNullOrEmpty(uid), "uid must not be null or empty");
     return ImplFirebaseTrampolines.getToken(firebaseApp, false).continueWith(
-        new Continuation<GetTokenResult, User>() {
+        new Continuation<GetTokenResult, UserRecord>() {
           @Override
-          public User then(Task<GetTokenResult> task) throws Exception {
+          public UserRecord then(Task<GetTokenResult> task) throws Exception {
             return userManager.getUserById(uid, task.getResult().getToken());
           }
         });
@@ -227,37 +227,38 @@ public class FirebaseAuth {
    * Gets the user data corresponding to the specified user email.
    *
    * @param email A user email address string.
-   * @return A {@link Task} which will complete successfully with a {@link User} instance.
+   * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance.
    *     If an error occurs while retrieving user data or if the email address does not correspond
    *     to a user, the task fails with a FirebaseAuthException.
    * @throws IllegalArgumentException If the email is null or empty.
    */
-  public Task<User> getUserByEmail(final String email) {
+  public Task<UserRecord> getUserByEmail(final String email) {
     checkArgument(!Strings.isNullOrEmpty(email), "email must not be null or empty");
     return ImplFirebaseTrampolines.getToken(firebaseApp, false).continueWith(
-        new Continuation<GetTokenResult, User>() {
+        new Continuation<GetTokenResult, UserRecord>() {
           @Override
-          public User then(Task<GetTokenResult> task) throws Exception {
+          public UserRecord then(Task<GetTokenResult> task) throws Exception {
             return userManager.getUserByEmail(email, task.getResult().getToken());
           }
         });
   }
 
   /**
-   * Creates a new user account with the attributes contained in the specified {@link User.Builder}.
+   * Creates a new user account with the attributes contained in the specified
+   * {@link UserRecord.Builder}.
    *
-   * @param builder A non-null {@link User.Builder} instance.
-   * @return A {@link Task} which will complete successfully with a {@link User} instance
+   * @param builder A non-null {@link UserRecord.Builder} instance.
+   * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance
    *     corresponding to the newly created account. If an error occurs while creating the user
    *     account, the task fails with a FirebaseAuthException.
    * @throws NullPointerException if the provided builder is null.
    */
-  public Task<User> createUser(final User.Builder builder) {
+  public Task<UserRecord> createUser(final UserRecord.Builder builder) {
     checkNotNull(builder, "builder must not be null");
     return ImplFirebaseTrampolines.getToken(firebaseApp, false).continueWith(
-        new Continuation<GetTokenResult, User>() {
+        new Continuation<GetTokenResult, UserRecord>() {
           @Override
-          public User then(Task<GetTokenResult> task) throws Exception {
+          public UserRecord then(Task<GetTokenResult> task) throws Exception {
             String uid = userManager.createUser(builder, task.getResult().getToken());
             return userManager.getUserById(uid, task.getResult().getToken());
           }
@@ -266,20 +267,20 @@ public class FirebaseAuth {
 
   /**
    * Updates an existing user account with the attributes contained in the specified
-   * {@link User.Updater}.
+   * {@link UserRecord.Updater}.
    *
-   * @param updater A non-null {@link User.Updater} instance.
-   * @return A {@link Task} which will complete successfully with a {@link User} instance
+   * @param updater A non-null {@link UserRecord.Updater} instance.
+   * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance
    *     corresponding to the updated user account. If an error occurs while updating the user
    *     account, the task fails with a FirebaseAuthException.
    * @throws NullPointerException if the provided updater is null.
    */
-  public Task<User> updateUser(final User.Updater updater) {
+  public Task<UserRecord> updateUser(final UserRecord.Updater updater) {
     checkNotNull(updater, "updater must not be null");
     return ImplFirebaseTrampolines.getToken(firebaseApp, false).continueWith(
-        new Continuation<GetTokenResult, User>() {
+        new Continuation<GetTokenResult, UserRecord>() {
           @Override
-          public User then(Task<GetTokenResult> task) throws Exception {
+          public UserRecord then(Task<GetTokenResult> task) throws Exception {
             userManager.updateUser(updater, task.getResult().getToken());
             return userManager.getUserById(updater.getUid(), task.getResult().getToken());
           }

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -253,7 +253,7 @@ public class FirebaseAuth {
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance
    *     corresponding to the newly created account. If an error occurs while creating the user
    *     account, the task fails with a FirebaseAuthException.
-   * @throws NullPointerException if the provided user is null.
+   * @throws NullPointerException if the provided request is null.
    */
   public Task<UserRecord> createUser(final CreateRequest request) {
     checkNotNull(request, "create request must not be null");
@@ -275,7 +275,7 @@ public class FirebaseAuth {
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance
    *     corresponding to the updated user account. If an error occurs while updating the user
    *     account, the task fails with a FirebaseAuthException.
-   * @throws NullPointerException if the provided update is null.
+   * @throws NullPointerException if the provided update request is null.
    */
   public Task<UserRecord> updateUser(final UpdateRequest request) {
     checkNotNull(request, "update request must not be null");

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -135,7 +135,7 @@ class FirebaseUserManager {
 
     if (response == null || !update.getUid().equals(response.get("localId"))) {
       throw new FirebaseAuthException(USER_UPDATE_ERROR,
-          "Failed to getProperties user: " + update.getUid());
+          "Failed to update user: " + update.getUid());
     }
   }
 

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -68,7 +68,7 @@ class FirebaseUserManager {
     this.requestFactory = transport.createRequestFactory();
   }
 
-  User getUserById(String uid, String token) throws FirebaseAuthException {
+  UserRecord getUserById(String uid, String token) throws FirebaseAuthException {
     final Map<String, Object> payload = ImmutableMap.<String, Object>of(
         "localId", ImmutableList.of(uid));
     GetAccountInfoResponse response;
@@ -84,10 +84,10 @@ class FirebaseUserManager {
       throw new FirebaseAuthException(USER_NOT_FOUND_ERROR,
           "No user record found for the provided user ID: " + uid);
     }
-    return new User(response.getUsers().get(0));
+    return new UserRecord(response.getUsers().get(0));
   }
 
-  User getUserByEmail(String email, String token) throws FirebaseAuthException {
+  UserRecord getUserByEmail(String email, String token) throws FirebaseAuthException {
     final Map<String, Object> payload = ImmutableMap.<String, Object>of(
         "email", ImmutableList.of(email));
     GetAccountInfoResponse response;
@@ -102,10 +102,10 @@ class FirebaseUserManager {
       throw new FirebaseAuthException(USER_NOT_FOUND_ERROR,
           "No user record found for the provided email: " + email);
     }
-    return new User(response.getUsers().get(0));
+    return new UserRecord(response.getUsers().get(0));
   }
 
-  String createUser(User.Builder builder, String token) throws FirebaseAuthException {
+  String createUser(UserRecord.Builder builder, String token) throws FirebaseAuthException {
     GenericJson response;
     try {
       response = post("signupNewUser", token, builder.build(), GenericJson.class);
@@ -123,7 +123,7 @@ class FirebaseUserManager {
     throw new FirebaseAuthException(USER_CREATE_ERROR, "Failed to create new user");
   }
 
-  void updateUser(User.Updater updater, String token) throws FirebaseAuthException {
+  void updateUser(UserRecord.Updater updater, String token) throws FirebaseAuthException {
     GenericJson response;
     try {
       response = post("setAccountInfo", token, updater.update(), GenericJson.class);

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -31,6 +31,7 @@ import com.google.api.client.json.JsonObjectParser;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.firebase.auth.UserRecord.Update;
 import com.google.firebase.auth.internal.GetAccountInfoResponse;
 
 import java.io.IOException;
@@ -105,10 +106,10 @@ class FirebaseUserManager {
     return new UserRecord(response.getUsers().get(0));
   }
 
-  String createUser(UserRecord.Builder builder, String token) throws FirebaseAuthException {
+  String createUser(UserRecord.NewUser user, String token) throws FirebaseAuthException {
     GenericJson response;
     try {
-      response = post("signupNewUser", token, builder.build(), GenericJson.class);
+      response = post("signupNewUser", token, user.getProperties(), GenericJson.class);
     } catch (IOException e) {
       throw new FirebaseAuthException(USER_CREATE_ERROR,
           "IO error while creating user account", e);
@@ -123,18 +124,18 @@ class FirebaseUserManager {
     throw new FirebaseAuthException(USER_CREATE_ERROR, "Failed to create new user");
   }
 
-  void updateUser(UserRecord.Updater updater, String token) throws FirebaseAuthException {
+  void updateUser(Update update, String token) throws FirebaseAuthException {
     GenericJson response;
     try {
-      response = post("setAccountInfo", token, updater.update(), GenericJson.class);
+      response = post("setAccountInfo", token, update.getProperties(), GenericJson.class);
     } catch (IOException e) {
       throw new FirebaseAuthException(USER_UPDATE_ERROR,
-          "IO error while updating user: " + updater.getUid(), e);
+          "IO error while updating user: " + update.getUid(), e);
     }
 
-    if (response == null || !updater.getUid().equals(response.get("localId"))) {
+    if (response == null || !update.getUid().equals(response.get("localId"))) {
       throw new FirebaseAuthException(USER_UPDATE_ERROR,
-          "Failed to update user: " + updater.getUid());
+          "Failed to getProperties user: " + update.getUid());
     }
   }
 

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -31,7 +31,8 @@ import com.google.api.client.json.JsonObjectParser;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.firebase.auth.UserRecord.Update;
+import com.google.firebase.auth.UserRecord.CreateRequest;
+import com.google.firebase.auth.UserRecord.UpdateRequest;
 import com.google.firebase.auth.internal.GetAccountInfoResponse;
 
 import java.io.IOException;
@@ -106,10 +107,10 @@ class FirebaseUserManager {
     return new UserRecord(response.getUsers().get(0));
   }
 
-  String createUser(UserRecord.NewUser user, String token) throws FirebaseAuthException {
+  String createUser(CreateRequest request, String token) throws FirebaseAuthException {
     GenericJson response;
     try {
-      response = post("signupNewUser", token, user.getProperties(), GenericJson.class);
+      response = post("signupNewUser", token, request.getProperties(), GenericJson.class);
     } catch (IOException e) {
       throw new FirebaseAuthException(USER_CREATE_ERROR,
           "IO error while creating user account", e);
@@ -124,18 +125,18 @@ class FirebaseUserManager {
     throw new FirebaseAuthException(USER_CREATE_ERROR, "Failed to create new user");
   }
 
-  void updateUser(Update update, String token) throws FirebaseAuthException {
+  void updateUser(UpdateRequest request, String token) throws FirebaseAuthException {
     GenericJson response;
     try {
-      response = post("setAccountInfo", token, update.getProperties(), GenericJson.class);
+      response = post("setAccountInfo", token, request.getProperties(), GenericJson.class);
     } catch (IOException e) {
       throw new FirebaseAuthException(USER_UPDATE_ERROR,
-          "IO error while updating user: " + update.getUid(), e);
+          "IO error while updating user: " + request.getUid(), e);
     }
 
-    if (response == null || !update.getUid().equals(response.get("localId"))) {
+    if (response == null || !request.getUid().equals(response.get("localId"))) {
       throw new FirebaseAuthException(USER_UPDATE_ERROR,
-          "Failed to update user: " + update.getUid());
+          "Failed to update user: " + request.getUid());
     }
   }
 

--- a/src/main/java/com/google/firebase/auth/ProviderUserInfo.java
+++ b/src/main/java/com/google/firebase/auth/ProviderUserInfo.java
@@ -17,6 +17,7 @@
 package com.google.firebase.auth;
 
 import com.google.firebase.auth.internal.GetAccountInfoResponse;
+import com.google.firebase.internal.Nullable;
 
 /**
  * Contains metadata regarding how a user is known by a particular identity provider (IdP).
@@ -38,22 +39,30 @@ class ProviderUserInfo implements UserInfo {
     this.providerId = response.getProviderId();
   }
 
+  @Override
   public String getUid() {
     return uid;
   }
 
+  @Nullable
+  @Override
   public String getDisplayName() {
     return displayName;
   }
 
+  @Nullable
+  @Override
   public String getEmail() {
     return email;
   }
 
+  @Nullable
+  @Override
   public String getPhotoUrl() {
     return photoUrl;
   }
 
+  @Override
   public String getProviderId() {
     return providerId;
   }

--- a/src/main/java/com/google/firebase/auth/ProviderUserInfo.java
+++ b/src/main/java/com/google/firebase/auth/ProviderUserInfo.java
@@ -17,13 +17,12 @@
 package com.google.firebase.auth;
 
 import com.google.firebase.auth.internal.GetAccountInfoResponse;
-import com.google.firebase.internal.Nullable;
 
 /**
  * Contains metadata regarding how a user is known by a particular identity provider (IdP).
  * Instances of this class are immutable and thread safe.
  */
-public class ProviderUserInfo {
+class ProviderUserInfo implements UserInfo {
 
   private final String uid;
   private final String displayName;
@@ -39,51 +38,22 @@ public class ProviderUserInfo {
     this.providerId = response.getProviderId();
   }
 
-  /**
-   * Returns the user's unique ID assigned by the identity provider.
-   *
-   * @return a user ID string.
-   */
   public String getUid() {
     return uid;
   }
 
-  /**
-   * Returns the user's display name.
-   *
-   * @return a display name string or null.
-   */
-  @Nullable
   public String getDisplayName() {
     return displayName;
   }
 
-  /**
-   * Returns the user's email address.
-   *
-   * @return an email address string or null.
-   */
-  @Nullable
   public String getEmail() {
     return email;
   }
 
-  /**
-   * Returns the user's photo URL.
-   *
-   * @return a URL string or null.
-   */
-  @Nullable
   public String getPhotoUrl() {
     return photoUrl;
   }
 
-  /**
-   * Returns the ID of the identity provider. This can be a short domain name (e.g. google.com) or
-   * the identifier of an OpenID identity provider.
-   *
-   * @return an ID string that uniquely identifies the identity provider.
-   */
   public String getProviderId() {
     return providerId;
   }

--- a/src/main/java/com/google/firebase/auth/User.java
+++ b/src/main/java/com/google/firebase/auth/User.java
@@ -36,8 +36,9 @@ import java.util.Map;
  * Contains metadata associated with a Firebase user account. Instances of this class are immutable
  * and thread safe.
  */
-public class User {
+public class User implements UserInfo {
 
+  private static final String PROVIDER_ID = "firebase";
   private static final Map<String, String> REMOVABLE_FIELDS = ImmutableMap.of(
       "displayName", "DISPLAY_NAME",
       "photoUrl", "PHOTO_URL");
@@ -76,8 +77,19 @@ public class User {
    *
    * @return a non-null, non-empty user ID string.
    */
+  @Override
   public String getUid() {
     return uid;
+  }
+
+  /**
+   * Returns the provider ID of this user.
+   *
+   * @return a constant provider ID value.
+   */
+  @Override
+  public String getProviderId() {
+    return PROVIDER_ID;
   }
 
   /**
@@ -86,6 +98,7 @@ public class User {
    * @return an email address string or null.
    */
   @Nullable
+  @Override
   public String getEmail() {
     return email;
   }
@@ -105,6 +118,7 @@ public class User {
    * @return a display name string or null.
    */
   @Nullable
+  @Override
   public String getDisplayName() {
     return displayName;
   }
@@ -115,6 +129,7 @@ public class User {
    * @return a URL string or null.
    */
   @Nullable
+  @Override
   public String getPhotoUrl() {
     return photoUrl;
   }
@@ -129,11 +144,12 @@ public class User {
   }
 
   /**
-   * Returns the identity providers associated with this user.
+   * Returns an array of UserInfo objects that represents the identities from different identity
+   * providers that are linked to this user.
    *
-   * @return an array of {@link ProviderUserInfo} instances, which may be empty.
+   * @return an array of {@link UserInfo} instances, which may be empty.
    */
-  public ProviderUserInfo[] getProviderData() {
+  public UserInfo[] getProviderData() {
     return providers;
   }
 

--- a/src/main/java/com/google/firebase/auth/UserInfo.java
+++ b/src/main/java/com/google/firebase/auth/UserInfo.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.auth;
+
+import com.google.firebase.internal.Nullable;
+
+/**
+ * A collection of standard profile information for a user. Used to expose profile information
+ * returned by an identity provider.
+ */
+public interface UserInfo {
+
+  /**
+   * Returns the user's unique ID assigned by the identity provider.
+   *
+   * @return a user ID string.
+   */
+  String getUid();
+
+  /**
+   * Returns the user's display name, if available.
+   *
+   * @return a display name string or null.
+   */
+  @Nullable
+  String getDisplayName();
+
+  /**
+   * Returns the user's email address, if available.
+   *
+   * @return an email address string or null.
+   */
+  @Nullable
+  String getEmail();
+
+  /**
+   * Returns the user's photo URL, if available.
+   *
+   * @return a URL string or null.
+   */
+  @Nullable
+  String getPhotoUrl();
+
+  /**
+   * Returns the ID of the identity provider. This can be a short domain name (e.g. google.com) or
+   * the identifier of an OpenID identity provider.
+   *
+   * @return an ID string that uniquely identifies the identity provider.
+   */
+  String getProviderId();
+
+}

--- a/src/main/java/com/google/firebase/auth/UserRecord.java
+++ b/src/main/java/com/google/firebase/auth/UserRecord.java
@@ -296,7 +296,7 @@ public class UserRecord implements UserInfo {
     private final Map<String,Object> properties = new HashMap<>();
 
     /**
-     * Creates a new {@link Update} instance, which can be used to getProperties the attributes
+     * Creates a new {@link Update} instance, which can be used to update the attributes
      * of the user identified by the specified user ID. This method allows updating attributes of
      * a user account, without first having to call {@link FirebaseAuth#getUser(String)}.
      *

--- a/src/main/java/com/google/firebase/auth/UserRecord.java
+++ b/src/main/java/com/google/firebase/auth/UserRecord.java
@@ -163,7 +163,7 @@ public class UserRecord implements UserInfo {
   }
 
   /**
-   * Returns a new {@link UpdateRequest}, which can be used to getProperties the attributes
+   * Returns a new {@link UpdateRequest}, which can be used to update the attributes
    * of this user.
    *
    * @return a non-null UserRecord.UpdateRequest instance.

--- a/src/main/java/com/google/firebase/auth/UserRecord.java
+++ b/src/main/java/com/google/firebase/auth/UserRecord.java
@@ -163,37 +163,13 @@ public class UserRecord implements UserInfo {
   }
 
   /**
-   * Returns a new {@link UserRecord.Updater} instance, which can be used to update the attributes
+   * Returns a new {@link Update} instance, which can be used to getProperties the attributes
    * of this user.
    *
-   * @return a non-null UserRecord.Updater instance.
+   * @return a non-null UserRecord.Update instance.
    */
-  public Updater updater() {
-    return new Updater(uid);
-  }
-
-  /**
-   * Returns a new {@link UserRecord.Updater} instance, which can be used to update the attributes
-   * of the user identified by the specified user ID. This method allows updating attributes of
-   * a user account, without first having to call {@link FirebaseAuth#getUser(String)}.
-   *
-   * @param uid a non-null, non-empty user ID string.
-   * @return a non-null UserRecord.Updater instance.
-   * @throws IllegalArgumentException If the user ID is null or empty.
-   */
-  public static Updater updater(String uid) {
-    return new Updater(uid);
-  }
-
-  /**
-   * Returns a new {@link UserRecord.Builder} instance, which can be used to create a new user. The
-   * returned builder should be passed to {@link FirebaseAuth#createUser(Builder)} to register
-   * the user information persistently.
-   *
-   * @return a non-null UserRecord.Builder instance.
-   */
-  public static Builder builder() {
-    return new Builder();
+  public Update newUpdate() {
+    return new Update(uid);
   }
 
   private static void checkEmail(String email) {
@@ -207,15 +183,20 @@ public class UserRecord implements UserInfo {
   }
 
   /**
-   * A builder class for creating new user accounts. Set the initial attributes of the new user
-   * account by calling various setter methods available in this class. None of the attributes
+   * A specification class for creating new user accounts. Set the initial attributes of the new
+   * user account by calling various setter methods available in this class. None of the attributes
    * are required.
    */
-  public static class Builder {
+  public static class NewUser {
 
     private final Map<String,Object> properties = new HashMap<>();
 
-    private Builder() {
+    /**
+     * Creates a new {@link NewUser} instance, which can be used to create a new user. The
+     * returned object should be passed to {@link FirebaseAuth#createUser(NewUser)} to register
+     * the user information persistently.
+     */
+    public NewUser() {
     }
 
     /**
@@ -224,7 +205,7 @@ public class UserRecord implements UserInfo {
      * @param uid a non-null, non-empty user ID that uniquely identifies the new user. The user ID
      *     must not be longer than 128 characters.
      */
-    public Builder setUid(String uid) {
+    public NewUser setUid(String uid) {
       checkArgument(!Strings.isNullOrEmpty(uid), "uid cannot be null or empty");
       checkArgument(uid.length() <= 128, "UID cannot be longer than 128 characters");
       properties.put("localId", uid);
@@ -236,7 +217,7 @@ public class UserRecord implements UserInfo {
      *
      * @param email a non-null, non-empty email address string.
      */
-    public Builder setEmail(String email) {
+    public NewUser setEmail(String email) {
       checkEmail(email);
       properties.put("email", email);
       return this;
@@ -247,7 +228,7 @@ public class UserRecord implements UserInfo {
      *
      * @param emailVerified a boolean indicating the email verification status.
      */
-    public Builder setEmailVerified(boolean emailVerified) {
+    public NewUser setEmailVerified(boolean emailVerified) {
       properties.put("emailVerified", emailVerified);
       return this;
     }
@@ -257,7 +238,7 @@ public class UserRecord implements UserInfo {
      *
      * @param displayName a non-null, non-empty display name string.
      */
-    public Builder setDisplayName(String displayName) {
+    public NewUser setDisplayName(String displayName) {
       checkNotNull(displayName, "displayName cannot be null or empty");
       properties.put("displayName", displayName);
       return this;
@@ -268,7 +249,7 @@ public class UserRecord implements UserInfo {
      *
      * @param photoUrl a non-null, non-empty URL string.
      */
-    public Builder setPhotoUrl(String photoUrl) {
+    public NewUser setPhotoUrl(String photoUrl) {
       checkArgument(!Strings.isNullOrEmpty(photoUrl), "photoUrl cannot be null or empty");
       try {
         new URL(photoUrl);
@@ -284,7 +265,7 @@ public class UserRecord implements UserInfo {
      *
      * @param disabled a boolean indicating whether the new account should be disabled.
      */
-    public Builder setDisabled(boolean disabled) {
+    public NewUser setDisabled(boolean disabled) {
       properties.put("disabled", disabled);
       return this;
     }
@@ -294,13 +275,13 @@ public class UserRecord implements UserInfo {
      *
      * @param password a password string that is at least 6 characters long.
      */
-    public Builder setPassword(String password) {
+    public NewUser setPassword(String password) {
       checkPassword(password);
       properties.put("password", password);
       return this;
     }
 
-    Map<String, Object> build() {
+    Map<String, Object> getProperties() {
       return ImmutableMap.copyOf(properties);
     }
   }
@@ -310,11 +291,19 @@ public class UserRecord implements UserInfo {
    * obtained via a {@link UserRecord} object, or from a user ID string. Specify the changes to be
    * made in the user account by calling the various setter methods available in this class.
    */
-  public static class Updater {
+  public static class Update {
 
     private final Map<String,Object> properties = new HashMap<>();
 
-    private Updater(String uid) {
+    /**
+     * Creates a new {@link Update} instance, which can be used to getProperties the attributes
+     * of the user identified by the specified user ID. This method allows updating attributes of
+     * a user account, without first having to call {@link FirebaseAuth#getUser(String)}.
+     *
+     * @param uid a non-null, non-empty user ID string.
+     * @throws IllegalArgumentException If the user ID is null or empty.
+     */
+    public Update(String uid) {
       checkArgument(!Strings.isNullOrEmpty(uid), "uid must not be null or empty");
       properties.put("localId", uid);
     }
@@ -328,7 +317,7 @@ public class UserRecord implements UserInfo {
      *
      * @param email a non-null, non-empty email address to be associated with the user.
      */
-    public Updater setEmail(String email) {
+    public Update setEmail(String email) {
       checkEmail(email);
       properties.put("email", email);
       return this;
@@ -339,7 +328,7 @@ public class UserRecord implements UserInfo {
      *
      * @param emailVerified a boolean indicating whether the email address has been verified.
      */
-    public Updater setEmailVerified(boolean emailVerified) {
+    public Update setEmailVerified(boolean emailVerified) {
       properties.put("emailVerified", emailVerified);
       return this;
     }
@@ -350,7 +339,7 @@ public class UserRecord implements UserInfo {
      *
      * @param displayName a display name string or null
      */
-    public Updater setDisplayName(String displayName) {
+    public Update setDisplayName(String displayName) {
       properties.put("displayName", displayName);
       return this;
     }
@@ -361,7 +350,7 @@ public class UserRecord implements UserInfo {
      *
      * @param photoUrl a valid URL string or null
      */
-    public Updater setPhotoUrl(String photoUrl) {
+    public Update setPhotoUrl(String photoUrl) {
       if (photoUrl != null) {
         try {
           new URL(photoUrl);
@@ -378,7 +367,7 @@ public class UserRecord implements UserInfo {
      *
      * @param disabled a boolean indicating whether this account should be disabled.
      */
-    public Updater setDisabled(boolean disabled) {
+    public Update setDisabled(boolean disabled) {
       properties.put("disableUser", disabled);
       return this;
     }
@@ -388,13 +377,13 @@ public class UserRecord implements UserInfo {
      *
      * @param password a new password string that is at least 6 characters long.
      */
-    public Updater setPassword(String password) {
+    public Update setPassword(String password) {
       checkPassword(password);
       properties.put("password", password);
       return this;
     }
 
-    Map<String, Object> update() {
+    Map<String, Object> getProperties() {
       Map<String, Object> copy = new HashMap<>(properties);
       List<String> remove = new ArrayList<>();
       for (Map.Entry<String, String> entry : REMOVABLE_FIELDS.entrySet()) {

--- a/src/main/java/com/google/firebase/auth/UserRecord.java
+++ b/src/main/java/com/google/firebase/auth/UserRecord.java
@@ -36,7 +36,7 @@ import java.util.Map;
  * Contains metadata associated with a Firebase user account. Instances of this class are immutable
  * and thread safe.
  */
-public class User implements UserInfo {
+public class UserRecord implements UserInfo {
 
   private static final String PROVIDER_ID = "firebase";
   private static final Map<String, String> REMOVABLE_FIELDS = ImmutableMap.of(
@@ -52,7 +52,7 @@ public class User implements UserInfo {
   private final ProviderUserInfo[] providers;
   private final UserMetadata userMetadata;
 
-  User(GetAccountInfoResponse.User response) {
+  UserRecord(GetAccountInfoResponse.User response) {
     checkNotNull(response, "Response must not be null");
     checkArgument(!Strings.isNullOrEmpty(response.getUid()), "uid must not be null or empty");
     this.uid = response.getUid();
@@ -163,22 +163,22 @@ public class User implements UserInfo {
   }
 
   /**
-   * Returns a new {@link User.Updater} instance, which can be used to update the attributes
+   * Returns a new {@link UserRecord.Updater} instance, which can be used to update the attributes
    * of this user.
    *
-   * @return a non-null User.Updater instance.
+   * @return a non-null UserRecord.Updater instance.
    */
   public Updater updater() {
     return new Updater(uid);
   }
 
   /**
-   * Returns a new {@link User.Updater} instance, which can be used to update the attributes
+   * Returns a new {@link UserRecord.Updater} instance, which can be used to update the attributes
    * of the user identified by the specified user ID. This method allows updating attributes of
    * a user account, without first having to call {@link FirebaseAuth#getUser(String)}.
    *
    * @param uid a non-null, non-empty user ID string.
-   * @return a non-null User.Updater instance.
+   * @return a non-null UserRecord.Updater instance.
    * @throws IllegalArgumentException If the user ID is null or empty.
    */
   public static Updater updater(String uid) {
@@ -186,11 +186,11 @@ public class User implements UserInfo {
   }
 
   /**
-   * Returns a new {@link User.Builder} instance, which can be used to create a new user. The
+   * Returns a new {@link UserRecord.Builder} instance, which can be used to create a new user. The
    * returned builder should be passed to {@link FirebaseAuth#createUser(Builder)} to register
    * the user information persistently.
    *
-   * @return a non-null User.Builder instance.
+   * @return a non-null UserRecord.Builder instance.
    */
   public static Builder builder() {
     return new Builder();
@@ -307,7 +307,7 @@ public class User implements UserInfo {
 
   /**
    * A class for updating the attributes of an existing user. An instance of this class can be
-   * obtained via a {@link User} object, or from a user ID string. Specify the changes to be
+   * obtained via a {@link UserRecord} object, or from a user ID string. Specify the changes to be
    * made in the user account by calling the various setter methods available in this class.
    */
   public static class Updater {

--- a/src/main/java/com/google/firebase/auth/UserRecord.java
+++ b/src/main/java/com/google/firebase/auth/UserRecord.java
@@ -163,13 +163,13 @@ public class UserRecord implements UserInfo {
   }
 
   /**
-   * Returns a new {@link Update} instance, which can be used to getProperties the attributes
+   * Returns a new {@link UpdateRequest}, which can be used to getProperties the attributes
    * of this user.
    *
-   * @return a non-null UserRecord.Update instance.
+   * @return a non-null UserRecord.UpdateRequest instance.
    */
-  public Update newUpdate() {
-    return new Update(uid);
+  public UpdateRequest updateRequest() {
+    return new UpdateRequest(uid);
   }
 
   private static void checkEmail(String email) {
@@ -187,16 +187,16 @@ public class UserRecord implements UserInfo {
    * user account by calling various setter methods available in this class. None of the attributes
    * are required.
    */
-  public static class NewUser {
+  public static class CreateRequest {
 
     private final Map<String,Object> properties = new HashMap<>();
 
     /**
-     * Creates a new {@link NewUser} instance, which can be used to create a new user. The
-     * returned object should be passed to {@link FirebaseAuth#createUser(NewUser)} to register
+     * Creates a new {@link CreateRequest}, which can be used to create a new user. The returned
+     * object should be passed to {@link FirebaseAuth#createUser(CreateRequest)} to register
      * the user information persistently.
      */
-    public NewUser() {
+    public CreateRequest() {
     }
 
     /**
@@ -205,7 +205,7 @@ public class UserRecord implements UserInfo {
      * @param uid a non-null, non-empty user ID that uniquely identifies the new user. The user ID
      *     must not be longer than 128 characters.
      */
-    public NewUser setUid(String uid) {
+    public CreateRequest setUid(String uid) {
       checkArgument(!Strings.isNullOrEmpty(uid), "uid cannot be null or empty");
       checkArgument(uid.length() <= 128, "UID cannot be longer than 128 characters");
       properties.put("localId", uid);
@@ -217,7 +217,7 @@ public class UserRecord implements UserInfo {
      *
      * @param email a non-null, non-empty email address string.
      */
-    public NewUser setEmail(String email) {
+    public CreateRequest setEmail(String email) {
       checkEmail(email);
       properties.put("email", email);
       return this;
@@ -228,7 +228,7 @@ public class UserRecord implements UserInfo {
      *
      * @param emailVerified a boolean indicating the email verification status.
      */
-    public NewUser setEmailVerified(boolean emailVerified) {
+    public CreateRequest setEmailVerified(boolean emailVerified) {
       properties.put("emailVerified", emailVerified);
       return this;
     }
@@ -238,7 +238,7 @@ public class UserRecord implements UserInfo {
      *
      * @param displayName a non-null, non-empty display name string.
      */
-    public NewUser setDisplayName(String displayName) {
+    public CreateRequest setDisplayName(String displayName) {
       checkNotNull(displayName, "displayName cannot be null or empty");
       properties.put("displayName", displayName);
       return this;
@@ -249,7 +249,7 @@ public class UserRecord implements UserInfo {
      *
      * @param photoUrl a non-null, non-empty URL string.
      */
-    public NewUser setPhotoUrl(String photoUrl) {
+    public CreateRequest setPhotoUrl(String photoUrl) {
       checkArgument(!Strings.isNullOrEmpty(photoUrl), "photoUrl cannot be null or empty");
       try {
         new URL(photoUrl);
@@ -265,7 +265,7 @@ public class UserRecord implements UserInfo {
      *
      * @param disabled a boolean indicating whether the new account should be disabled.
      */
-    public NewUser setDisabled(boolean disabled) {
+    public CreateRequest setDisabled(boolean disabled) {
       properties.put("disabled", disabled);
       return this;
     }
@@ -275,7 +275,7 @@ public class UserRecord implements UserInfo {
      *
      * @param password a password string that is at least 6 characters long.
      */
-    public NewUser setPassword(String password) {
+    public CreateRequest setPassword(String password) {
       checkPassword(password);
       properties.put("password", password);
       return this;
@@ -291,19 +291,19 @@ public class UserRecord implements UserInfo {
    * obtained via a {@link UserRecord} object, or from a user ID string. Specify the changes to be
    * made in the user account by calling the various setter methods available in this class.
    */
-  public static class Update {
+  public static class UpdateRequest {
 
     private final Map<String,Object> properties = new HashMap<>();
 
     /**
-     * Creates a new {@link Update} instance, which can be used to update the attributes
+     * Creates a new {@link UpdateRequest}, which can be used to update the attributes
      * of the user identified by the specified user ID. This method allows updating attributes of
      * a user account, without first having to call {@link FirebaseAuth#getUser(String)}.
      *
      * @param uid a non-null, non-empty user ID string.
      * @throws IllegalArgumentException If the user ID is null or empty.
      */
-    public Update(String uid) {
+    public UpdateRequest(String uid) {
       checkArgument(!Strings.isNullOrEmpty(uid), "uid must not be null or empty");
       properties.put("localId", uid);
     }
@@ -317,7 +317,7 @@ public class UserRecord implements UserInfo {
      *
      * @param email a non-null, non-empty email address to be associated with the user.
      */
-    public Update setEmail(String email) {
+    public UpdateRequest setEmail(String email) {
       checkEmail(email);
       properties.put("email", email);
       return this;
@@ -328,7 +328,7 @@ public class UserRecord implements UserInfo {
      *
      * @param emailVerified a boolean indicating whether the email address has been verified.
      */
-    public Update setEmailVerified(boolean emailVerified) {
+    public UpdateRequest setEmailVerified(boolean emailVerified) {
       properties.put("emailVerified", emailVerified);
       return this;
     }
@@ -339,7 +339,7 @@ public class UserRecord implements UserInfo {
      *
      * @param displayName a display name string or null
      */
-    public Update setDisplayName(String displayName) {
+    public UpdateRequest setDisplayName(String displayName) {
       properties.put("displayName", displayName);
       return this;
     }
@@ -350,7 +350,7 @@ public class UserRecord implements UserInfo {
      *
      * @param photoUrl a valid URL string or null
      */
-    public Update setPhotoUrl(String photoUrl) {
+    public UpdateRequest setPhotoUrl(String photoUrl) {
       if (photoUrl != null) {
         try {
           new URL(photoUrl);
@@ -367,7 +367,7 @@ public class UserRecord implements UserInfo {
      *
      * @param disabled a boolean indicating whether this account should be disabled.
      */
-    public Update setDisabled(boolean disabled) {
+    public UpdateRequest setDisabled(boolean disabled) {
       properties.put("disableUser", disabled);
       return this;
     }
@@ -377,7 +377,7 @@ public class UserRecord implements UserInfo {
      *
      * @param password a new password string that is at least 6 characters long.
      */
-    public Update setPassword(String password) {
+    public UpdateRequest setPassword(String password) {
       checkPassword(password);
       properties.put("password", password);
       return this;

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -23,7 +23,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.auth.UserRecord.Update;
+import com.google.firebase.auth.UserRecord.CreateRequest;
+import com.google.firebase.auth.UserRecord.UpdateRequest;
 import com.google.firebase.tasks.Tasks;
 import com.google.firebase.testing.IntegrationTestUtils;
 import java.util.UUID;
@@ -68,7 +69,7 @@ public class FirebaseAuthIT {
   @Test
   public void testUpdateNonExistingUser() throws Exception {
     try {
-      Tasks.await(auth.updateUser(new UserRecord.Update("non.existing")));
+      Tasks.await(auth.updateUser(new UpdateRequest("non.existing")));
       fail("No error thrown for non existing uid");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -94,7 +95,7 @@ public class FirebaseAuthIT {
     String randomId = UUID.randomUUID().toString().replaceAll("-", "");
     String userEmail = ("test" + randomId.substring(0, 12) + "@example." + randomId.substring(12)
         + ".com").toLowerCase();
-    UserRecord.NewUser user = new UserRecord.NewUser()
+    CreateRequest user = new CreateRequest()
         .setUid(randomId)
         .setEmail(userEmail)
         .setDisplayName("Random User")
@@ -119,7 +120,7 @@ public class FirebaseAuthIT {
 
   private void checkRecreate(String uid) throws Exception {
     try {
-      Tasks.await(auth.createUser(new UserRecord.NewUser().setUid(uid)));
+      Tasks.await(auth.createUser(new CreateRequest().setUid(uid)));
       fail("No error thrown for creating user with existing ID");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -131,7 +132,7 @@ public class FirebaseAuthIT {
   @Test
   public void testUserLifecycle() throws Exception {
     // Create user
-    UserRecord userRecord = Tasks.await(auth.createUser(new UserRecord.NewUser()));
+    UserRecord userRecord = Tasks.await(auth.createUser(new CreateRequest()));
     String uid = userRecord.getUid();
 
     // Get user
@@ -149,13 +150,13 @@ public class FirebaseAuthIT {
     String randomId = UUID.randomUUID().toString().replaceAll("-", "");
     String userEmail = ("test" + randomId.substring(0, 12) + "@example." + randomId.substring(12)
         + ".com").toLowerCase();
-    Update update = userRecord.newUpdate()
+    UpdateRequest request = userRecord.updateRequest()
         .setDisplayName("Updated Name")
         .setEmail(userEmail)
         .setPhotoUrl("https://example.com/photo.png")
         .setEmailVerified(true)
         .setPassword("secret");
-    userRecord = Tasks.await(auth.updateUser(update));
+    userRecord = Tasks.await(auth.updateUser(request));
     assertEquals(uid, userRecord.getUid());
     assertEquals("Updated Name", userRecord.getDisplayName());
     assertEquals(userEmail, userRecord.getEmail());
@@ -168,11 +169,11 @@ public class FirebaseAuthIT {
     assertEquals(uid, userRecord.getUid());
 
     // Disable user and remove properties
-    update = userRecord.newUpdate()
+    request = userRecord.updateRequest()
         .setPhotoUrl(null)
         .setDisplayName(null)
         .setDisabled(true);
-    userRecord = Tasks.await(auth.updateUser(update));
+    userRecord = Tasks.await(auth.updateUser(request));
     assertEquals(uid, userRecord.getUid());
     assertNull(userRecord.getDisplayName());
     assertEquals(userEmail, userRecord.getEmail());

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -67,7 +67,7 @@ public class FirebaseAuthIT {
   @Test
   public void testUpdateNonExistingUser() throws Exception {
     try {
-      Tasks.await(auth.updateUser(User.updater("non.existing")));
+      Tasks.await(auth.updateUser(UserRecord.updater("non.existing")));
       fail("No error thrown for non existing uid");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -93,7 +93,7 @@ public class FirebaseAuthIT {
     String randomId = UUID.randomUUID().toString().replaceAll("-", "");
     String userEmail = ("test" + randomId.substring(0, 12) + "@example." + randomId.substring(12)
         + ".com").toLowerCase();
-    User.Builder builder = User.builder()
+    UserRecord.Builder builder = UserRecord.builder()
         .setUid(randomId)
         .setEmail(userEmail)
         .setDisplayName("Random User")
@@ -101,24 +101,24 @@ public class FirebaseAuthIT {
         .setEmailVerified(true)
         .setPassword("password");
 
-    User user = Tasks.await(auth.createUser(builder));
+    UserRecord userRecord = Tasks.await(auth.createUser(builder));
     try {
-      assertEquals(randomId, user.getUid());
-      assertEquals("Random User", user.getDisplayName());
-      assertEquals(userEmail, user.getEmail());
-      assertEquals("https://example.com/photo.png", user.getPhotoUrl());
-      assertTrue(user.isEmailVerified());
-      assertFalse(user.isDisabled());
+      assertEquals(randomId, userRecord.getUid());
+      assertEquals("Random User", userRecord.getDisplayName());
+      assertEquals(userEmail, userRecord.getEmail());
+      assertEquals("https://example.com/photo.png", userRecord.getPhotoUrl());
+      assertTrue(userRecord.isEmailVerified());
+      assertFalse(userRecord.isDisabled());
 
       checkRecreate(randomId);
     } finally {
-      Tasks.await(auth.deleteUser(user.getUid()));
+      Tasks.await(auth.deleteUser(userRecord.getUid()));
     }
   }
 
   private void checkRecreate(String uid) throws Exception {
     try {
-      Tasks.await(auth.createUser(User.builder().setUid(uid)));
+      Tasks.await(auth.createUser(UserRecord.builder().setUid(uid)));
       fail("No error thrown for creating user with existing ID");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -130,55 +130,55 @@ public class FirebaseAuthIT {
   @Test
   public void testUserLifecycle() throws Exception {
     // Create user
-    User user = Tasks.await(auth.createUser(User.builder()));
-    String uid = user.getUid();
+    UserRecord userRecord = Tasks.await(auth.createUser(UserRecord.builder()));
+    String uid = userRecord.getUid();
 
     // Get user
-    user = Tasks.await(auth.getUser(user.getUid()));
-    assertEquals(uid, user.getUid());
-    assertNull(user.getDisplayName());
-    assertNull(user.getEmail());
-    assertNull(user.getPhotoUrl());
-    assertFalse(user.isEmailVerified());
-    assertFalse(user.isDisabled());
-    assertTrue(user.getUserMetadata().getCreationTimestamp() > 0);
-    assertEquals(0, user.getUserMetadata().getLastSignInTimestamp());
+    userRecord = Tasks.await(auth.getUser(userRecord.getUid()));
+    assertEquals(uid, userRecord.getUid());
+    assertNull(userRecord.getDisplayName());
+    assertNull(userRecord.getEmail());
+    assertNull(userRecord.getPhotoUrl());
+    assertFalse(userRecord.isEmailVerified());
+    assertFalse(userRecord.isDisabled());
+    assertTrue(userRecord.getUserMetadata().getCreationTimestamp() > 0);
+    assertEquals(0, userRecord.getUserMetadata().getLastSignInTimestamp());
 
     // Update user
     String randomId = UUID.randomUUID().toString().replaceAll("-", "");
     String userEmail = ("test" + randomId.substring(0, 12) + "@example." + randomId.substring(12)
         + ".com").toLowerCase();
-    User.Updater updater = user.updater()
+    UserRecord.Updater updater = userRecord.updater()
         .setDisplayName("Updated Name")
         .setEmail(userEmail)
         .setPhotoUrl("https://example.com/photo.png")
         .setEmailVerified(true)
         .setPassword("secret");
-    user = Tasks.await(auth.updateUser(updater));
-    assertEquals(uid, user.getUid());
-    assertEquals("Updated Name", user.getDisplayName());
-    assertEquals(userEmail, user.getEmail());
-    assertEquals("https://example.com/photo.png", user.getPhotoUrl());
-    assertTrue(user.isEmailVerified());
-    assertFalse(user.isDisabled());
+    userRecord = Tasks.await(auth.updateUser(updater));
+    assertEquals(uid, userRecord.getUid());
+    assertEquals("Updated Name", userRecord.getDisplayName());
+    assertEquals(userEmail, userRecord.getEmail());
+    assertEquals("https://example.com/photo.png", userRecord.getPhotoUrl());
+    assertTrue(userRecord.isEmailVerified());
+    assertFalse(userRecord.isDisabled());
 
     // Disable user and remove properties
-    updater = user.updater()
+    updater = userRecord.updater()
         .setPhotoUrl(null)
         .setDisplayName(null)
         .setDisabled(true);
-    user = Tasks.await(auth.updateUser(updater));
-    assertEquals(uid, user.getUid());
-    assertNull(user.getDisplayName());
-    assertEquals(userEmail, user.getEmail());
-    assertNull(user.getPhotoUrl());
-    assertTrue(user.isEmailVerified());
-    assertTrue(user.isDisabled());
+    userRecord = Tasks.await(auth.updateUser(updater));
+    assertEquals(uid, userRecord.getUid());
+    assertNull(userRecord.getDisplayName());
+    assertEquals(userEmail, userRecord.getEmail());
+    assertNull(userRecord.getPhotoUrl());
+    assertTrue(userRecord.isEmailVerified());
+    assertTrue(userRecord.isDisabled());
 
     // Delete user
-    Tasks.await(auth.deleteUser(user.getUid()));
+    Tasks.await(auth.deleteUser(userRecord.getUid()));
     try {
-      Tasks.await(auth.getUser(user.getUid()));
+      Tasks.await(auth.getUser(userRecord.getUid()));
       fail("No error thrown for deleted user");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -25,7 +25,8 @@ import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.common.collect.ImmutableList;
-import com.google.firebase.auth.UserRecord.Update;
+import com.google.firebase.auth.UserRecord.CreateRequest;
+import com.google.firebase.auth.UserRecord.UpdateRequest;
 import com.google.firebase.testing.TestUtils;
 
 import java.io.IOException;
@@ -84,7 +85,7 @@ public class FirebaseUserManagerTest {
         .setLowLevelHttpResponse(response)
         .build();
     FirebaseUserManager userManager = new FirebaseUserManager(gson, transport);
-    String uid = userManager.createUser(new UserRecord.NewUser(), "token");
+    String uid = userManager.createUser(new CreateRequest(), "token");
     assertEquals("testuser", uid);
   }
 
@@ -97,7 +98,7 @@ public class FirebaseUserManagerTest {
         .build();
     FirebaseUserManager userManager = new FirebaseUserManager(gson, transport);
     // should not throw
-    userManager.updateUser(new UserRecord.Update("testuser"), "token");
+    userManager.updateUser(new UpdateRequest("testuser"), "token");
   }
 
   @Test
@@ -138,14 +139,13 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testUserBuilder() {
-    Map<String, Object> map = new UserRecord.NewUser()
-        .getProperties();
+    Map<String, Object> map = new CreateRequest().getProperties();
     assertTrue(map.isEmpty());
   }
 
   @Test
   public void testUserBuilderWithParams() {
-    Map<String, Object> map = new UserRecord.NewUser()
+    Map<String, Object> map = new CreateRequest()
         .setUid("TestUid")
         .setDisplayName("Display Name")
         .setPhotoUrl("http://test.com/example.png")
@@ -164,7 +164,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidUid() {
-    UserRecord.NewUser user = new UserRecord.NewUser();
+    CreateRequest user = new CreateRequest();
     try {
       user.setUid(null);
       fail("No error thrown for null uid");
@@ -189,7 +189,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidDisplayName() {
-    UserRecord.NewUser user = new UserRecord.NewUser();
+    CreateRequest user = new CreateRequest();
     try {
       user.setDisplayName(null);
       fail("No error thrown for null display name");
@@ -200,7 +200,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidPhotoUrl() {
-    UserRecord.NewUser user = new UserRecord.NewUser();
+    CreateRequest user = new CreateRequest();
     try {
       user.setPhotoUrl(null);
       fail("No error thrown for null photo url");
@@ -225,7 +225,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidEmail() {
-    UserRecord.NewUser user = new UserRecord.NewUser();
+    CreateRequest user = new CreateRequest();
     try {
       user.setEmail(null);
       fail("No error thrown for null email");
@@ -250,7 +250,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidPassword() {
-    UserRecord.NewUser user = new UserRecord.NewUser();
+    CreateRequest user = new CreateRequest();
     try {
       user.setPassword(null);
       fail("No error thrown for null password");
@@ -268,7 +268,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testUserUpdater() {
-    Update update = new UserRecord.Update("test");
+    UpdateRequest update = new UpdateRequest("test");
     Map<String, Object> map = update
         .setDisplayName("Display Name")
         .setPhotoUrl("http://test.com/example.png")
@@ -287,7 +287,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testDeleteDisplayName() {
-    Map<String, Object> map = new UserRecord.Update("test")
+    Map<String, Object> map = new UpdateRequest("test")
         .setDisplayName(null)
         .getProperties();
     assertEquals(ImmutableList.of("DISPLAY_NAME"), map.get("deleteAttribute"));
@@ -295,7 +295,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testDeletePhotoUrl() {
-    Map<String, Object> map = new UserRecord.Update("test")
+    Map<String, Object> map = new UpdateRequest("test")
         .setPhotoUrl(null)
         .getProperties();
     assertEquals(ImmutableList.of("PHOTO_URL"), map.get("deleteAttribute"));
@@ -303,7 +303,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidUpdatePhotoUrl() {
-    Update update = new UserRecord.Update("test");
+    UpdateRequest update = new UpdateRequest("test");
     try {
       update.setPhotoUrl("");
       fail("No error thrown for invalid photo url");
@@ -321,7 +321,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidUpdateEmail() {
-    Update update = new UserRecord.Update("test");
+    UpdateRequest update = new UpdateRequest("test");
     try {
       update.setEmail(null);
       fail("No error thrown for null email");
@@ -346,7 +346,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidUpdatePassword() {
-    Update update = new UserRecord.Update("test");
+    UpdateRequest update = new UpdateRequest("test");
     try {
       update.setPassword(null);
       fail("No error thrown for null password");

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -43,8 +43,8 @@ public class FirebaseUserManagerTest {
         .setLowLevelHttpResponse(response)
         .build();
     FirebaseUserManager userManager = new FirebaseUserManager(gson, transport);
-    User user = userManager.getUserById("testuser", "token");
-    checkUser(user);
+    UserRecord userRecord = userManager.getUserById("testuser", "token");
+    checkUserRecord(userRecord);
   }
 
   @Test
@@ -71,8 +71,8 @@ public class FirebaseUserManagerTest {
         .setLowLevelHttpResponse(response)
         .build();
     FirebaseUserManager userManager = new FirebaseUserManager(gson, transport);
-    User user = userManager.getUserByEmail("testuser@example.com", "token");
-    checkUser(user);
+    UserRecord userRecord = userManager.getUserByEmail("testuser@example.com", "token");
+    checkUserRecord(userRecord);
   }
 
   @Test
@@ -83,7 +83,7 @@ public class FirebaseUserManagerTest {
         .setLowLevelHttpResponse(response)
         .build();
     FirebaseUserManager userManager = new FirebaseUserManager(gson, transport);
-    String uid = userManager.createUser(User.builder(), "token");
+    String uid = userManager.createUser(UserRecord.builder(), "token");
     assertEquals("testuser", uid);
   }
 
@@ -96,7 +96,7 @@ public class FirebaseUserManagerTest {
         .build();
     FirebaseUserManager userManager = new FirebaseUserManager(gson, transport);
     // should not throw
-    userManager.updateUser(User.updater("testuser"), "token");
+    userManager.updateUser(UserRecord.updater("testuser"), "token");
   }
 
   @Test
@@ -137,14 +137,14 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testUserBuilder() {
-    Map<String, Object> map = User.builder()
+    Map<String, Object> map = UserRecord.builder()
         .build();
     assertTrue(map.isEmpty());
   }
 
   @Test
   public void testUserBuilderWithParams() {
-    Map<String, Object> map = User.builder()
+    Map<String, Object> map = UserRecord.builder()
         .setUid("TestUid")
         .setDisplayName("Display Name")
         .setPhotoUrl("http://test.com/example.png")
@@ -163,7 +163,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidUid() {
-    User.Builder builder = User.builder();
+    UserRecord.Builder builder = UserRecord.builder();
     try {
       builder.setUid(null);
       fail("No error thrown for null uid");
@@ -188,7 +188,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidDisplayName() {
-    User.Builder builder = User.builder();
+    UserRecord.Builder builder = UserRecord.builder();
     try {
       builder.setDisplayName(null);
       fail("No error thrown for null display name");
@@ -199,7 +199,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidPhotoUrl() {
-    User.Builder builder = User.builder();
+    UserRecord.Builder builder = UserRecord.builder();
     try {
       builder.setPhotoUrl(null);
       fail("No error thrown for null photo url");
@@ -224,7 +224,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidEmail() {
-    User.Builder builder = User.builder();
+    UserRecord.Builder builder = UserRecord.builder();
     try {
       builder.setEmail(null);
       fail("No error thrown for null email");
@@ -249,7 +249,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidPassword() {
-    User.Builder builder = User.builder();
+    UserRecord.Builder builder = UserRecord.builder();
     try {
       builder.setPassword(null);
       fail("No error thrown for null password");
@@ -267,7 +267,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testUserUpdater() {
-    User.Updater updater = User.updater("test");
+    UserRecord.Updater updater = UserRecord.updater("test");
     Map<String, Object> map = updater
         .setDisplayName("Display Name")
         .setPhotoUrl("http://test.com/example.png")
@@ -286,7 +286,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testDeleteDisplayName() {
-    Map<String, Object> map = User.updater("test")
+    Map<String, Object> map = UserRecord.updater("test")
         .setDisplayName(null)
         .update();
     assertEquals(ImmutableList.of("DISPLAY_NAME"), map.get("deleteAttribute"));
@@ -294,7 +294,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testDeletePhotoUrl() {
-    Map<String, Object> map = User.updater("test")
+    Map<String, Object> map = UserRecord.updater("test")
         .setPhotoUrl(null)
         .update();
     assertEquals(ImmutableList.of("PHOTO_URL"), map.get("deleteAttribute"));
@@ -302,7 +302,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidUpdatePhotoUrl() {
-    User.Updater updater = User.updater("test");
+    UserRecord.Updater updater = UserRecord.updater("test");
     try {
       updater.setPhotoUrl("");
       fail("No error thrown for invalid photo url");
@@ -320,7 +320,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidUpdateEmail() {
-    User.Updater updater = User.updater("test");
+    UserRecord.Updater updater = UserRecord.updater("test");
     try {
       updater.setEmail(null);
       fail("No error thrown for null email");
@@ -345,7 +345,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testInvalidUpdatePassword() {
-    User.Updater updater = User.updater("test");
+    UserRecord.Updater updater = UserRecord.updater("test");
     try {
       updater.setPassword(null);
       fail("No error thrown for null password");
@@ -361,18 +361,18 @@ public class FirebaseUserManagerTest {
     }
   }
 
-  private void checkUser(User user) {
-    assertEquals("testuser", user.getUid());
-    assertEquals("testuser@example.com", user.getEmail());
-    assertEquals("Test User", user.getDisplayName());
-    assertEquals("http://www.example.com/testuser/photo.png", user.getPhotoUrl());
-    assertEquals(1234567890, user.getUserMetadata().getCreationTimestamp());
-    assertEquals(0, user.getUserMetadata().getLastSignInTimestamp());
-    assertEquals(1, user.getProviderData().length);
-    assertFalse(user.isDisabled());
-    assertTrue(user.isEmailVerified());
+  private void checkUserRecord(UserRecord userRecord) {
+    assertEquals("testuser", userRecord.getUid());
+    assertEquals("testuser@example.com", userRecord.getEmail());
+    assertEquals("Test User", userRecord.getDisplayName());
+    assertEquals("http://www.example.com/testuser/photo.png", userRecord.getPhotoUrl());
+    assertEquals(1234567890, userRecord.getUserMetadata().getCreationTimestamp());
+    assertEquals(0, userRecord.getUserMetadata().getLastSignInTimestamp());
+    assertEquals(1, userRecord.getProviderData().length);
+    assertFalse(userRecord.isDisabled());
+    assertTrue(userRecord.isEmailVerified());
 
-    UserInfo provider = user.getProviderData()[0];
+    UserInfo provider = userRecord.getProviderData()[0];
     assertEquals("testuser@example.com", provider.getUid());
     assertEquals("testuser@example.com", provider.getEmail());
     assertEquals("Test User", provider.getDisplayName());

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -372,7 +372,7 @@ public class FirebaseUserManagerTest {
     assertFalse(user.isDisabled());
     assertTrue(user.isEmailVerified());
 
-    ProviderUserInfo provider = user.getProviderData()[0];
+    UserInfo provider = user.getProviderData()[0];
     assertEquals("testuser@example.com", provider.getUid());
     assertEquals("testuser@example.com", provider.getEmail());
     assertEquals("Test User", provider.getDisplayName());


### PR DESCRIPTION
Following changes were suggested at the API review:
* Introduce `UserInfo` public interface type
* Rename `User` to `UserRecord`
* Rename `User.Builder` to `UserRecord.CreateRequest`
* Rename `User.Updater` to `UserRecord.UpdateRequest`
* Drop `ProviderUserInfo` from the public API
* Implement `UserInfo` at both `UserRecord` and `ProviderUserInfo`
