### PR TITLE
Adding an extra dependency to javadoc classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,13 @@
                             </docletArtifact>
                             <doclet>com.google.doclava.Doclava</doclet>
                             <bootclasspath>${sun.boot.class.path}</bootclasspath>
+                            <additionalDependencies>
+                                <additionalDependency>
+                                    <groupId>com.google.errorprone</groupId>
+                                    <artifactId>error_prone_annotations</artifactId>
+                                    <version>2.0.15</version>
+                                </additionalDependency>
+                            </additionalDependencies>
                             <additionalparam>
                                 -hdf book.path /_book.yaml
                                 -hdf project.path /_project.yaml


### PR DESCRIPTION
Adding `google-cloud-storage` to the project classpath has somehow broken our javadoc generation tools:

```
Constructing Javadoc information...
1 error
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 8.764 s
[INFO] Finished at: 2017-08-11T12:15:41-07:00
[INFO] Final Memory: 58M/1617M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:aggregate (default) on project firebase-admin: An error has occurred in JavaDocs report generation:
[ERROR] Exit code: 1 - javadoc: error - In doclet class com.google.doclava.Doclava,  method start has thrown an exception java.lang.reflect.InvocationTargetException
[ERROR] com.sun.tools.javac.code.Symbol$CompletionFailure: class file for com.google.errorprone.annotations.CanIgnoreReturnValue not found
[ERROR] 
[ERROR] Command line was: /usr/local/google/home/hkj/.homebrew/Cellar/jdk/1.8.0-112/jre/../bin/javadoc -J-Xmx1024m @options @packages
[ERROR] 
[ERROR] Refer to the generated Javadoc files in '/usr/local/google/home/hkj/Projects/firebase-admin-java/public/target/site/apidocs' dir.
[ERROR] -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:aggregate (default) on project firebase-admin: An error has occurred in JavaDocs report generation: 
Exit code: 1 - javadoc: error - In doclet class com.google.doclava.Doclava,  method start has thrown an exception java.lang.reflect.InvocationTargetException
com.sun.tools.javac.code.Symbol$CompletionFailure: class file for com.google.errorprone.annotations.CanIgnoreReturnValue not found

Command line was: /usr/local/google/home/hkj/.homebrew/Cellar/jdk/1.8.0-112/jre/../bin/javadoc -J-Xmx1024m @options @packages

Refer to the generated Javadoc files in '/usr/local/google/home/hkj/Projects/firebase-admin-java/public/target/site/apidocs' dir.

	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoExecutionException: An error has occurred in JavaDocs report generation: 
Exit code: 1 - javadoc: error - In doclet class com.google.doclava.Doclava,  method start has thrown an exception java.lang.reflect.InvocationTargetException
com.sun.tools.javac.code.Symbol$CompletionFailure: class file for com.google.errorprone.annotations.CanIgnoreReturnValue not found

Command line was: /usr/local/google/home/hkj/.homebrew/Cellar/jdk/1.8.0-112/jre/../bin/javadoc -J-Xmx1024m @options @packages

Refer to the generated Javadoc files in '/usr/local/google/home/hkj/Projects/firebase-admin-java/public/target/site/apidocs' dir.

	at org.apache.maven.plugin.javadoc.AbstractJavadocMojo.failOnError(AbstractJavadocMojo.java:6082)
	at org.apache.maven.plugin.javadoc.JavadocReport.execute(JavadocReport.java:322)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
	... 20 more
Caused by: org.apache.maven.reporting.MavenReportException: 
Exit code: 1 - javadoc: error - In doclet class com.google.doclava.Doclava,  method start has thrown an exception java.lang.reflect.InvocationTargetException
com.sun.tools.javac.code.Symbol$CompletionFailure: class file for com.google.errorprone.annotations.CanIgnoreReturnValue not found

Command line was: /usr/local/google/home/hkj/.homebrew/Cellar/jdk/1.8.0-112/jre/../bin/javadoc -J-Xmx1024m @options @packages

Refer to the generated Javadoc files in '/usr/local/google/home/hkj/Projects/firebase-admin-java/public/target/site/apidocs' dir.

	at org.apache.maven.plugin.javadoc.AbstractJavadocMojo.executeJavadocCommandLine(AbstractJavadocMojo.java:5188)
	at org.apache.maven.plugin.javadoc.AbstractJavadocMojo.executeReport(AbstractJavadocMojo.java:2075)
	at org.apache.maven.plugin.javadoc.JavadocReport.generate(JavadocReport.java:130)
	at org.apache.maven.plugin.javadoc.JavadocReport.execute(JavadocReport.java:318)
	... 22 more
```

I have no flipping idea why!

For now I'm adding the dependency it's complaining about (`error_prone_annotations`) to the javadoc classpath, which seems to fix it.