### PR TITLE
Removing toString, hashCode and equals methods from FirebaseOptions

### DIFF
--- a/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/src/main/java/com/google/firebase/FirebaseApp.java
@@ -276,7 +276,7 @@ public class FirebaseApp {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("name", name).add("options", options).toString();
+    return MoreObjects.toStringHelper(this).add("name", name).toString();
   }
 
   /**

--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -22,7 +22,6 @@ import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import com.google.firebase.auth.FirebaseCredential;
 import com.google.firebase.auth.FirebaseCredentials;
 import com.google.firebase.internal.NonNull;
@@ -77,7 +76,8 @@ public final class FirebaseOptions {
   }
 
   /**
-   * Returns the HttpTransport used to call remote HTTP endpoints.
+   * Returns the HttpTransport used to call remote HTTP endpoints. This transport is used by all
+   * services of the SDK, except for FirebaseDatabase.
    *
    * @return A Google API client HttpTransport instance.
    */
@@ -94,31 +94,6 @@ public final class FirebaseOptions {
   @NonNull
   public JsonFactory getJsonFactory() {
     return jsonFactory;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (!(obj instanceof FirebaseOptions)) {
-      return false;
-    }
-    FirebaseOptions other = (FirebaseOptions) obj;
-    return Objects.equal(databaseUrl, other.databaseUrl)
-        && Objects.equal(firebaseCredential, other.firebaseCredential)
-        && Objects.equal(databaseAuthVariableOverride, other.databaseAuthVariableOverride);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(databaseUrl, firebaseCredential, databaseAuthVariableOverride);
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("databaseUrl", databaseUrl)
-        .add("credential", firebaseCredential)
-        .add("databaseAuthVariableOverride", databaseAuthVariableOverride)
-        .toString();
   }
 
   /** 
@@ -204,7 +179,8 @@ public final class FirebaseOptions {
 
     /**
      * Sets the HttpTransport used to make remote HTTP calls. A reasonable default
-     * will be used if not explicitly set.
+     * will be used if not explicitly set. The transport specified by calling this method will be
+     * used by all services of the SDK, except for FirebaseDatabase.
      *
      * @param httpTransport An HttpTransport instance
      * @return This <code>Builder</code> instance is returned so subsequent calls can be chained.

--- a/src/test/java/com/google/firebase/FirebaseAppTest.java
+++ b/src/test/java/com/google/firebase/FirebaseAppTest.java
@@ -181,8 +181,7 @@ public class FirebaseAppTest {
             .setCredential(FirebaseCredentials.fromCertificate(ServiceAccount.EDITOR.asStream()))
             .build();
     FirebaseApp app = FirebaseApp.initializeApp(options, "app");
-    String pattern = "FirebaseApp\\{name=app, options=FirebaseOptions\\{"
-        + "databaseUrl=null, credential=[^\\s]+, databaseAuthVariableOverride=\\{}}}";
+    String pattern = "FirebaseApp\\{name=app}";
     assertTrue(app.toString().matches(pattern));
   }
 

--- a/src/test/java/com/google/firebase/FirebaseOptionsTest.java
+++ b/src/test/java/com/google/firebase/FirebaseOptionsTest.java
@@ -18,11 +18,9 @@ package com.google.firebase;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
@@ -130,22 +128,10 @@ public class FirebaseOptionsTest {
   public void checkToBuilderCreatesNewEquivalentInstance() {
     FirebaseOptions allValuesOptionsCopy = new FirebaseOptions.Builder(ALL_VALUES_OPTIONS).build();
     assertNotSame(ALL_VALUES_OPTIONS, allValuesOptionsCopy);
-    assertEquals(ALL_VALUES_OPTIONS, allValuesOptionsCopy);
-  }
-
-  @Test
-  public void testEquals() throws IOException {
-    FirebaseCredential credential = FirebaseCredentials
-        .fromCertificate(ServiceAccount.EDITOR.asStream());
-    FirebaseOptions options1 =
-        new FirebaseOptions.Builder()
-            .setCredential(credential)
-            .build();
-    FirebaseOptions options2 =
-        new FirebaseOptions.Builder()
-            .setCredential(credential)
-            .build();
-    assertTrue(options1.equals(options2));
+    assertEquals(ALL_VALUES_OPTIONS.getCredential(), allValuesOptionsCopy.getCredential());
+    assertEquals(ALL_VALUES_OPTIONS.getDatabaseUrl(), allValuesOptionsCopy.getDatabaseUrl());
+    assertEquals(ALL_VALUES_OPTIONS.getJsonFactory(), allValuesOptionsCopy.getJsonFactory());
+    assertEquals(ALL_VALUES_OPTIONS.getHttpTransport(), allValuesOptionsCopy.getHttpTransport());
   }
 
   @Test
@@ -162,28 +148,5 @@ public class FirebaseOptionsTest {
             .setDatabaseUrl("https://test.firebaseio.com")
             .build();
     assertFalse(options1.equals(options2));
-  }
-
-  @Test
-  public void testHashCode() throws IOException {
-    FirebaseCredential credential = FirebaseCredentials
-        .fromCertificate(ServiceAccount.EDITOR.asStream());
-    FirebaseOptions options1 =
-        new FirebaseOptions.Builder()
-            .setCredential(credential)
-            .setDatabaseUrl("https://test.firebaseio.com")
-            .build();
-    FirebaseOptions options2 =
-        new FirebaseOptions.Builder()
-            .setCredential(credential)
-            .setDatabaseUrl("https://test.firebaseio.com")
-            .build();
-    FirebaseOptions options3 =
-        new FirebaseOptions.Builder()
-            .setCredential(credential)
-            .setDatabaseUrl("https://test2.firebaseio.com")
-            .build();
-    assertEquals(options1.hashCode(), options2.hashCode());
-    assertNotEquals(options1.hashCode(), options3.hashCode());
   }
 }


### PR DESCRIPTION
* Removed `toString()`, `hashCode()` and `equals()` methods from `FirebaseOptions` class. These methods had been originally implemented to support some persistence requirements, which are no longer in use. We can consider adding these methods back if and when we decide to add persistence in the future.
* Removed the affected test cases.
* Changed `FirebaseApp.toString()` to no longer include options in the output.

See #38 for a related discussion