### PR TITLE
Making JsonFactory and HttpFactory Configurable

### DIFF
--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -16,7 +16,6 @@
 
 package com.google.firebase;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.client.googleapis.util.Utils;
@@ -146,6 +145,8 @@ public final class FirebaseOptions {
       databaseUrl = options.databaseUrl;
       firebaseCredential = options.firebaseCredential;
       databaseAuthVariableOverride = options.databaseAuthVariableOverride;
+      httpTransport = options.httpTransport;
+      jsonFactory = options.jsonFactory;
     }
 
     /**

--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -19,6 +19,9 @@ package com.google.firebase;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.api.client.googleapis.util.Utils;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.firebase.auth.FirebaseCredential;
@@ -37,15 +40,18 @@ public final class FirebaseOptions {
   private final String databaseUrl;
   private final FirebaseCredential firebaseCredential;
   private final Map<String, Object> databaseAuthVariableOverride;
+  private final HttpTransport httpTransport;
+  private final JsonFactory jsonFactory;
 
-  private FirebaseOptions(
-      @Nullable String databaseUrl,
-      @NonNull FirebaseCredential firebaseCredential,
-      @Nullable Map<String, Object> databaseAuthVariableOverride) {
-
-    this.databaseUrl = databaseUrl;
-    this.firebaseCredential = checkNotNull(firebaseCredential, "Service Account must be provided.");
-    this.databaseAuthVariableOverride = databaseAuthVariableOverride;
+  private FirebaseOptions(@NonNull FirebaseOptions.Builder builder) {
+    this.firebaseCredential = checkNotNull(builder.firebaseCredential,
+        "FirebaseOptions must be initialized with setCredential().");
+    this.databaseUrl = builder.databaseUrl;
+    this.databaseAuthVariableOverride = builder.databaseAuthVariableOverride;
+    this.httpTransport = checkNotNull(builder.httpTransport,
+        "FirebaseOptions must be initialized with a non-null HttpTransport.");
+    this.jsonFactory = checkNotNull(builder.jsonFactory,
+        "FirebaseOptions must be initialized with a non-null JsonFactory.");
   }
 
   /**
@@ -69,6 +75,26 @@ public final class FirebaseOptions {
    */
   public Map<String, Object> getDatabaseAuthVariableOverride() {
     return databaseAuthVariableOverride;
+  }
+
+  /**
+   * Returns the HttpTransport used to call remote HTTP endpoints.
+   *
+   * @return A Google API client HttpTransport instance.
+   */
+  @NonNull
+  public HttpTransport getHttpTransport() {
+    return httpTransport;
+  }
+
+  /**
+   * Returns the JsonFactory used to parse JSON when calling remote HTTP endpoints.
+   *
+   * @return A Google API client JsonFactory instance.
+   */
+  @NonNull
+  public JsonFactory getJsonFactory() {
+    return jsonFactory;
   }
 
   @Override
@@ -104,6 +130,8 @@ public final class FirebaseOptions {
     private String databaseUrl;
     private FirebaseCredential firebaseCredential;
     private Map<String, Object> databaseAuthVariableOverride = new HashMap<>();
+    private HttpTransport httpTransport = Utils.getDefaultTransport();
+    private JsonFactory jsonFactory = Utils.getDefaultJsonFactory();
 
     /** Constructs an empty builder. */
     public Builder() {}
@@ -174,14 +202,36 @@ public final class FirebaseOptions {
     }
 
     /**
+     * Sets the HttpTransport used to make remote HTTP calls. A reasonable default
+     * will be used if not explicitly set.
+     *
+     * @param httpTransport An HttpTransport instance
+     * @return This <code>Builder</code> instance is returned so subsequent calls can be chained.
+     */
+    public Builder setHttpTransport(HttpTransport httpTransport) {
+      this.httpTransport = httpTransport;
+      return this;
+    }
+
+    /**
+     * Sets the JsonFactory used to parse JSON when making remote HTTP calls. A reasonable default
+     * will be used if not explicitly set.
+     *
+     * @param jsonFactory A JsonFactory instance.
+     * @return This <code>Builder</code> instance is returned so subsequent calls can be chained.
+     */
+    public Builder setJsonFactory(JsonFactory jsonFactory) {
+      this.jsonFactory = jsonFactory;
+      return this;
+    }
+
+    /**
      * Builds the {@link FirebaseOptions} instance from the previously set options.
      *
      * @return A {@link FirebaseOptions} instance created from the previously set options.
      */
     public FirebaseOptions build() {
-      checkArgument(firebaseCredential != null,
-          "FirebaseOptions must be initialized with setCredential().");
-      return new FirebaseOptions(databaseUrl, firebaseCredential, databaseAuthVariableOverride);
+      return new FirebaseOptions(this);
     }
   }
 }

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -21,9 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.auth.oauth2.GooglePublicKeysManager;
-import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.Clock;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -51,12 +49,10 @@ import java.util.Map;
  */
 public class FirebaseAuth {
 
-  /** A global, thread-safe Json Factory built using Gson. */
-  private static final JsonFactory jsonFactory = new GsonFactory();
-
   private final FirebaseApp firebaseApp;
   private final GooglePublicKeysManager googlePublicKeysManager;
   private final Clock clock;
+  private final JsonFactory jsonFactory;
   private final FirebaseUserManager userManager;
 
   private FirebaseAuth(FirebaseApp firebaseApp) {
@@ -73,7 +69,9 @@ public class FirebaseAuth {
     this.firebaseApp = firebaseApp;
     this.googlePublicKeysManager = googlePublicKeysManager;
     this.clock = clock;
-    this.userManager = new FirebaseUserManager(jsonFactory, Utils.getDefaultTransport());
+    this.jsonFactory = firebaseApp.getOptions().getJsonFactory();
+    this.userManager = new FirebaseUserManager(jsonFactory,
+        firebaseApp.getOptions().getHttpTransport());
   }
 
   /**

--- a/src/main/java/com/google/firebase/auth/FirebaseCredentials.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseCredentials.java
@@ -93,6 +93,7 @@ public class FirebaseCredentials {
    *
    * @param transport HttpTransport used to communicate with the remote authentication server.
    * @param jsonFactory JsonFactory used to parse JSON responses from the remote authentication
+   *     server.
    * @return A {@link FirebaseCredential} based on Google Application Default Credentials which can
    *     be used to authenticate the SDK.
    */

--- a/src/main/java/com/google/firebase/auth/FirebaseCredentials.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseCredentials.java
@@ -22,7 +22,6 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
 import com.google.firebase.internal.NonNull;
@@ -80,8 +79,26 @@ public class FirebaseCredentials {
     return DefaultCredentialsHolder.INSTANCE;
   }
 
-  @VisibleForTesting
-  static FirebaseCredential applicationDefault(HttpTransport transport, JsonFactory jsonFactory) {
+  /**
+   * Returns a {@link FirebaseCredential} based on Google Application Default Credentials which can
+   * be used to authenticate the SDK. Allows specifying the HttpTransport and the
+   * JsonFactory to be used when communicating with the remote authentication server.
+   *
+   * <p>See <a
+   * href="https://developers.google.com/identity/protocols/application-default-credentials">Google
+   * Application Default Credentials</a> for details on Google Application Deafult Credentials.
+   *
+   * <p>See <a href="/docs/admin/setup#initialize_the_sdk">Initialize the SDK</a> for code samples
+   * and detailed documentation.
+   *
+   * @param transport HttpTransport used to communicate with the remote authentication server.
+   * @param jsonFactory JsonFactory used to parse JSON responses from the remote authentication
+   * @return A {@link FirebaseCredential} based on Google Application Default Credentials which can
+   *     be used to authenticate the SDK.
+   */
+  @NonNull
+  public static FirebaseCredential applicationDefault(
+      HttpTransport transport, JsonFactory jsonFactory) {
     return new ApplicationDefaultCredential(transport, jsonFactory);
   }
 
@@ -104,9 +121,26 @@ public class FirebaseCredentials {
         Utils.getDefaultJsonFactory());
   }
 
-  @VisibleForTesting
-  static FirebaseCredential fromCertificate(InputStream serviceAccount, HttpTransport transport,
-      JsonFactory jsonFactory) throws IOException {
+  /**
+   * Returns a {@link FirebaseCredential} generated from the provided service account certificate
+   * which can be used to authenticate the SDK. Allows specifying the HttpTransport and the
+   * JsonFactory to be used when communicating with the remote authentication server.
+   *
+   * <p>See <a href="/docs/admin/setup#initialize_the_sdk">Initialize the SDK</a> for code samples
+   * and detailed documentation.
+   *
+   * @param serviceAccount An <code>InputStream</code> containing the JSON representation of a
+   *     service account certificate.
+   * @param transport HttpTransport used to communicate with the remote authentication server.
+   * @param jsonFactory JsonFactory used to parse JSON responses from the remote authentication
+   *     server.
+   * @return A {@link FirebaseCredential} generated from the provided service account certificate
+   *     which can be used to authenticate the SDK.
+   * @throws IOException If an error occurs while parsing the service account certificate.
+   */
+  @NonNull
+  public static FirebaseCredential fromCertificate(InputStream serviceAccount,
+      HttpTransport transport, JsonFactory jsonFactory) throws IOException {
     return new CertCredential(serviceAccount, transport, jsonFactory);
   }
 
@@ -129,8 +163,25 @@ public class FirebaseCredentials {
         refreshToken, Utils.getDefaultTransport(), Utils.getDefaultJsonFactory());
   }
 
-  @VisibleForTesting
-  static FirebaseCredential fromRefreshToken(final InputStream refreshToken,
+  /**
+   * Returns a {@link FirebaseCredential} generated from the provided refresh token which can be
+   * used to authenticate the SDK. Allows specifying the HttpTransport and the
+   * JsonFactory to be used when communicating with the remote authentication server.
+   *
+   * <p>See <a href="/docs/admin/setup#initialize_the_sdk">Initialize the SDK</a> for code samples
+   * and detailed documentation.
+   *
+   * @param refreshToken An <code>InputStream</code> containing the JSON representation of a refresh
+   *     token.
+   * @param transport HttpTransport used to communicate with the remote authentication server.
+   * @param jsonFactory JsonFactory used to parse JSON responses from the remote authentication
+   *     server.
+   * @return A {@link FirebaseCredential} generated from the provided service account credential
+   *     which can be used to authenticate the SDK.
+   * @throws IOException If an error occurs while parsing the refresh token.
+   */
+  @NonNull
+  public static FirebaseCredential fromRefreshToken(final InputStream refreshToken,
       HttpTransport transport, JsonFactory jsonFactory) throws IOException {
     return new RefreshTokenCredential(refreshToken, transport, jsonFactory);
   }

--- a/src/test/java/com/google/firebase/FirebaseOptionsTest.java
+++ b/src/test/java/com/google/firebase/FirebaseOptionsTest.java
@@ -19,11 +19,15 @@ package com.google.firebase;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.firebase.auth.FirebaseCredential;
 import com.google.firebase.auth.FirebaseCredentials;
 import com.google.firebase.auth.TestOnlyImplFirebaseAuthTrampolines;
@@ -53,12 +57,18 @@ public class FirebaseOptionsTest {
   @Test
   public void createOptionsWithAllValuesSet() throws IOException, InterruptedException {
     final Semaphore semaphore = new Semaphore(0);
+    GsonFactory jsonFactory = new GsonFactory();
+    NetHttpTransport httpTransport = new NetHttpTransport();
     FirebaseOptions firebaseOptions =
         new FirebaseOptions.Builder()
             .setDatabaseUrl(FIREBASE_DB_URL)
             .setCredential(FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream()))
+            .setJsonFactory(jsonFactory)
+            .setHttpTransport(httpTransport)
             .build();
     assertEquals(FIREBASE_DB_URL, firebaseOptions.getDatabaseUrl());
+    assertSame(jsonFactory, firebaseOptions.getJsonFactory());
+    assertSame(httpTransport, firebaseOptions.getHttpTransport());
     TestOnlyImplFirebaseAuthTrampolines.getCertificate(firebaseOptions.getCredential())
         .addOnSuccessListener(
             new OnSuccessListener<GoogleCredential>() {
@@ -79,6 +89,8 @@ public class FirebaseOptionsTest {
         new FirebaseOptions.Builder()
             .setCredential(FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream()))
             .build();
+    assertNotNull(firebaseOptions.getJsonFactory());
+    assertNotNull(firebaseOptions.getHttpTransport());
     TestOnlyImplFirebaseAuthTrampolines.getCertificate(firebaseOptions.getCredential())
         .addOnSuccessListener(
             new OnSuccessListener<GoogleCredential>() {
@@ -109,7 +121,7 @@ public class FirebaseOptionsTest {
     assertEquals("mock-project-id", Tasks.await(projectId));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = NullPointerException.class)
   public void createOptionsWithCredentialMissing() {
     new FirebaseOptions.Builder().build();
   }


### PR DESCRIPTION
* Exposed protected factory methods in `FirebaseCredentials`, which accept `JsonFactory` and `HttpTransport` arguments.
* Added `setJsonFactory()` and `setHttpTransport()` methods to `FirebaseOptions`.

Related to #35 