### PR TITLE
Updating the build configuration to include source files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,12 +187,6 @@
                     <plugin>
                         <artifactId>maven-source-plugin</artifactId>
                         <version>2.2.1</version>
-                        <configuration>
-                            <excludes>
-                                <!-- Exclude all files until we go open source -->
-                                <exclude>com/**</exclude>
-                            </excludes>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>


### PR DESCRIPTION
Fixing #40 

Our source distribution (firebase-admin-source.jar uploaded to Maven) does not actually contain any source files. This was the behavior we had configured in the pre-open source days. Now that we are open source, we should include source files in the distribution.