### PR TITLE
Deprecated the Task API and introduced ApiFutures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,11 @@
             <version>20.0</version>
         </dependency>
         <dependency>
+            <groupId>com.google.api</groupId>
+            <artifactId>api-common</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
             <version>1.2.1</version>

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -103,8 +103,7 @@ public class FirebaseAuth {
   }
 
   /**
-   * Creates a Firebase Custom Token associated with the given UID. This token can then be provided
-   * back to a client application for use with the signInWithCustomToken authentication API.
+   * Similar to {@link #createCustomTokenAsync(String)}, but returns a Task.
    *
    * @param uid The UID to store in the token. This identifies the user to other Firebase services
    *     (Firebase Database, Firebase Auth, etc.)
@@ -117,9 +116,7 @@ public class FirebaseAuth {
   }
 
   /**
-   * Creates a Firebase Custom Token associated with the given UID and additionally containing the
-   * specified developerClaims. This token can then be provided back to a client application for use
-   * with the signInWithCustomToken authentication API.
+   * Similar to {@link #createCustomTokenAsync(String, Map)}, but returns a Task.
    *
    * @param uid The UID to store in the token. This identifies the user to other Firebase services
    *     (Realtime Database, Storage, etc.). Should be less than 128 characters.
@@ -189,20 +186,7 @@ public class FirebaseAuth {
   }
 
   /**
-   * Parses and verifies a Firebase ID Token.
-   *
-   * <p>A Firebase application can identify itself to a trusted backend server by sending its
-   * Firebase ID Token (accessible via the getToken API in the Firebase Authentication client) with
-   * its request.
-   *
-   * <p>The backend server can then use the verifyIdToken() method to verify the token is valid,
-   * meaning: the token is properly signed, has not expired, and it was issued for the project
-   * associated with this FirebaseAuth instance (which by default is extracted from your service
-   * account)
-   *
-   * <p>If the token is valid, the returned {@link Task} will complete successfully and provide a
-   * parsed version of the token from which the UID and other claims in the token can be inspected.
-   * If the token is invalid, the Task will fail with an exception indicating the failure.
+   * Similar to {@link #verifyIdTokenAsync(String)}, but returns a Task.
    *
    * @param token A Firebase ID Token to verify and parse.
    * @return A {@link Task} which will complete successfully with the parsed token, or
@@ -264,7 +248,7 @@ public class FirebaseAuth {
   }
 
   /**
-   * Gets the user data corresponding to the specified user ID.
+   * Similar to {@link #getUserAsync(String)}, but returns a Task.
    *
    * @param uid A user ID string.
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance.
@@ -298,7 +282,7 @@ public class FirebaseAuth {
   }
 
   /**
-   * Gets the user data corresponding to the specified user email.
+   * Similar to {@link #getUserByEmailAsync(String)}, but returns a Task.
    *
    * @param email A user email address string.
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance.
@@ -332,7 +316,7 @@ public class FirebaseAuth {
   }
 
   /**
-   * Gets the user data corresponding to the specified user phone number.
+   * Similar to {@link #getUserByPhoneNumberAsync(String)}, but returns a Task.
    *
    * @param phoneNumber A user phone number string.
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance.
@@ -366,8 +350,7 @@ public class FirebaseAuth {
   }
 
   /**
-   * Creates a new user account with the attributes contained in the specified
-   * {@link CreateRequest}.
+   * Similar to {@link #createUserAsync(CreateRequest)}, but returns a Task.
    *
    * @param request A non-null {@link CreateRequest} instance.
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance
@@ -403,8 +386,7 @@ public class FirebaseAuth {
   }
 
   /**
-   * Updates an existing user account with the attributes contained in the specified
-   * {@link UpdateRequest}.
+   * Similar to {@link #updateUserAsync(UpdateRequest)}, but returns a Task.
    *
    * @param request A non-null {@link UpdateRequest} instance.
    * @return A {@link Task} which will complete successfully with a {@link UserRecord} instance
@@ -440,7 +422,7 @@ public class FirebaseAuth {
   }
 
   /**
-   * Deletes the user identified by the specified user ID.
+   * Similar to {@link #deleteUserAsync(String)}, but returns a Task.
    *
    * @param uid A user ID string.
    * @return A {@link Task} which will complete successfully when the specified user account has

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -110,6 +110,7 @@ public class FirebaseAuth {
    *     (Firebase Database, Firebase Auth, etc.)
    * @return A {@link Task} which will complete successfully with the created Firebase Custom Token,
    *     or unsuccessfully with the failure Exception.
+   * @deprecated Use {@link #createCustomTokenAsync(String)}
    */
   public Task<String> createCustomToken(String uid) {
     return createCustomToken(uid, null);
@@ -127,6 +128,7 @@ public class FirebaseAuth {
    *     (e.g. contain only Maps, Arrays, Strings, Booleans, Numbers, etc.)
    * @return A {@link Task} which will complete successfully with the created Firebase Custom Token,
    *     or unsuccessfully with the failure Exception.
+   * @deprecated Use {@link #createCustomTokenAsync(String, Map)}
    */
   public Task<String> createCustomToken(
       final String uid, final Map<String, Object> developerClaims) {
@@ -205,6 +207,7 @@ public class FirebaseAuth {
    * @param token A Firebase ID Token to verify and parse.
    * @return A {@link Task} which will complete successfully with the parsed token, or
    *     unsuccessfully with the failure Exception.
+   * @deprecated Use {@link #verifyIdTokenAsync(String)}
    */
   public Task<FirebaseToken> verifyIdToken(final String token) {
     FirebaseCredential credential = ImplFirebaseTrampolines.getCredential(firebaseApp);
@@ -268,6 +271,7 @@ public class FirebaseAuth {
    *     If an error occurs while retrieving user data or if the specified user ID does not exist,
    *     the task fails with a FirebaseAuthException.
    * @throws IllegalArgumentException If the user ID string is null or empty.
+   * @deprecated Use {@link #getUserAsync(String)}
    */
   public Task<UserRecord> getUser(final String uid) {
     checkArgument(!Strings.isNullOrEmpty(uid), "uid must not be null or empty");
@@ -301,6 +305,7 @@ public class FirebaseAuth {
    *     If an error occurs while retrieving user data or if the email address does not correspond
    *     to a user, the task fails with a FirebaseAuthException.
    * @throws IllegalArgumentException If the email is null or empty.
+   * @deprecated Use {@link #getUserByEmailAsync(String)}
    */
   public Task<UserRecord> getUserByEmail(final String email) {
     checkArgument(!Strings.isNullOrEmpty(email), "email must not be null or empty");
@@ -334,6 +339,7 @@ public class FirebaseAuth {
    *     If an error occurs while retrieving user data or if the phone number does not
    *     correspond to a user, the task fails with a FirebaseAuthException.
    * @throws IllegalArgumentException If the phone number is null or empty.
+   * @deprecated Use {@link #getUserByPhoneNumberAsync(String)}
    */
   public Task<UserRecord> getUserByPhoneNumber(final String phoneNumber) {
     checkArgument(!Strings.isNullOrEmpty(phoneNumber), "phone number must not be null or empty");
@@ -368,6 +374,7 @@ public class FirebaseAuth {
    *     corresponding to the newly created account. If an error occurs while creating the user
    *     account, the task fails with a FirebaseAuthException.
    * @throws NullPointerException if the provided request is null.
+   * @deprecated Use {@link #createUserAsync(CreateRequest)}
    */
   public Task<UserRecord> createUser(final CreateRequest request) {
     checkNotNull(request, "create request must not be null");
@@ -404,6 +411,7 @@ public class FirebaseAuth {
    *     corresponding to the updated user account. If an error occurs while updating the user
    *     account, the task fails with a FirebaseAuthException.
    * @throws NullPointerException if the provided update request is null.
+   * @deprecated Use {@link #updateUserAsync(UpdateRequest)}
    */
   public Task<UserRecord> updateUser(final UpdateRequest request) {
     checkNotNull(request, "update request must not be null");
@@ -439,6 +447,7 @@ public class FirebaseAuth {
    *     been deleted. If an error occurs while deleting the user account, the task fails with a
    *     FirebaseAuthException.
    * @throws IllegalArgumentException If the user ID string is null or empty.
+   * @deprecated Use {@link #deleteUserAsync(String)}
    */
   public Task<Void> deleteUser(final String uid) {
     checkArgument(!Strings.isNullOrEmpty(uid), "uid must not be null or empty");

--- a/src/main/java/com/google/firebase/database/DatabaseReference.java
+++ b/src/main/java/com/google/firebase/database/DatabaseReference.java
@@ -16,6 +16,7 @@
 
 package com.google.firebase.database;
 
+import com.google.api.core.ApiFuture;
 import com.google.firebase.database.core.CompoundWrite;
 import com.google.firebase.database.core.DatabaseConfig;
 import com.google.firebase.database.core.Path;
@@ -32,6 +33,7 @@ import com.google.firebase.database.utilities.PushIdGenerator;
 import com.google.firebase.database.utilities.Utilities;
 import com.google.firebase.database.utilities.Validation;
 import com.google.firebase.database.utilities.encoding.CustomClassMapper;
+import com.google.firebase.internal.TaskToApiFuture;
 import com.google.firebase.tasks.Task;
 
 import java.io.UnsupportedEncodingException;
@@ -172,13 +174,11 @@ public class DatabaseReference extends Query {
    * <code>Map&lt;String, MyPOJO&gt;</code>, as well as null values.
    *
    * @param value The value to set at this location
-   * @return The {@link Task} for this operation.
+   * @return The ApiFuture for this operation.
    */
-  public Task<Void> setValue(Object value) {
-    return setValueInternal(value, PriorityUtilities.parsePriority(null), null);
+  public ApiFuture<Void> setValueAsync(Object value) {
+    return new TaskToApiFuture<>(setValue(value));
   }
-
-  // Set priority
 
   /**
    * Set the data and priority to the given values. Passing null to setValue() will delete the data
@@ -212,7 +212,30 @@ public class DatabaseReference extends Query {
    *
    * @param value The value to set at this location
    * @param priority The priority to set at this location
+   * @return The ApiFuture for this operation.
+   */
+  public ApiFuture<Void> setValueAsync(Object value, Object priority) {
+    return new TaskToApiFuture<>(setValue(value, priority));
+  }
+
+  /**
+   * Similar to {@link #setValueAsync(Object)} but returns a Task.
+   *
+   * @param value The value to set at this location
    * @return The {@link Task} for this operation.
+   * @deprecated Use {@link #setValueAsync(Object)}
+   */
+  public Task<Void> setValue(Object value) {
+    return setValueInternal(value, PriorityUtilities.parsePriority(null), null);
+  }
+
+  /**
+   * Similar to {@link #setValueAsync(Object, Object)} but returns a Task.
+   *
+   * @param value The value to set at this location
+   * @param priority The priority to set at this location
+   * @return The {@link Task} for this operation.
+   * @deprecated Use {@link #setValueAsync(Object, Object)}
    */
   public Task<Void> setValue(Object value, Object priority) {
     return setValueInternal(value, PriorityUtilities.parsePriority(priority), null);
@@ -292,8 +315,6 @@ public class DatabaseReference extends Query {
     setValueInternal(value, PriorityUtilities.parsePriority(priority), listener);
   }
 
-  // Update
-
   private Task<Void> setValueInternal(Object value, Node priority, CompletionListener optListener) {
     Validation.validateWritablePath(getPath());
     ValidationPath.validateWithObject(getPath(), value);
@@ -310,6 +331,8 @@ public class DatabaseReference extends Query {
         });
     return wrapped.getFirst();
   }
+
+  // Set priority
 
   /**
    * Set a priority for the data at this Database location. Priorities can be used to provide a
@@ -338,7 +361,18 @@ public class DatabaseReference extends Query {
    * they can be parsed as a 32-bit integer.
    *
    * @param priority The priority to set at the specified location.
+   * @return The ApiFuture for this operation.
+   */
+  public ApiFuture<Void> setPriorityAsync(Object priority) {
+    return new TaskToApiFuture<>(setPriority(priority));
+  }
+
+  /**
+   * Similar to {@link #setPriorityAsync(Object)} but returns a Task.
+   *
+   * @param priority The priority to set at the specified location.
    * @return The {@link Task} for this operation.
+   * @deprecated Use {@link #setPriorityAsync(Object)}
    */
   public Task<Void> setPriority(Object priority) {
     return setPriorityInternal(PriorityUtilities.parsePriority(priority), null);
@@ -394,12 +428,25 @@ public class DatabaseReference extends Query {
     return wrapped.getFirst();
   }
 
+  // Update
+
   /**
    * Update the specific child keys to the specified values. Passing null in a map to
    * updateChildren() will remove the value at the specified location.
    *
    * @param update The paths to update and their new values
+   * @return The ApiFuture for this operation.
+   */
+  public ApiFuture<Void> updateChildrenAsync(Map<String, Object> update) {
+    return new TaskToApiFuture<>(updateChildren(update));
+  }
+
+  /**
+   * Similar to {@link #updateChildrenAsync(Map)} but returns a Task.
+   *
+   * @param update The paths to update and their new values
    * @return The {@link Task} for this operation.
+   * @deprecated Use {@link #updateChildrenAsync(Map)}
    */
   public Task<Void> updateChildren(Map<String, Object> update) {
     return updateChildrenInternal(update, null);
@@ -444,7 +491,17 @@ public class DatabaseReference extends Query {
   /**
    * Set the value at this location to 'null'
    *
-   * @return The {@link Task} for this operation.
+   * @return The ApiFuture for this operation.
+   */
+  public ApiFuture<Void> removeValueAsync() {
+    return new TaskToApiFuture<>(removeValue());
+  }
+
+  /**
+   * Similar to {@link #removeValueAsync()} but returns a Task.
+   *
+   * @return The Task for this operation.
+   * @deprecated Use {@link #removeValueAsync()}
    */
   public Task<Void> removeValue() {
     return setValue(null);

--- a/src/main/java/com/google/firebase/database/OnDisconnect.java
+++ b/src/main/java/com/google/firebase/database/OnDisconnect.java
@@ -16,6 +16,7 @@
 
 package com.google.firebase.database;
 
+import com.google.api.core.ApiFuture;
 import com.google.firebase.database.DatabaseReference.CompletionListener;
 import com.google.firebase.database.core.Path;
 import com.google.firebase.database.core.Repo;
@@ -27,6 +28,7 @@ import com.google.firebase.database.utilities.Pair;
 import com.google.firebase.database.utilities.Utilities;
 import com.google.firebase.database.utilities.Validation;
 import com.google.firebase.database.utilities.encoding.CustomClassMapper;
+import com.google.firebase.internal.TaskToApiFuture;
 import com.google.firebase.tasks.Task;
 
 import java.util.Map;
@@ -51,44 +53,35 @@ public class OnDisconnect {
   }
 
   /**
-   * Ensure the data at this location is set to the specified value when the client is disconnected
-   * (due to closing the browser, navigating to a new page, or network issues). <br>
-   * <br>
-   * This method is especially useful for implementing "presence" systems, where a value should be
-   * changed or cleared when a user disconnects so that they appear "offline" to other users.
+   * Similar to {@link #setValueAsync(Object)}, but returns a Task.
    *
    * @param value The value to be set when a disconnect occurs
    * @return The {@link Task} for this operation.
+   * @deprecated Use {@link #setValueAsync(Object)}
    */
   public Task<Void> setValue(Object value) {
     return onDisconnectSetInternal(value, PriorityUtilities.NullPriority(), null);
   }
 
   /**
-   * Ensure the data at this location is set to the specified value and priority when the client is
-   * disconnected (due to closing the browser, navigating to a new page, or network issues). <br>
-   * <br>
-   * This method is especially useful for implementing "presence" systems, where a value should be
-   * changed or cleared when a user disconnects so that they appear "offline" to other users.
+   * Similar to {@link #setValueAsync(Object, String)}, but returns a Task.
    *
    * @param value The value to be set when a disconnect occurs
    * @param priority The priority to be set when a disconnect occurs
    * @return The {@link Task} for this operation.
+   * @deprecated Use {@link #setValueAsync(Object, String)}
    */
   public Task<Void> setValue(Object value, String priority) {
     return onDisconnectSetInternal(value, PriorityUtilities.parsePriority(priority), null);
   }
 
   /**
-   * Ensure the data at this location is set to the specified value and priority when the client is
-   * disconnected (due to closing the browser, navigating to a new page, or network issues). <br>
-   * <br>
-   * This method is especially useful for implementing "presence" systems, where a value should be
-   * changed or cleared when a user disconnects so that they appear "offline" to other users.
+   * Similar to {@link #setValueAsync(Object, double)}, but returns a Task.
    *
    * @param value The value to be set when a disconnect occurs
    * @param priority The priority to be set when a disconnect occurs
    * @return The {@link Task} for this operation.
+   * @deprecated Use {@link #setValueAsync(Object, double)}
    */
   public Task<Void> setValue(Object value, double priority) {
     return onDisconnectSetInternal(value, PriorityUtilities.parsePriority(priority), null);
@@ -153,6 +146,50 @@ public class OnDisconnect {
     onDisconnectSetInternal(value, PriorityUtilities.parsePriority(priority), listener);
   }
 
+  /**
+   * Ensure the data at this location is set to the specified value when the client is disconnected
+   * (due to closing the browser, navigating to a new page, or network issues). <br>
+   * <br>
+   * This method is especially useful for implementing "presence" systems, where a value should be
+   * changed or cleared when a user disconnects so that they appear "offline" to other users.
+   *
+   * @param value The value to be set when a disconnect occurs
+   * @return The ApiFuture for this operation.
+   */
+  public ApiFuture<Void> setValueAsync(Object value) {
+    return new TaskToApiFuture<>(setValue(value));
+  }
+
+  /**
+   * Ensure the data at this location is set to the specified value and priority when the client is
+   * disconnected (due to closing the browser, navigating to a new page, or network issues). <br>
+   * <br>
+   * This method is especially useful for implementing "presence" systems, where a value should be
+   * changed or cleared when a user disconnects so that they appear "offline" to other users.
+   *
+   * @param value The value to be set when a disconnect occurs
+   * @param priority The priority to be set when a disconnect occurs
+   * @return The ApiFuture for this operation.
+   */
+  public ApiFuture<Void> setValueAsync(Object value, String priority) {
+    return new TaskToApiFuture<>(setValue(value, priority));
+  }
+
+  /**
+   * Ensure the data at this location is set to the specified value and priority when the client is
+   * disconnected (due to closing the browser, navigating to a new page, or network issues). <br>
+   * <br>
+   * This method is especially useful for implementing "presence" systems, where a value should be
+   * changed or cleared when a user disconnects so that they appear "offline" to other users.
+   *
+   * @param value The value to be set when a disconnect occurs
+   * @param priority The priority to be set when a disconnect occurs
+   * @return The ApiFuture for this operation.
+   */
+  public ApiFuture<Void> setValueAsync(Object value, double priority) {
+    return new TaskToApiFuture<>(setValue(value, priority));
+  }
+
   private Task<Void> onDisconnectSetInternal(
       Object value, Node priority, final CompletionListener optListener) {
     Validation.validateWritablePath(path);
@@ -174,10 +211,11 @@ public class OnDisconnect {
   // Update
 
   /**
-   * Ensure the data has the specified child values updated when the client is disconnected
+   * Similar to {@link #updateChildrenAsync(Map)}, but returns a Task.
    *
    * @param update The paths to update, along with their desired values
    * @return The {@link Task} for this operation.
+   * @deprecated Use {@link #updateChildrenAsync(Map)}
    */
   public Task<Void> updateChildren(Map<String, Object> update) {
     return updateChildrenInternal(update, null);
@@ -191,6 +229,16 @@ public class OnDisconnect {
    */
   public void updateChildren(final Map<String, Object> update, final CompletionListener listener) {
     updateChildrenInternal(update, listener);
+  }
+
+  /**
+   * Ensure the data has the specified child values updated when the client is disconnected
+   *
+   * @param update The paths to update, along with their desired values
+   * @return The ApiFuture for this operation.
+   */
+  public ApiFuture<Void> updateChildrenAsync(Map<String, Object> update) {
+    return new TaskToApiFuture<>(updateChildren(update));
   }
 
   private Task<Void> updateChildrenInternal(
@@ -210,9 +258,10 @@ public class OnDisconnect {
   // Remove
 
   /**
-   * Remove the value at this location when the client disconnects
+   * Similar to {@link #removeValueAsync()}, but returns a Task.
    *
    * @return The {@link Task} for this operation.
+   * @deprecated Use {@link #removeValueAsync()}
    */
   public Task<Void> removeValue() {
     return setValue(null);
@@ -227,12 +276,22 @@ public class OnDisconnect {
     setValue(null, listener);
   }
 
+  /**
+   * Remove the value at this location when the client disconnects
+   *
+   * @return The ApiFuture for this operation.
+   */
+  public ApiFuture<Void> removeValueAsync() {
+    return new TaskToApiFuture<>(removeValue());
+  }
+
   // Cancel the operation
 
   /**
-   * Cancel any disconnect operations that are queued up at this location
+   * Similar to {@link #cancelAsync()} ()}, but returns a Task.
    *
    * @return The {@link Task} for this operation.
+   * @deprecated Use {@link #cancelAsync()}.
    */
   public Task<Void> cancel() {
     return cancelInternal(null);
@@ -245,6 +304,15 @@ public class OnDisconnect {
    */
   public void cancel(final CompletionListener listener) {
     cancelInternal(listener);
+  }
+
+  /**
+   * Cancel any disconnect operations that are queued up at this location
+   *
+   * @return The ApiFuture for this operation.
+   */
+  public ApiFuture<Void> cancelAsync() {
+    return new TaskToApiFuture<>(cancel());
   }
 
   private Task<Void> cancelInternal(final CompletionListener optListener) {

--- a/src/main/java/com/google/firebase/internal/TaskToApiFuture.java
+++ b/src/main/java/com/google/firebase/internal/TaskToApiFuture.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.api.core.ApiFuture;
+import com.google.firebase.tasks.OnCompleteListener;
+import com.google.firebase.tasks.Task;
+import com.google.firebase.tasks.Tasks;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * An ApiFuture implementation that wraps a {@link Task}. This is an interim solution that enables
+ * us to expose Tasks as ApiFutures, until we fully remove the Task API.
+ *
+ * @param <T> Type of the result produced by this Future.
+ */
+public class TaskToApiFuture<T> implements ApiFuture<T> {
+
+  private final Task<T> task;
+
+  public TaskToApiFuture(Task<T> task) {
+    this.task = checkNotNull(task, "task must not be null");
+  }
+
+  @Override
+  public void addListener(final Runnable runnable, Executor executor) {
+    task.addOnCompleteListener(executor, new OnCompleteListener<T>() {
+      @Override
+      public void onComplete(Task<T> task) {
+        runnable.run();
+      }
+    });
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    // Cannot be supported with Tasks
+    return false;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return false;
+  }
+
+  @Override
+  public boolean isDone() {
+    return task.isComplete();
+  }
+
+  @Override
+  public T get() throws InterruptedException, ExecutionException {
+    return Tasks.await(task);
+  }
+
+  @Override
+  public T get(long timeout, @NonNull TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return Tasks.await(task, timeout, unit);
+  }
+}

--- a/src/main/java/com/google/firebase/internal/TaskToApiFuture.java
+++ b/src/main/java/com/google/firebase/internal/TaskToApiFuture.java
@@ -36,6 +36,7 @@ import java.util.concurrent.TimeoutException;
 public class TaskToApiFuture<T> implements ApiFuture<T> {
 
   private final Task<T> task;
+  private boolean cancelled;
 
   public TaskToApiFuture(Task<T> task) {
     this.task = checkNotNull(task, "task must not be null");
@@ -54,6 +55,7 @@ public class TaskToApiFuture<T> implements ApiFuture<T> {
   @Override
   public boolean cancel(boolean mayInterruptIfRunning) {
     // Cannot be supported with Tasks
+    cancelled = true;
     return false;
   }
 
@@ -64,7 +66,7 @@ public class TaskToApiFuture<T> implements ApiFuture<T> {
 
   @Override
   public boolean isDone() {
-    return task.isComplete();
+    return cancelled || task.isComplete();
   }
 
   @Override

--- a/src/main/java/com/google/firebase/tasks/Task.java
+++ b/src/main/java/com/google/firebase/tasks/Task.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executor;
  * Represents an asynchronous operation.
  *
  * @param <T> the type of the result of the operation
+ * @deprecated Use ApiFuture interface instead
  */
 public abstract class Task<T> {
 

--- a/src/main/java/com/google/firebase/tasks/Task.java
+++ b/src/main/java/com/google/firebase/tasks/Task.java
@@ -25,7 +25,9 @@ import java.util.concurrent.Executor;
  * Represents an asynchronous operation.
  *
  * @param <T> the type of the result of the operation
- * @deprecated Use ApiFuture interface instead
+ * @deprecated Task has been deprecated in favor of ApiFuture. For every method xyz() that returns
+ *     a {@code Task<T>}, you should be able to find a corresponding xyzAsync() method that returns
+ *     an {@code ApiFuture<T>}.
  */
 public abstract class Task<T> {
 

--- a/src/test/java/com/google/firebase/FirebaseAppTest.java
+++ b/src/test/java/com/google/firebase/FirebaseAppTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.base.Defaults;
 import com.google.common.io.BaseEncoding;
-import com.google.firebase.FirebaseApp.Clock;
 import com.google.firebase.FirebaseApp.TokenRefresher;
 import com.google.firebase.FirebaseOptions.Builder;
 import com.google.firebase.auth.FirebaseCredential;
@@ -260,10 +259,10 @@ public class FirebaseAppTest {
   @Test
   public void testTokenCaching() throws ExecutionException, InterruptedException, IOException {
     FirebaseApp firebaseApp = FirebaseApp.initializeApp(MOCK_CREDENTIAL_OPTIONS, "myApp");
-    GetTokenResult token1 = Tasks.await(TestOnlyImplFirebaseTrampolines.getToken(
-        firebaseApp, false));
-    GetTokenResult token2 = Tasks.await(TestOnlyImplFirebaseTrampolines.getToken(
-        firebaseApp, false));
+    GetTokenResult token1 = TestOnlyImplFirebaseTrampolines.getToken(
+        firebaseApp, false).get();
+    GetTokenResult token2 = TestOnlyImplFirebaseTrampolines.getToken(
+        firebaseApp, false).get();
     Assert.assertNotNull(token1);
     Assert.assertNotNull(token2);
     Assert.assertEquals(token1, token2);
@@ -272,10 +271,10 @@ public class FirebaseAppTest {
   @Test
   public void testTokenForceRefresh() throws ExecutionException, InterruptedException, IOException {
     FirebaseApp firebaseApp = FirebaseApp.initializeApp(MOCK_CREDENTIAL_OPTIONS, "myApp");
-    GetTokenResult token1 = Tasks.await(TestOnlyImplFirebaseTrampolines.getToken(
-        firebaseApp, false));
-    GetTokenResult token2 = Tasks.await(TestOnlyImplFirebaseTrampolines.getToken(
-        firebaseApp, true));
+    GetTokenResult token1 = TestOnlyImplFirebaseTrampolines.getToken(
+        firebaseApp, false).get();
+    GetTokenResult token2 = TestOnlyImplFirebaseTrampolines.getToken(
+        firebaseApp, true).get();
     Assert.assertNotNull(token1);
     Assert.assertNotNull(token2);
     Assert.assertNotEquals(token1, token2);
@@ -287,17 +286,17 @@ public class FirebaseAppTest {
     FirebaseApp firebaseApp = FirebaseApp.initializeApp(new Builder()
         .setCredential(new ClockedMockFirebaseCredential(clock)).build(), "myApp",
         FirebaseApp.DEFAULT_TOKEN_REFRESHER_FACTORY, clock);
-    GetTokenResult token1 = Tasks.await(TestOnlyImplFirebaseTrampolines.getToken(
-        firebaseApp, false));
-    GetTokenResult token2 = Tasks.await(TestOnlyImplFirebaseTrampolines.getToken(
-        firebaseApp, false));
+    GetTokenResult token1 = TestOnlyImplFirebaseTrampolines.getToken(
+        firebaseApp, false).get();
+    GetTokenResult token2 = TestOnlyImplFirebaseTrampolines.getToken(
+        firebaseApp, false).get();
     Assert.assertNotNull(token1);
     Assert.assertNotNull(token2);
     Assert.assertEquals(token1, token2);
 
     clock.timestamp += TimeUnit.HOURS.toMillis(1);
-    GetTokenResult token3 = Tasks.await(TestOnlyImplFirebaseTrampolines.getToken(
-        firebaseApp, false));
+    GetTokenResult token3 = TestOnlyImplFirebaseTrampolines.getToken(
+        firebaseApp, false).get();
     Assert.assertNotNull(token3);
     Assert.assertNotEquals(token1, token3);
   }

--- a/src/test/java/com/google/firebase/TestOnlyImplFirebaseTrampolines.java
+++ b/src/test/java/com/google/firebase/TestOnlyImplFirebaseTrampolines.java
@@ -16,7 +16,9 @@
 
 package com.google.firebase;
 
+import com.google.api.core.ApiFuture;
 import com.google.firebase.internal.GetTokenResult;
+import com.google.firebase.internal.TaskToApiFuture;
 import com.google.firebase.tasks.Task;
 
 /**
@@ -36,7 +38,7 @@ public final class TestOnlyImplFirebaseTrampolines {
     FirebaseApp.clearInstancesForTest();
   }
 
-  public static Task<GetTokenResult> getToken(FirebaseApp app, boolean forceRefresh) {
-    return app.getToken(forceRefresh);
+  public static ApiFuture<GetTokenResult> getToken(FirebaseApp app, boolean forceRefresh) {
+    return new TaskToApiFuture<>(app.getToken(forceRefresh));
   }
 }

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -35,7 +35,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.UserRecord.CreateRequest;
 import com.google.firebase.auth.UserRecord.UpdateRequest;
-import com.google.firebase.tasks.Tasks;
 import com.google.firebase.testing.IntegrationTestUtils;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -65,7 +64,7 @@ public class FirebaseAuthIT {
   @Test
   public void testGetNonExistingUser() throws Exception {
     try {
-      Tasks.await(auth.getUser("non.existing"));
+      auth.getUserAsync("non.existing").get();
       fail("No error thrown for non existing uid");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -77,7 +76,7 @@ public class FirebaseAuthIT {
   @Test
   public void testGetNonExistingUserByEmail() throws Exception {
     try {
-      Tasks.await(auth.getUserByEmail("non.existing@definitely.non.existing"));
+      auth.getUserByEmailAsync("non.existing@definitely.non.existing").get();
       fail("No error thrown for non existing email");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -89,7 +88,7 @@ public class FirebaseAuthIT {
   @Test
   public void testUpdateNonExistingUser() throws Exception {
     try {
-      Tasks.await(auth.updateUser(new UpdateRequest("non.existing")));
+      auth.updateUserAsync(new UpdateRequest("non.existing")).get();
       fail("No error thrown for non existing uid");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -101,7 +100,7 @@ public class FirebaseAuthIT {
   @Test
   public void testDeleteNonExistingUser() throws Exception {
     try {
-      Tasks.await(auth.deleteUser("non.existing"));
+      auth.deleteUserAsync("non.existing").get();
       fail("No error thrown for non existing uid");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -134,7 +133,7 @@ public class FirebaseAuthIT {
         .setEmailVerified(true)
         .setPassword("password");
 
-    UserRecord userRecord = Tasks.await(auth.createUser(user));
+    UserRecord userRecord = auth.createUserAsync(user).get();
     try {
       assertEquals(randomId, userRecord.getUid());
       assertEquals("Random User", userRecord.getDisplayName());
@@ -154,13 +153,13 @@ public class FirebaseAuthIT {
 
       checkRecreate(randomId);
     } finally {
-      Tasks.await(auth.deleteUser(userRecord.getUid()));
+      auth.deleteUserAsync(userRecord.getUid()).get();
     }
   }
 
   private void checkRecreate(String uid) throws Exception {
     try {
-      Tasks.await(auth.createUser(new CreateRequest().setUid(uid)));
+      auth.createUserAsync(new CreateRequest().setUid(uid)).get();
       fail("No error thrown for creating user with existing ID");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -172,11 +171,11 @@ public class FirebaseAuthIT {
   @Test
   public void testUserLifecycle() throws Exception {
     // Create user
-    UserRecord userRecord = Tasks.await(auth.createUser(new CreateRequest()));
+    UserRecord userRecord = auth.createUserAsync(new CreateRequest()).get();
     String uid = userRecord.getUid();
 
     // Get user
-    userRecord = Tasks.await(auth.getUser(userRecord.getUid()));
+    userRecord = auth.getUserAsync(userRecord.getUid()).get();
     assertEquals(uid, userRecord.getUid());
     assertNull(userRecord.getDisplayName());
     assertNull(userRecord.getEmail());
@@ -200,7 +199,7 @@ public class FirebaseAuthIT {
         .setPhotoUrl("https://example.com/photo.png")
         .setEmailVerified(true)
         .setPassword("secret");
-    userRecord = Tasks.await(auth.updateUser(request));
+    userRecord = auth.updateUserAsync(request).get();
     assertEquals(uid, userRecord.getUid());
     assertEquals("Updated Name", userRecord.getDisplayName());
     assertEquals(userEmail, userRecord.getEmail());
@@ -211,7 +210,7 @@ public class FirebaseAuthIT {
     assertEquals(2, userRecord.getProviderData().length);
 
     // Get user by email
-    userRecord = Tasks.await(auth.getUserByEmail(userRecord.getEmail()));
+    userRecord = auth.getUserByEmailAsync(userRecord.getEmail()).get();
     assertEquals(uid, userRecord.getUid());
 
     // Disable user and remove properties
@@ -220,7 +219,7 @@ public class FirebaseAuthIT {
         .setDisplayName(null)
         .setPhoneNumber(null)
         .setDisabled(true);
-    userRecord = Tasks.await(auth.updateUser(request));
+    userRecord = auth.updateUserAsync(request).get();
     assertEquals(uid, userRecord.getUid());
     assertNull(userRecord.getDisplayName());
     assertEquals(userEmail, userRecord.getEmail());
@@ -231,9 +230,9 @@ public class FirebaseAuthIT {
     assertEquals(1, userRecord.getProviderData().length);
 
     // Delete user
-    Tasks.await(auth.deleteUser(userRecord.getUid()));
+    auth.deleteUserAsync(userRecord.getUid()).get();
     try {
-      Tasks.await(auth.getUser(userRecord.getUid()));
+      auth.getUserAsync(userRecord.getUid()).get();
       fail("No error thrown for deleted user");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -244,9 +243,9 @@ public class FirebaseAuthIT {
 
   @Test
   public void testCustomToken() throws Exception {
-    String customToken = Tasks.await(auth.createCustomToken("user1"));
+    String customToken = auth.createCustomTokenAsync("user1").get();
     String idToken = signInWithCustomToken(customToken);
-    FirebaseToken decoded = Tasks.await(auth.verifyIdToken(idToken));
+    FirebaseToken decoded = auth.verifyIdTokenAsync(idToken).get();
     assertEquals("user1", decoded.getUid());
   }
 
@@ -254,9 +253,9 @@ public class FirebaseAuthIT {
   public void testCustomTokenWithClaims() throws Exception {
     Map<String, Object> devClaims = ImmutableMap.<String, Object>of(
         "premium", true, "subscription", "silver");
-    String customToken = Tasks.await(auth.createCustomToken("user2", devClaims));
+    String customToken = auth.createCustomTokenAsync("user2", devClaims).get();
     String idToken = signInWithCustomToken(customToken);
-    FirebaseToken decoded = Tasks.await(auth.verifyIdToken(idToken));
+    FirebaseToken decoded = auth.verifyIdTokenAsync(idToken).get();
     assertEquals("user2", decoded.getUid());
     assertTrue((Boolean) decoded.getClaims().get("premium"));
     assertEquals("silver", decoded.getClaims().get("subscription"));

--- a/src/test/java/com/google/firebase/database/integration/DataTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/DataTestIT.java
@@ -101,7 +101,7 @@ public class DataTestIT {
   public void testWriteData() {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
     // just make sure it doesn't throw
-    ref.setValue(42);
+    ref.setValueAsync(42);
     assertTrue(true);
   }
 
@@ -110,7 +110,7 @@ public class DataTestIT {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
     ReadFuture future = ReadFuture.untilNonNull(ref);
 
-    ref.setValue(42);
+    ref.setValueAsync(42);
     List<EventRecord> events = future.timedGet();
     assertEquals(42L, events.get(events.size() - 1).getSnapshot().getValue());
   }
@@ -127,7 +127,7 @@ public class DataTestIT {
 
     ReadFuture future = ReadFuture.untilNonNull(ref);
 
-    ref.setValue(expected);
+    ref.setValueAsync(expected);
     List<EventRecord> events = future.timedGet();
     EventRecord eventRecord = events.get(events.size() - 1);
     Object result = eventRecord.getSnapshot().getValue();
@@ -138,7 +138,7 @@ public class DataTestIT {
   public void testWriteAndWaitForServerConfirmation()
       throws TimeoutException, InterruptedException, TestFailure {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
-    ref.setValue(42);
+    ref.setValueAsync(42);
 
     ReadFuture future = new ReadFuture(ref);
 
@@ -171,9 +171,9 @@ public class DataTestIT {
     final DatabaseReference writer = refs.get(0);
     final DatabaseReference reader = refs.get(1);
 
-    writer.child("a").child("b").child("c").setValue(1);
-    writer.child("a").child("d").child("e").setValue(2);
-    writer.child("a").child("d").child("f").setValue(3);
+    writer.child("a").child("b").child("c").setValueAsync(1);
+    writer.child("a").child("d").child("e").setValueAsync(2);
+    writer.child("a").child("d").child("f").setValueAsync(3);
     WriteFuture writeFuture = new WriteFuture(writer.child("g"), 4);
     writeFuture.timedGet();
 
@@ -200,8 +200,8 @@ public class DataTestIT {
         .addChildExpectation(ref.child("a"), Event.EventType.CHILD_CHANGED, "aa")
         .addValueExpectation(ref.child("a")).startListening(true);
 
-    ref.child("a/aa").setValue(1);
-    ref.child("a").setValue(new MapBuilder().put("aa", 2).build());
+    ref.child("a/aa").setValueAsync(1);
+    ref.child("a").setValueAsync(new MapBuilder().put("aa", 2).build());
 
     assertTrue(helper.waitForEvents());
     helper.cleanup();
@@ -234,10 +234,10 @@ public class DataTestIT {
         .addChildExpectation(ref.child("a"), Event.EventType.CHILD_CHANGED, "aa")
         .addValueExpectation(ref.child("a")).startListening(true);
 
-    ref.child("a/aa").setValue(1);
-    ref.child("a").setValue(MapBuilder.of("aa", 2));
-    ref.child("a").setValue(MapBuilder.of("aa", 3));
-    ref.child("a").setValue(MapBuilder.of("aa", 3));
+    ref.child("a/aa").setValueAsync(1);
+    ref.child("a").setValueAsync(MapBuilder.of("aa", 2));
+    ref.child("a").setValueAsync(MapBuilder.of("aa", 3));
+    ref.child("a").setValueAsync(MapBuilder.of("aa", 3));
 
     assertTrue(helper.waitForEvents());
     helper.cleanup();
@@ -255,8 +255,8 @@ public class DataTestIT {
         .addChildExpectation(ref.child("a"), Event.EventType.CHILD_CHANGED, "aa")
         .addValueExpectation(ref.child("a")).startListening(true);
 
-    ref.child("a").setValue(new MapBuilder().put("aa", 2).build());
-    ref.child("a/aa").setValue(1);
+    ref.child("a").setValueAsync(new MapBuilder().put("aa", 2).build());
+    ref.child("a/aa").setValueAsync(1);
 
     assertTrue(helper.waitForEvents());
     helper.cleanup();
@@ -300,7 +300,7 @@ public class DataTestIT {
         .addChildExpectation(reader, Event.EventType.CHILD_REMOVED, "a").addValueExpectation(reader)
         .startListening();
 
-    writer.child("a").removeValue();
+    writer.child("a").removeValueAsync();
     assertTrue(writeHelper.waitForEvents());
     assertTrue(readHelper.waitForEvents());
     writeHelper.cleanup();
@@ -314,7 +314,7 @@ public class DataTestIT {
 
     ReadFuture writeFuture = ReadFuture.untilNonNull(writer);
 
-    writer.child("a/aa").setValue(3.1415);
+    writer.child("a/aa").setValueAsync(3.1415);
 
     List<EventRecord> readerEvents = readFuture.timedGet();
     List<EventRecord> writerEvents = writeFuture.timedGet();
@@ -366,7 +366,7 @@ public class DataTestIT {
         .addChildExpectation(reader, Event.EventType.CHILD_REMOVED, "a").addValueExpectation(reader)
         .startListening();
 
-    writer.child("a/aa").removeValue();
+    writer.child("a/aa").removeValueAsync();
     assertTrue(writeHelper.waitForEvents());
     assertTrue(readHelper.waitForEvents());
     writeHelper.cleanup();
@@ -387,7 +387,7 @@ public class DataTestIT {
     ReadFuture readFuture = ReadFuture.untilNonNull(reader);
     ReadFuture writeFuture = ReadFuture.untilNonNull(writer);
 
-    writer.child("a/aa").setValue(3.1415);
+    writer.child("a/aa").setValueAsync(3.1415);
 
     final List<EventRecord> readerEvents = readFuture.timedGet();
     final List<EventRecord> writerEvents = writeFuture.timedGet();
@@ -426,8 +426,8 @@ public class DataTestIT {
         .addChildExpectation(reader, Event.EventType.CHILD_CHANGED, "a").addValueExpectation(reader)
         .startListening(true);
 
-    writer.child("a/aa").setValue(42);
-    writer.child("a/bb").setValue(24);
+    writer.child("a/aa").setValueAsync(42);
+    writer.child("a/bb").setValueAsync(24);
 
     assertTrue(writeHelper.waitForEvents());
     assertTrue(readHelper.waitForEvents());
@@ -444,7 +444,7 @@ public class DataTestIT {
         .addChildExpectation(writer, Event.EventType.CHILD_CHANGED, "a").addValueExpectation(writer)
         .startListening();
 
-    writer.child("a/aa").removeValue();
+    writer.child("a/aa").removeValueAsync();
     assertTrue(writeHelper.waitForEvents());
     assertTrue(readHelper.waitForEvents());
 
@@ -484,11 +484,11 @@ public class DataTestIT {
   @Test
   public void testNumericKeysGetTurnedIntoArrays() throws InterruptedException {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
-    ref.child("0").setValue("alpha");
-    ref.child("1").setValue("bravo");
-    ref.child("2").setValue("charlie");
-    ref.child("3").setValue("delta");
-    ref.child("4").setValue("echo");
+    ref.child("0").setValueAsync("alpha");
+    ref.child("1").setValueAsync("bravo");
+    ref.child("2").setValueAsync("charlie");
+    ref.child("3").setValueAsync("delta");
+    ref.child("4").setValueAsync("echo");
 
     DataSnapshot snap = TestHelpers.getSnap(ref);
     List<Object> expected = ImmutableList.of((Object) "alpha", "bravo", "charlie",
@@ -512,7 +512,7 @@ public class DataTestIT {
 
     ReadFuture readFuture = ReadFuture.untilNonNull(ref);
 
-    ref.setValue(expected);
+    ref.setValueAsync(expected);
     List<EventRecord> events = readFuture.timedGet();
     Object result = events.get(events.size() - 1).getSnapshot().getValue();
     TestHelpers.assertDeepEquals(expected, result);
@@ -581,7 +581,7 @@ public class DataTestIT {
   public void testUsingNumbersAsKeys()
       throws TimeoutException, InterruptedException, TestFailure {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
-    ref.child("3024").setValue(5);
+    ref.child("3024").setValueAsync(5);
     ReadFuture future = new ReadFuture(ref);
 
     List<EventRecord> events = future.timedGet();
@@ -650,7 +650,9 @@ public class DataTestIT {
       throws TimeoutException, InterruptedException, TestFailure {
     final DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
-    ref.setValue(new MapBuilder().put("one", 42).put("two", new MapBuilder().put("a", 5).build())
+    ref.setValueAsync(new MapBuilder()
+        .put("one", 42)
+        .put("two", new MapBuilder().put("a", 5).build())
         .put("three", new MapBuilder().put("a", 5).put("b", 6).build()).build());
     final AtomicBoolean removedTwo = new AtomicBoolean(false);
     ReadFuture readFuture = new ReadFuture(ref, new ReadFuture.CompletionCondition() {
@@ -659,7 +661,7 @@ public class DataTestIT {
         if (removedTwo.compareAndSet(false, true)) {
           // removedTwo did equal false, now equals true
           try {
-            ref.child("two").removeValue();
+            ref.child("two").removeValueAsync();
           } catch (DatabaseException e) {
             fail("Should not fail");
           }
@@ -701,7 +703,7 @@ public class DataTestIT {
       public boolean isComplete(List<EventRecord> events) {
         if (sawJson.compareAndSet(false, true)) {
           try {
-            writer.setValue(primitive);
+            writer.setValueAsync(primitive);
           } catch (DatabaseException e) {
             fail("Shouldn't happen: " + e.toString());
           }
@@ -709,7 +711,7 @@ public class DataTestIT {
           // Saw the json already
           if (sawPrimitive.compareAndSet(false, true)) {
             try {
-              writer.setValue(json);
+              writer.setValueAsync(json);
             } catch (DatabaseException e) {
               fail("Shouldn't happen: " + e.toString());
             }
@@ -740,8 +742,8 @@ public class DataTestIT {
     final DatabaseReference reader = refs.get(0);
     final DatabaseReference writer = refs.get(1);
 
-    writer.setValue(5);
-    writer.removeValue();
+    writer.setValueAsync(5);
+    writer.removeValueAsync();
     new WriteFuture(writer.child("abc"), 5).timedGet();
 
     DataSnapshot snap = new ReadFuture(reader).timedGet().get(0).getSnapshot();
@@ -762,7 +764,7 @@ public class DataTestIT {
 
     // Slight race condition. We're banking on this local set being processed
     // before the network catches up with the writer's broadcast.
-    reader.child("a").setValue(10);
+    reader.child("a").setValueAsync(10);
 
     EventRecord event = readFuture.timedGet().get(0);
     assertEquals(10L, event.getSnapshot().child("a").getValue());
@@ -789,7 +791,7 @@ public class DataTestIT {
   public void testSetPriority() throws InterruptedException {
     final DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
-    ref.setValue("hello!");
+    ref.setValueAsync("hello!");
     final Semaphore semaphore = new Semaphore(0);
     ref.setPriority(10, new DatabaseReference.CompletionListener() {
       @Override
@@ -835,9 +837,9 @@ public class DataTestIT {
     final DatabaseReference ref1 = refs.get(0);
     final DatabaseReference ref2 = refs.get(1);
 
-    ref1.setValue(new MapBuilder().put("a", 5).build());
-    ref1.setPriority(10);
-    ref1.child("a").setPriority(18);
+    ref1.setValueAsync(new MapBuilder().put("a", 5).build());
+    ref1.setPriorityAsync(10);
+    ref1.child("a").setPriorityAsync(18);
     new WriteFuture(ref1, new MapBuilder().put("a", 7).build()).timedGet();
 
     DataSnapshot snap = new ReadFuture(ref2).timedGet().get(0).getSnapshot();
@@ -884,13 +886,13 @@ public class DataTestIT {
 
     ReadFuture readFuture = ReadFuture.untilCountAfterNull(ref, 7);
 
-    ref.setValue("a");
-    ref.setValue("b", 5);
-    ref.setValue("c", "6");
-    ref.setValue("d", 7);
-    ref.setValue(new MapBuilder().put(".value", "e").put(".priority", 8).build());
-    ref.setValue(new MapBuilder().put(".value", "f").put(".priority", "8").build());
-    ref.setValue(new MapBuilder().put(".value", "g").put(".priority", null).build());
+    ref.setValueAsync("a");
+    ref.setValueAsync("b", 5);
+    ref.setValueAsync("c", "6");
+    ref.setValueAsync("d", 7);
+    ref.setValueAsync(new MapBuilder().put(".value", "e").put(".priority", 8).build());
+    ref.setValueAsync(new MapBuilder().put(".value", "f").put(".priority", "8").build());
+    ref.setValueAsync(new MapBuilder().put(".value", "g").put(".priority", null).build());
 
     List<EventRecord> events = readFuture.timedGet();
     assertNull(events.get(0).getSnapshot().getPriority());
@@ -913,7 +915,7 @@ public class DataTestIT {
             .put(".priority", "hi").build())
         .build();
     ReadFuture readFuture = ReadFuture.untilNonNull(ref);
-    ref.setValue(expected);
+    ref.setValueAsync(expected);
     DataSnapshot snap = readFuture.timedGet().get(0).getSnapshot();
     Object result = snap.getValue(true);
     TestHelpers.assertDeepEquals(expected, result);
@@ -928,7 +930,7 @@ public class DataTestIT {
 
     ReadFuture readFuture = ReadFuture.untilCountAfterNull(ref1, 2);
 
-    ref1.setValue("hi", 100);
+    ref1.setValueAsync("hi", 100);
 
     new ReadFuture(ref2, new ReadFuture.CompletionCondition() {
       @Override
@@ -937,7 +939,7 @@ public class DataTestIT {
         Object priority = snap.getPriority();
         if (priority != null && priority.equals(100.0)) {
           try {
-            ref2.setValue("whatever");
+            ref2.setValueAsync("whatever");
           } catch (DatabaseException e) {
             fail("Shouldn't happen: " + e.toString());
           }
@@ -1110,14 +1112,14 @@ public class DataTestIT {
 
     for (Object badObject : badObjects) {
       try {
-        ref.setValue(badObject);
+        ref.setValueAsync(badObject);
         fail("Should not be a valid object: " + badObject);
       } catch (DatabaseException e) {
         // No-op, expected
       }
 
       try {
-        ref.onDisconnect().setValue(badObject);
+        ref.onDisconnect().setValueAsync(badObject);
         fail("Should not be a valid object: " + badObject);
       } catch (DatabaseException e) {
         // No-op, expected
@@ -1142,14 +1144,14 @@ public class DataTestIT {
         new MapBuilder().put("/a/b/.priority", MapBuilder.of("x", "y")).build());
     for (Map<String, Object> badUpdate : badUpdates) {
       try {
-        ref.updateChildren(badUpdate);
+        ref.updateChildrenAsync(badUpdate);
         fail("Should not be a valid update: " + badUpdate);
       } catch (DatabaseException e) {
         // No-op, expected
       }
 
       try {
-        ref.onDisconnect().updateChildren(badUpdate);
+        ref.onDisconnect().updateChildrenAsync(badUpdate);
         fail("Should not be a valid object: " + badUpdate);
       } catch (DatabaseException e) {
         // No-op, expected
@@ -1165,7 +1167,7 @@ public class DataTestIT {
       String ch = new String(Character.toChars(i < 32 ? i : 127));
       Map<String, Object> obj = TestHelpers.buildObjFromPath(new Path(ch), "test_value");
       try {
-        node.setValue(obj);
+        node.setValueAsync(obj);
         fail("Ascii control character should not be allowed in path.");
       } catch (DatabaseException e) {
         // expected
@@ -1215,15 +1217,15 @@ public class DataTestIT {
     for (String key : goodKeys) {
       Path path = new Path(key);
       Map<String, Object> obj = TestHelpers.buildObjFromPath(path, "test_value");
-      node.setValue(obj);
+      node.setValueAsync(obj);
       ReadFuture future = ReadFuture.untilNonNull(node);
       assertEquals("test_value", TestHelpers.applyPath(future.waitForLastValue(), path));
 
-      node.child(key).setValue("another_value");
+      node.child(key).setValueAsync("another_value");
       future = ReadFuture.untilNonNull(node.child(key));
       assertEquals("another_value", future.waitForLastValue());
 
-      node.updateChildren(obj);
+      node.updateChildrenAsync(obj);
       future = ReadFuture.untilNonNull(node);
       assertEquals("test_value", TestHelpers.applyPath(future.waitForLastValue(), path));
     }
@@ -1234,26 +1236,26 @@ public class DataTestIT {
     for (String key : goodKeys) {
       Map<String, Object> obj = TestHelpers.buildObjFromPath(new Path(key), "test_value");
       try {
-        nodeChild.setValue(obj);
+        nodeChild.setValueAsync(obj);
         fail("Too-long path for setValue should throw exception.");
       } catch (DatabaseException e) {
         // expected
       }
       try {
-        nodeChild.child(key).setValue("another_value");
+        nodeChild.child(key).setValueAsync("another_value");
         fail("Too-long path before setValue should throw exception.");
       } catch (DatabaseException e) {
         // expected
       }
       try {
-        nodeChild.updateChildren(obj);
+        nodeChild.updateChildrenAsync(obj);
         fail("Too-long path for updateChildren should throw exception.");
       } catch (DatabaseException e) {
         // expected
       }
       try {
         Map<String, Object> deepUpdate = MapBuilder.of(key, "test_value");
-        nodeChild.updateChildren(deepUpdate);
+        nodeChild.updateChildrenAsync(deepUpdate);
         fail("Too-long path in deep update for updateChildren should throw exception.");
       } catch (DatabaseException e) {
         // expected
@@ -1264,46 +1266,46 @@ public class DataTestIT {
       for (String key : badGroup.keys) {
         Map<String, Object> obj = TestHelpers.buildObjFromPath(new Path(key), "test_value");
         try {
-          node.setValue(obj);
-          fail("Expected setValue(bad key) to throw exception: " + key);
+          node.setValueAsync(obj);
+          fail("Expected setValueAsync(bad key) to throw exception: " + key);
         } catch (DatabaseException e) {
           TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
         }
         try {
-          node.child(key).setValue("another_value");
-          fail("Expected child(\"" + key + "\").setValue() to throw exception: " + key);
+          node.child(key).setValueAsync("another_value");
+          fail("Expected child(\"" + key + "\").setValueAsync() to throw exception: " + key);
         } catch (DatabaseException e) {
           TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
         }
         try {
-          node.updateChildren(obj);
-          fail("Expected updateChildrean(bad key) to throw exception: " + key);
+          node.updateChildrenAsync(obj);
+          fail("Expected updateChildrenAsync(bad key) to throw exception: " + key);
         } catch (DatabaseException e) {
           TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
         }
         try {
           Map<String, Object> deepUpdate = MapBuilder.of(key, "test_value");
-          node.updateChildren(deepUpdate);
+          node.updateChildrenAsync(deepUpdate);
           fail("Expected updateChildrean(bad deep update key) to throw exception: " + key);
         } catch (DatabaseException e) {
           TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
         }
         try {
-          node.onDisconnect().setValue(obj);
-          fail("Expected onDisconnect.setValue(bad key) to throw exception: " + key);
+          node.onDisconnect().setValueAsync(obj);
+          fail("Expected onDisconnect.setValueAsync(bad key) to throw exception: " + key);
         } catch (DatabaseException e) {
           TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
         }
         try {
-          node.onDisconnect().updateChildren(obj);
-          fail("Expected onDisconnect.updateChildren(bad key) to throw exception: " + key);
+          node.onDisconnect().updateChildrenAsync(obj);
+          fail("Expected onDisconnect.updateChildrenAsync(bad key) to throw exception: " + key);
         } catch (DatabaseException e) {
           TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
         }
         try {
           Map<String, Object> deepUpdate = MapBuilder.of(key, "test_value");
-          node.onDisconnect().updateChildren(deepUpdate);
-          fail("Expected onDisconnect.updateChildren(bad deep update key) to throw " + "exception: "
+          node.onDisconnect().updateChildrenAsync(deepUpdate);
+          fail("Expected onDisconnect.updateChildrenAsync(bad deep update key) to throw exception: "
               + key);
         } catch (DatabaseException e) {
           TestHelpers.assertContains(e.getMessage(), badGroup.expectedError);
@@ -1369,7 +1371,7 @@ public class DataTestIT {
     EventHelper helper = new EventHelper().addValueExpectation(ref.child("a/aa/aaa"))
         .addValueExpectation(ref.child("a/aa")).addValueExpectation(ref.child("a"))
         .startListening();
-    ref.setValue(MapBuilder.of("b", 5));
+    ref.setValueAsync(MapBuilder.of("b", 5));
 
     assertTrue(helper.waitForEvents());
     helper.cleanup();
@@ -1518,7 +1520,7 @@ public class DataTestIT {
 
     final ReadFuture readFuture = ReadFuture.untilCountAfterNull(ref, 2);
 
-    ref.setValue(new MapBuilder().put("a", 1).put("b", 2).put("c", 3).put("d", 4).build());
+    ref.setValueAsync(new MapBuilder().put("a", 1).put("b", 2).put("c", 3).put("d", 4).build());
 
     EventHelper helper = new EventHelper().addValueExpectation(ref.child("a"))
         .addValueExpectation(ref.child("d"))
@@ -1526,7 +1528,7 @@ public class DataTestIT {
         .addChildExpectation(ref, Event.EventType.CHILD_CHANGED, "d").addValueExpectation(ref)
         .startListening(true);
 
-    ref.updateChildren(new MapBuilder().put("a", 4).put("d", 1).build());
+    ref.updateChildrenAsync(new MapBuilder().put("a", 4).put("d", 1).build());
     helper.waitForEvents();
     List<EventRecord> events = readFuture.timedGet();
     helper.cleanup();
@@ -1553,7 +1555,7 @@ public class DataTestIT {
         .addChildExpectation(reader, Event.EventType.CHILD_CHANGED, "d").addValueExpectation(reader)
         .startListening(true);
 
-    writer.updateChildren(new MapBuilder().put("a", 4).put("d", 1).build());
+    writer.updateChildrenAsync(new MapBuilder().put("a", 4).put("d", 1).build());
     helper.waitForEvents();
     helper.cleanup();
 
@@ -1575,8 +1577,8 @@ public class DataTestIT {
         .addChildExpectation(ref, Event.EventType.CHILD_ADDED, "c")
         .addChildExpectation(ref, Event.EventType.CHILD_CHANGED, "d").startListening();
 
-    ref.updateChildren(new MapBuilder().put("a", 11).put("d", 44).build());
-    ref.updateChildren(new MapBuilder().put("c", 33).put("d", 45).build());
+    ref.updateChildrenAsync(new MapBuilder().put("a", 11).put("d", 44).build());
+    ref.updateChildrenAsync(new MapBuilder().put("c", 33).put("d", 45).build());
     helper.waitForEvents();
     helper.cleanup();
   }
@@ -1599,8 +1601,8 @@ public class DataTestIT {
       public void onCancelled(DatabaseError error) {
       }
     });
-    ref.setValue(42);
-    ref.updateChildren(expected);
+    ref.setValueAsync(42);
+    ref.updateChildrenAsync(expected);
 
     TestHelpers.waitFor(semaphore);
   }
@@ -1641,8 +1643,8 @@ public class DataTestIT {
 
     ReadFuture readFuture = ReadFuture.untilCountAfterNull(ref, 2);
 
-    ref.setValue(new MapBuilder().put("a", 1).put("b", 2).put("c", 3).build(), "testpri");
-    ref.updateChildren(MapBuilder.of("a", 4));
+    ref.setValueAsync(new MapBuilder().put("a", 1).put("b", 2).put("c", 3).build(), "testpri");
+    ref.updateChildrenAsync(MapBuilder.of("a", 4));
 
     List<EventRecord> events = readFuture.timedGet();
     DataSnapshot snap = events.get(0).getSnapshot();
@@ -1690,7 +1692,7 @@ public class DataTestIT {
 
     final ReadFuture readFuture = ReadFuture.untilCountAfterNull(writer, 2);
 
-    writer.setValue(
+    writer.setValueAsync(
         new MapBuilder().put("a", new MapBuilder().put("aa", 1).put("ab", 2).build()).build());
     final Semaphore semaphore = new Semaphore(0);
     Map<String, Object> expected = MapBuilder.of("a", MapBuilder.of("aa", 1L));
@@ -1719,7 +1721,7 @@ public class DataTestIT {
 
     final ReadFuture readFuture = ReadFuture.untilCount(writer, 2);
 
-    writer.setValue(
+    writer.setValueAsync(
         new MapBuilder().put("a", new MapBuilder().put("aa", 1).put("ab", 2).build()).build());
     Map<String, Object> expected = new MapBuilder()
         .put("a", new MapBuilder().put("aa", 10L).put("ab", 20L).build()).build();
@@ -1793,7 +1795,7 @@ public class DataTestIT {
 
     TestHelpers.waitFor(semaphore);
 
-    writer.updateChildren(MapBuilder.of("a", null));
+    writer.updateChildrenAsync(MapBuilder.of("a", null));
     DataSnapshot snap = writerFuture.timedGet().get(1).getSnapshot();
 
     Map<String, Object> expected = MapBuilder.of("b", 6L);
@@ -1835,7 +1837,7 @@ public class DataTestIT {
     TestHelpers.waitFor(readerInitializedSemaphore);
     TestHelpers.waitFor(writerInitializedSemaphore);
 
-    writer.updateChildren(MapBuilder.of("a", 42));
+    writer.updateChildrenAsync(MapBuilder.of("a", 42));
     DataSnapshot snap = writerFuture.timedGet().get(1).getSnapshot();
 
     Map<String, Object> expected = MapBuilder.of("a", 42L);
@@ -1868,7 +1870,7 @@ public class DataTestIT {
 
     TestHelpers.waitFor(semaphore);
 
-    writer.updateChildren(MapBuilder.of("a", null));
+    writer.updateChildrenAsync(MapBuilder.of("a", null));
     DataSnapshot snap = writerFuture.timedGet().get(1).getSnapshot();
 
     assertNull(snap.getValue());
@@ -1900,7 +1902,7 @@ public class DataTestIT {
 
     TestHelpers.waitFor(semaphore);
 
-    writer.updateChildren(MapBuilder.of("a", 11));
+    writer.updateChildrenAsync(MapBuilder.of("a", 11));
     DataSnapshot snap = writerFuture.timedGet().get(1).getSnapshot();
 
     Map<String, Object> expected = MapBuilder.of("a", 11L);
@@ -1923,7 +1925,7 @@ public class DataTestIT {
         .put("b", new MapBuilder().put(".priority", "pri3").put("c", 10).build()).build();
 
     final Semaphore semaphore = new Semaphore(0);
-    writer.setValue(writeValue);
+    writer.setValueAsync(writeValue);
     writer.updateChildren(updateValue, new DatabaseReference.CompletionListener() {
       @Override
       public void onComplete(DatabaseError error, DatabaseReference ref) {
@@ -1978,7 +1980,7 @@ public class DataTestIT {
           public void onCancelled(DatabaseError error) {
           }
         });
-    writer.child(childName).setValue("foo");
+    writer.child(childName).setValueAsync("foo");
     // Make sure we get the data in the listener before we delete it
     TestHelpers.waitFor(semaphore);
 
@@ -2033,7 +2035,7 @@ public class DataTestIT {
           }
         });
 
-    writer.child(childName).setValue("foo");
+    writer.child(childName).setValueAsync("foo");
     final Semaphore semaphore = new Semaphore(0);
     deleter.removeValue(new DatabaseReference.CompletionListener() {
       @Override
@@ -2443,10 +2445,10 @@ public class DataTestIT {
           }
         });
 
-        ref.child("b").setValue("b");
+        ref.child("b").setValueAsync("b");
 
         Map<String, Object> update = MapBuilder.of("c", "c");
-        ref.updateChildren(update);
+        ref.updateChildrenAsync(update);
       }
     });
 
@@ -2725,7 +2727,7 @@ public class DataTestIT {
       }
     });
 
-    writer.setValue(ServerValue.TIMESTAMP, ServerValue.TIMESTAMP);
+    writer.setValueAsync(ServerValue.TIMESTAMP, ServerValue.TIMESTAMP);
 
     TestHelpers.waitFor(completionSemaphore, 3);
 

--- a/src/test/java/com/google/firebase/database/integration/EventTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/EventTestIT.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.database.ChildEventListener;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
@@ -48,7 +47,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -87,7 +85,7 @@ public class EventTestIT {
 
     ZombieVerifier.verifyRepoZombies(refs);
 
-    writer.setValue(42);
+    writer.setValueAsync(42);
     assertTrue(writerHelper.waitForEvents());
     assertTrue(readerHelper.waitForEvents());
     writerHelper.cleanup();
@@ -106,7 +104,7 @@ public class EventTestIT {
 
     ZombieVerifier.verifyRepoZombies(ref);
 
-    ref.child("foo").setValue(42);
+    ref.child("foo").setValueAsync(42);
     assertTrue(helper.waitForEvents());
     ZombieVerifier.verifyRepoZombies(ref);
     helper.cleanup();
@@ -146,10 +144,10 @@ public class EventTestIT {
 
     ZombieVerifier.verifyRepoZombies(refs);
 
-    writer.child("foo").setValue(42);
-    writer.child("bar").setValue(24);
+    writer.child("foo").setValueAsync(42);
+    writer.child("bar").setValueAsync(24);
 
-    writer.child("foo").setValue(31415);
+    writer.child("foo").setValueAsync(31415);
     assertTrue(writeHelper.waitForEvents());
     assertTrue(readHelper.waitForEvents());
     ZombieVerifier.verifyRepoZombies(refs);
@@ -175,7 +173,7 @@ public class EventTestIT {
 
     ZombieVerifier.verifyRepoZombies(refs);
 
-    writer.setValue(42);
+    writer.setValueAsync(42);
     assertTrue(writeHelper.waitForEvents());
     assertTrue(writeHelper2.waitForEvents());
     assertTrue(readHelper.waitForEvents());
@@ -197,7 +195,7 @@ public class EventTestIT {
     ZombieVerifier.verifyRepoZombies(ref);
 
     for (int i = 0; i < 3; ++i) {
-      ref.setValue(i);
+      ref.setValueAsync(i);
     }
 
     List<EventRecord> events = readFuture.timedGet();
@@ -234,7 +232,7 @@ public class EventTestIT {
     ZombieVerifier.verifyRepoZombies(ref);
 
     for (int i = 0; i < 3; ++i) {
-      ref.setValue(i);
+      ref.setValueAsync(i);
     }
 
     TestHelpers.waitForRoundtrip(ref);
@@ -242,11 +240,11 @@ public class EventTestIT {
     ZombieVerifier.verifyRepoZombies(ref);
 
     for (int i = 10; i < 13; ++i) {
-      ref.setValue(i);
+      ref.setValueAsync(i);
     }
 
     for (int i = 20; i < 22; ++i) {
-      ref.setValue(i);
+      ref.setValueAsync(i);
     }
     new WriteFuture(ref, 22).timedGet();
     assertEquals(3, callbackCount.get());
@@ -397,11 +395,11 @@ public class EventTestIT {
 
     ZombieVerifier.verifyRepoZombies(refs);
 
-    writer.setValue(MapBuilder.of("a", 10, "b", 20));
+    writer.setValueAsync(MapBuilder.of("a", 10, "b", 20));
     TestHelpers.waitFor(writerReady, 2);
     TestHelpers.waitFor(readerReady, 2);
 
-    writer.setValue(MapBuilder.of("a", 10, "b", 30));
+    writer.setValueAsync(MapBuilder.of("a", 10, "b", 30));
     TestHelpers.waitFor(writerReady);
     TestHelpers.waitFor(readerReady);
   }
@@ -425,10 +423,10 @@ public class EventTestIT {
 
     ZombieVerifier.verifyRepoZombies(ref);
 
-    ref.setValue(42);
-    ref.setValue(MapBuilder.of("a", 2));
-    ref.setValue(84);
-    ref.setValue(null);
+    ref.setValueAsync(42);
+    ref.setValueAsync(MapBuilder.of("a", 2));
+    ref.setValueAsync(84);
+    ref.setValueAsync(null);
 
     List<EventRecord> events = readFuture.timedGet();
     ZombieVerifier.verifyRepoZombies(ref);
@@ -549,9 +547,9 @@ public class EventTestIT {
         });
     ZombieVerifier.verifyRepoZombies(ref);
 
-    ref.setValue(42);
+    ref.setValueAsync(42);
     TestHelpers.waitForQueue(ref);
-    ref.setValue(84);
+    ref.setValueAsync(84);
     blockSem.release();
     new WriteFuture(ref, null).timedGet();
     TestHelpers.waitFor(endingSemaphore);
@@ -601,9 +599,9 @@ public class EventTestIT {
 
     TestHelpers.waitFor(gotInitialEvent);
 
-    ref.child("a").setValue(42);
+    ref.child("a").setValueAsync(42);
     TestHelpers.waitForQueue(ref);
-    ref.child("b").setValue(84);
+    ref.child("b").setValueAsync(84);
     blockSem.release();
     new WriteFuture(ref, null).timedGet();
     TestHelpers.waitFor(endingSemaphore);
@@ -654,9 +652,9 @@ public class EventTestIT {
     ZombieVerifier.verifyRepoZombies(ref);
 
     TestHelpers.waitFor(gotInitialEvent, 2);
-    ref.child("a").setValue(42);
+    ref.child("a").setValueAsync(42);
     TestHelpers.waitForQueue(ref);
-    ref.child("b").setValue(84);
+    ref.child("b").setValueAsync(84);
     blockSem.release();
     new WriteFuture(ref, null).timedGet();
     TestHelpers.waitFor(endingSemaphore);
@@ -708,9 +706,9 @@ public class EventTestIT {
 
     ZombieVerifier.verifyRepoZombies(ref);
 
-    ref.child("a").setValue(42);
+    ref.child("a").setValueAsync(42);
     TestHelpers.waitForQueue(ref);
-    ref.child("b").setValue(84);
+    ref.child("b").setValueAsync(84);
     blockSem.release();
     new WriteFuture(ref, null).timedGet();
     TestHelpers.waitFor(endingSemaphore);
@@ -738,8 +736,8 @@ public class EventTestIT {
 
     ZombieVerifier.verifyRepoZombies(ref);
 
-    ref.setValue(42);
-    ref.setValue(84);
+    ref.setValueAsync(42);
+    ref.setValueAsync(84);
     new WriteFuture(ref, null).timedGet();
     assertEquals(1, called.get());
     ZombieVerifier.verifyRepoZombies(ref);
@@ -958,9 +956,9 @@ public class EventTestIT {
             .addValueExpectation(ref)
             .startListening(true);
 
-    ref.child("bar").setValue(42, 10);
+    ref.child("bar").setValueAsync(42, 10);
     TestHelpers.waitForRoundtrip(ref);
-    ref.child("foo").setValue(42, 20);
+    ref.child("foo").setValueAsync(42, 20);
 
     assertTrue(helper.waitForEvents());
     helper
@@ -970,7 +968,7 @@ public class EventTestIT {
         .addValueExpectation(ref)
         .startListening();
 
-    ref.child("bar").setPriority(30);
+    ref.child("bar").setPriorityAsync(30);
     assertTrue(helper.waitForEvents());
     helper.cleanup();
     ZombieVerifier.verifyRepoZombies(ref);
@@ -991,7 +989,7 @@ public class EventTestIT {
             .startListening(true);
 
     ZombieVerifier.verifyRepoZombies(ref);
-    ref.setValue(
+    ref.setValueAsync(
         MapBuilder.of(
             "bar", MapBuilder.of(".value", 42, ".priority", 10),
             "foo", MapBuilder.of(".value", 42, ".priority", 20)));
@@ -1004,7 +1002,7 @@ public class EventTestIT {
         .startListening();
 
     ZombieVerifier.verifyRepoZombies(ref);
-    ref.setValue(
+    ref.setValueAsync(
         MapBuilder.of(
             "foo", MapBuilder.of(".value", 42, ".priority", 20),
             "bar", MapBuilder.of(".value", 42, ".priority", 30)));

--- a/src/test/java/com/google/firebase/database/integration/FirebaseDatabaseAuthTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/FirebaseDatabaseAuthTestIT.java
@@ -19,6 +19,8 @@ package com.google.firebase.database.integration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
@@ -29,8 +31,6 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.database.TestHelpers;
 import com.google.firebase.database.ValueEventListener;
-import com.google.firebase.tasks.OnCompleteListener;
-import com.google.firebase.tasks.Task;
 import com.google.firebase.testing.IntegrationTestUtils;
 import com.google.firebase.testing.IntegrationTestUtils.AppHttpClient;
 import com.google.firebase.testing.IntegrationTestUtils.ResponseInfo;
@@ -156,16 +156,20 @@ public class FirebaseDatabaseAuthTestIT {
       DatabaseReference ref, final boolean shouldSucceed, final boolean shouldTimeout)
       throws InterruptedException {
     final CountDownLatch lock = new CountDownLatch(1);
-    final AtomicBoolean success = new AtomicBoolean(false); 
-    ref.setValue("wrote something")
-        .addOnCompleteListener(
-            new OnCompleteListener<Void>() {
-              @Override
-              public void onComplete(Task<Void> task) {
-                success.compareAndSet(false, task.isSuccessful());
-                lock.countDown();                
-              }
-            });
+    final AtomicBoolean success = new AtomicBoolean(false);
+    ApiFutures.addCallback(ref.setValueAsync("wrote something"), new ApiFutureCallback<Void>() {
+      @Override
+      public void onFailure(Throwable throwable) {
+        success.compareAndSet(false, false);
+        lock.countDown();
+      }
+
+      @Override
+      public void onSuccess(Void result) {
+        success.compareAndSet(false, true);
+        lock.countDown();
+      }
+    });
     boolean finished = lock.await(TestUtils.TEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     if (shouldTimeout) {
       assertTrue("Write finished (expected to timeout).", !finished);

--- a/src/test/java/com/google/firebase/database/integration/InfoTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/InfoTestIT.java
@@ -60,7 +60,7 @@ public class InfoTestIT {
   public void testInfoNodeSetValue() {
     DatabaseReference ref = FirebaseDatabase.getInstance().getReference(".info");
     try {
-      ref.setValue("hi");
+      ref.setValueAsync("hi");
       fail("Should not be allowed");
     } catch (DatabaseException expected) {
       // No-op, expected
@@ -71,7 +71,7 @@ public class InfoTestIT {
   public void testInfoNodeSetValueWithPriority() {
     DatabaseReference ref = FirebaseDatabase.getInstance().getReference(".info");
     try {
-      ref.setValue("hi", 5);
+      ref.setValueAsync("hi", 5);
       fail("Should not be allowed");
     } catch (DatabaseException expected) {
       // No-op, expected
@@ -82,7 +82,7 @@ public class InfoTestIT {
   public void testInfoNodeSetPriority() {
     DatabaseReference ref = FirebaseDatabase.getInstance().getReference(".info");
     try {
-      ref.setPriority("hi");
+      ref.setPriorityAsync("hi");
       fail("Should not be allowed");
     } catch (DatabaseException expected) {
       // No-op, expected
@@ -117,7 +117,7 @@ public class InfoTestIT {
   public void testInfoNodeRemoveValue() {
     DatabaseReference ref = FirebaseDatabase.getInstance().getReference(".info");
     try {
-      ref.removeValue();
+      ref.removeValueAsync();
       fail("Should not be allowed");
     } catch (DatabaseException expected) {
       // No-op, expected
@@ -128,7 +128,7 @@ public class InfoTestIT {
   public void testInfoNodeChildSetValue() {
     DatabaseReference ref = FirebaseDatabase.getInstance().getReference(".info");
     try {
-      ref.child("test").setValue("hi");
+      ref.child("test").setValueAsync("hi");
       fail("Should not be allowed");
     } catch (DatabaseException expected) {
       // No-op, expected

--- a/src/test/java/com/google/firebase/database/integration/OrderTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/OrderTestIT.java
@@ -76,7 +76,7 @@ public class OrderTestIT {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
     for (int i = 0; i < 10; ++i) {
-      ref.push().setValue(i);
+      ref.push().setValueAsync(i);
     }
 
     DataSnapshot snap = new ReadFuture(ref).timedGet().get(0).getSnapshot();
@@ -102,7 +102,7 @@ public class OrderTestIT {
     }
 
     for (int i = 0; i < paths.size(); ++i) {
-      paths.get(i).setValue(i);
+      paths.get(i).setValueAsync(i);
     }
 
     DataSnapshot snap = new ReadFuture(ref).timedGet().get(0).getSnapshot();
@@ -125,7 +125,7 @@ public class OrderTestIT {
     final DatabaseReference reader = refs.get(1);
 
     for (int i = 0; i < 9; ++i) {
-      writer.push().setValue(i);
+      writer.push().setValueAsync(i);
     }
     new WriteFuture(writer.push(), 9).timedGet();
 
@@ -155,7 +155,7 @@ public class OrderTestIT {
     final DatabaseReference reader = refs.get(1);
 
     for (int i = 0; i < 9; ++i) {
-      writer.push().setValue(i, 10 - i);
+      writer.push().setValueAsync(i, 10 - i);
     }
     new WriteFuture(writer.push(), 9, 1).timedGet();
 
@@ -185,7 +185,7 @@ public class OrderTestIT {
     final DatabaseReference reader = refs.get(1);
 
     for (int i = 0; i < 9; ++i) {
-      writer.push().setValue(i, 111111111111111111111111111111.0 / Math.pow(10, i));
+      writer.push().setValueAsync(i, 111111111111111111111111111111.0 / Math.pow(10, i));
     }
     new WriteFuture(writer.push(), 9, 111111111111111111111111111111.0 / Math.pow(10, 9))
         .timedGet();
@@ -212,7 +212,7 @@ public class OrderTestIT {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
     ref.child("foo");
-    ref.child("bar").setValue("test");
+    ref.child("bar").setValueAsync("test");
 
     DataSnapshot snap = TestHelpers.getSnap(ref);
     int i = 0;
@@ -240,10 +240,10 @@ public class OrderTestIT {
             .addValueExpectation(ref)
             .startListening(true);
 
-    ref.child("a").setValue("first", 1);
-    ref.child("b").setValue("second", 5);
-    ref.child("c").setValue("third", 10);
-    ref.child("a").setPriority(15);
+    ref.child("a").setValueAsync("first", 1);
+    ref.child("b").setValueAsync("second", 5);
+    ref.child("c").setValueAsync("third", 10);
+    ref.child("a").setPriorityAsync(15);
 
     assertTrue(helper.waitForEvents());
     helper.cleanup();
@@ -253,8 +253,8 @@ public class OrderTestIT {
   public void testResetPriorityToNull() throws InterruptedException {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
-    ref.child("a").setValue("a", 1);
-    ref.child("b").setValue("b", 2);
+    ref.child("a").setValueAsync("a", 1);
+    ref.child("b").setValueAsync("b", 2);
 
     TestHelpers.waitForRoundtrip(ref);
     EventHelper helper =
@@ -272,7 +272,7 @@ public class OrderTestIT {
         .addValueExpectation(ref)
         .startListening();
 
-    ref.child("b").setPriority(null);
+    ref.child("b").setPriorityAsync(null);
     assertTrue(helper.waitForEvents());
 
     DataSnapshot snap = TestHelpers.getSnap(ref);
@@ -287,8 +287,8 @@ public class OrderTestIT {
 
     ReadFuture readFuture = ReadFuture.untilCountAfterNull(ref, 2);
 
-    ref.setValue("a", 10);
-    ref.child("deeper").setValue("deeper");
+    ref.setValueAsync("a", 10);
+    ref.child("deeper").setValueAsync("deeper");
 
     DataSnapshot snap = readFuture.timedGet().get(1).getSnapshot();
     assertEquals(10.0, snap.getPriority());
@@ -301,24 +301,24 @@ public class OrderTestIT {
     final DatabaseReference writer = refs.get(0);
     final DatabaseReference reader = refs.get(1);
 
-    writer.child("alpha42").setValue(1, "zed");
-    writer.child("noPriorityC").setValue(1, (String) null);
-    writer.child("num41").setValue(1, 500);
-    writer.child("noPriorityB").setValue(1, (String) null);
-    writer.child("num80").setValue(1, 4000.1);
-    writer.child("num50").setValue(1, 4000);
-    writer.child("num10").setValue(1, 24);
-    writer.child("alpha41").setValue(1, "zed");
-    writer.child("alpha20").setValue(1, "horse");
-    writer.child("num20").setValue(1, 123);
-    writer.child("num70").setValue(1, 4000.01);
-    writer.child("noPriorityA").setValue(1, (String) null);
-    writer.child("alpha30").setValue(1, "tree");
-    writer.child("num30").setValue(1, 300);
-    writer.child("num60").setValue(1, 4000.001);
-    writer.child("alpha10").setValue(1, "0horse");
-    writer.child("num42").setValue(1, 500);
-    writer.child("alpha40").setValue(1, "zed");
+    writer.child("alpha42").setValueAsync(1, "zed");
+    writer.child("noPriorityC").setValueAsync(1, null);
+    writer.child("num41").setValueAsync(1, 500);
+    writer.child("noPriorityB").setValueAsync(1, null);
+    writer.child("num80").setValueAsync(1, 4000.1);
+    writer.child("num50").setValueAsync(1, 4000);
+    writer.child("num10").setValueAsync(1, 24);
+    writer.child("alpha41").setValueAsync(1, "zed");
+    writer.child("alpha20").setValueAsync(1, "horse");
+    writer.child("num20").setValueAsync(1, 123);
+    writer.child("num70").setValueAsync(1, 4000.01);
+    writer.child("noPriorityA").setValueAsync(1, null);
+    writer.child("alpha30").setValueAsync(1, "tree");
+    writer.child("num30").setValueAsync(1, 300);
+    writer.child("num60").setValueAsync(1, 4000.001);
+    writer.child("alpha10").setValueAsync(1, "0horse");
+    writer.child("num42").setValueAsync(1, 500);
+    writer.child("alpha40").setValueAsync(1, "zed");
     new WriteFuture(writer.child("num40"), 1, 500).timedGet();
 
     List<String> expected = ImmutableList.<String>builder().add(
@@ -363,15 +363,15 @@ public class OrderTestIT {
     List<DatabaseReference> refs = IntegrationTestUtils.getRandomNode(masterApp, 2);
     DatabaseReference writer = refs.get(0);
 
-    writer.child("foo").setValue(0);
-    writer.child("bar").setValue(0);
-    writer.child("03").setValue(0);
-    writer.child("0").setValue(0);
-    writer.child("100").setValue(0);
-    writer.child("20").setValue(0);
-    writer.child("5").setValue(0);
-    writer.child("3").setValue(0);
-    writer.child("003").setValue(0);
+    writer.child("foo").setValueAsync(0);
+    writer.child("bar").setValueAsync(0);
+    writer.child("03").setValueAsync(0);
+    writer.child("0").setValueAsync(0);
+    writer.child("100").setValueAsync(0);
+    writer.child("20").setValueAsync(0);
+    writer.child("5").setValueAsync(0);
+    writer.child("3").setValueAsync(0);
+    writer.child("003").setValueAsync(0);
     new WriteFuture(writer.child("9"), 0).timedGet();
 
     List<String> expected = ImmutableList.of(
@@ -390,7 +390,7 @@ public class OrderTestIT {
     List<DatabaseReference> refs = IntegrationTestUtils.getRandomNode(masterApp, 2);
     DatabaseReference writer = refs.get(0);
 
-    writer.child("2000000000").setValue(0);
+    writer.child("2000000000").setValueAsync(0);
     new WriteFuture(writer.child("-2000000000"), 0).timedGet();
 
     List<String> expected = ImmutableList.of("-2000000000", "2000000000");
@@ -437,7 +437,7 @@ public class OrderTestIT {
               public void onCancelled(DatabaseError error) {}
             });
 
-    ref.setValue(new MapBuilder().put("a", 1).put("b", 2).put("c", 3).build());
+    ref.setValueAsync(new MapBuilder().put("a", 1).put("b", 2).put("c", 3).build());
 
     TestHelpers.waitFor(semaphore, 3);
     List<String> expected = Arrays.asList("a", null, "b", "a", "c", "b");
@@ -480,10 +480,10 @@ public class OrderTestIT {
               public void onCancelled(DatabaseError error) {}
             });
 
-    ref.setValue(MapBuilder.of("b", 2, "c", 3, "d", 4));
+    ref.setValueAsync(MapBuilder.of("b", 2, "c", 3, "d", 4));
 
-    ref.child("a").setValue(1);
-    ref.child("e").setValue(5);
+    ref.child("a").setValueAsync(1);
+    ref.child("e").setValueAsync(5);
 
     TestHelpers.waitFor(semaphore, 5);
     List<String> expected = Arrays.asList("b", null, "c", "b", "d", "c", "a", null, "e", "d");
@@ -526,9 +526,9 @@ public class OrderTestIT {
               public void onCancelled(DatabaseError error) {}
             });
 
-    ref.setValue(MapBuilder.of("b", 2, "c", 3, "d", 4));
-    ref.setValue(new MapBuilder().put("a", 1).put("b", 2).put("c", 3).put("d", 4).build());
-    ref.setValue(new MapBuilder().put("a", 1).put("b", 2).put("c", 3)
+    ref.setValueAsync(MapBuilder.of("b", 2, "c", 3, "d", 4));
+    ref.setValueAsync(new MapBuilder().put("a", 1).put("b", 2).put("c", 3).put("d", 4).build());
+    ref.setValueAsync(new MapBuilder().put("a", 1).put("b", 2).put("c", 3)
         .put("d", 4).put("e", 5).build());
 
     TestHelpers.waitFor(semaphore, 5);
@@ -572,16 +572,16 @@ public class OrderTestIT {
               public void onCancelled(DatabaseError error) {}
             });
 
-    ref.child("a").setValue("a", 1);
-    ref.child("b").setValue("b", 2);
-    ref.child("c").setValue("c", 3);
-    ref.child("d").setValue("d", 4);
+    ref.child("a").setValueAsync("a", 1);
+    ref.child("b").setValueAsync("b", 2);
+    ref.child("c").setValueAsync("c", 3);
+    ref.child("d").setValueAsync("d", 4);
 
-    ref.child("d").setPriority(0);
+    ref.child("d").setPriorityAsync(0);
 
-    ref.child("a").setPriority(4);
+    ref.child("a").setPriorityAsync(4);
 
-    ref.child("c").setPriority(0.5);
+    ref.child("c").setPriorityAsync(0.5);
 
     TestHelpers.waitFor(semaphore, 6);
 
@@ -626,7 +626,7 @@ public class OrderTestIT {
               public void onCancelled(DatabaseError error) {}
             });
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("a", new MapBuilder().put(".value", "a").put(".priority", 1).build())
             .put("b", new MapBuilder().put(".value", "b").put(".priority", 2).build())
@@ -634,7 +634,7 @@ public class OrderTestIT {
             .put("d", new MapBuilder().put(".value", "d").put(".priority", 4).build())
             .build());
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("d", new MapBuilder().put(".value", "d").put(".priority", 0).build())
             .put("a", new MapBuilder().put(".value", "a").put(".priority", 1).build())
@@ -642,7 +642,7 @@ public class OrderTestIT {
             .put("c", new MapBuilder().put(".value", "c").put(".priority", 3).build())
             .build());
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("d", new MapBuilder().put(".value", "d").put(".priority", 0).build())
             .put("b", new MapBuilder().put(".value", "b").put(".priority", 2).build())
@@ -650,7 +650,7 @@ public class OrderTestIT {
             .put("a", new MapBuilder().put(".value", "a").put(".priority", 4).build())
             .build());
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("d", new MapBuilder().put(".value", "d").put(".priority", 0).build())
             .put("c", new MapBuilder().put(".value", "c").put(".priority", 0.5).build())
@@ -698,9 +698,9 @@ public class OrderTestIT {
               public void onCancelled(DatabaseError error) {}
             });
 
-    ref.child("test/foo").setValue(42, "5");
-    ref.child("test/f002").setValue(42, "10");
-    ref.child("test/foo").removeValue();
+    ref.child("test/foo").setValueAsync(42, "5");
+    ref.child("test/f002").setValueAsync(42, "10");
+    ref.child("test/foo").removeValueAsync();
     new WriteFuture(ref.child("test/foo2"), null).timedGet();
     // If child_moved has been raised, the test will have failed by now
     ref.removeEventListener(listener);
@@ -712,7 +712,7 @@ public class OrderTestIT {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
     ReadFuture readFuture = new ReadFuture(ref);
-    ref.setValue("test", 0);
+    ref.setValueAsync("test", 0);
 
     DataSnapshot snap = readFuture.timedGet().get(0).getSnapshot();
 
@@ -725,7 +725,7 @@ public class OrderTestIT {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
     ReadFuture readFuture = new ReadFuture(ref);
-    ref.setValue(new MapBuilder().put("x", "test").put("y", 7).build(), 0);
+    ref.setValueAsync(new MapBuilder().put("x", "test").put("y", 7).build(), 0);
 
     DataSnapshot snap = readFuture.timedGet().get(0).getSnapshot();
 
@@ -767,7 +767,7 @@ public class OrderTestIT {
               public void onCancelled(DatabaseError error) {}
             });
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("a", new MapBuilder().put(".value", "a").put(".priority", 0).build())
             .put("b", new MapBuilder().put(".value", "b").put(".priority", 1).build())
@@ -775,7 +775,7 @@ public class OrderTestIT {
             .put("d", new MapBuilder().put(".value", "d").put(".priority", 3).build())
             .build());
 
-    ref.child("b").setPriority(1.5);
+    ref.child("b").setPriorityAsync(1.5);
     TestHelpers.waitFor(semaphore, 2);
 
     assertEquals(2, results.size());
@@ -820,7 +820,7 @@ public class OrderTestIT {
               }
             });
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("a", new MapBuilder().put(".value", "a").put(".priority", 0).build())
             .put("b", new MapBuilder().put(".value", "b").put(".priority", 1).build())
@@ -828,7 +828,7 @@ public class OrderTestIT {
             .put("d", new MapBuilder().put(".value", "d").put(".priority", 3).build())
             .build());
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("a", new MapBuilder().put(".value", "a").put(".priority", 0).build())
             .put("b", new MapBuilder().put(".value", "b").put(".priority", 1.5).build())

--- a/src/test/java/com/google/firebase/database/integration/QueryTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/QueryTestIT.java
@@ -330,7 +330,7 @@ public class QueryTestIT {
           }
         });
 
-    ref.setValue(MapBuilder.of("a", 5, "b", 6));
+    ref.setValueAsync(MapBuilder.of("a", 5, "b", 6));
     TestHelpers.waitFor(semaphore, 1);
     ref.limitToLast(5).removeEventListener(listener);
     new WriteFuture(ref, MapBuilder.of("a", 6, "b", 5)).timedGet();
@@ -344,7 +344,7 @@ public class QueryTestIT {
       throws TestFailure, TimeoutException, InterruptedException {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
-    ref.setValue(new MapBuilder().put("a", 1).put("b", 2).put("c", 3).put("d", 4)
+    ref.setValueAsync(new MapBuilder().put("a", 1).put("b", 2).put("c", 3).put("d", 4)
         .put("e", 5).put("f", 6).build());
 
     DataSnapshot snap = new ReadFuture(ref.limitToLast(5)).timedGet().get(0).getSnapshot();
@@ -361,7 +361,7 @@ public class QueryTestIT {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
     for (int i = 0; i < 9; ++i) {
-      ref.push().setValue(i);
+      ref.push().setValueAsync(i);
     }
     new WriteFuture(ref.push(), 9).timedGet();
 
@@ -389,7 +389,7 @@ public class QueryTestIT {
     expectations.add(ref.limitToLast(4),
         MapBuilder.of("a", 1L, "b", 2L, "c", 3L));
 
-    ref.setValue(MapBuilder.of("a", 1L, "b", 2L, "c", 3L));
+    ref.setValueAsync(MapBuilder.of("a", 1L, "b", 2L, "c", 3L));
 
     expectations.waitForEvents();
   }
@@ -410,7 +410,7 @@ public class QueryTestIT {
     expectations.add(ref.startAt(null, "b").limitToFirst(3),
         MapBuilder.of("b", 2L, "c", 3L));
 
-    ref.setValue(MapBuilder.of("a", 1, "b", 2, "c", 3));
+    ref.setValueAsync(MapBuilder.of("a", 1, "b", 2, "c", 3));
     expectations.waitForEvents();
   }
 
@@ -921,7 +921,7 @@ public class QueryTestIT {
     helper.add(ref.startAt("w").endAt("w"), MapBuilder.of("d", 4L));
     helper.add(ref.startAt("a").endAt("c"), null);
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("a", MapBuilder.of(".value", 1, ".priority", "z"))
             .put("b", MapBuilder.of(".value", 2, ".priority", "y"))
@@ -935,7 +935,7 @@ public class QueryTestIT {
   public void testStartAtEndAtWithPriorityUsingServerData() throws InterruptedException {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("a", MapBuilder.of(".value", 1, ".priority", "z"))
             .put("b", MapBuilder.of(".value", 2, ".priority", "y"))
@@ -963,7 +963,7 @@ public class QueryTestIT {
     helper.add(ref.startAt(1, "c").endAt(2),
         MapBuilder.of("c", 3L, "d", 4L));
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("a", MapBuilder.of(".value", 1, ".priority", 1))
             .put("b", MapBuilder.of(".value", 2, ".priority", 1))
@@ -985,7 +985,7 @@ public class QueryTestIT {
     helper.add(ref.startAt(1, "e").endAt(2),
         MapBuilder.of("a", 1L, "b", 2L));
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("c", MapBuilder.of(".value", 3, ".priority", 1))
             .put("d", MapBuilder.of(".value", 4, ".priority", 1))
@@ -999,7 +999,7 @@ public class QueryTestIT {
   public void testStartAtEndAtWithPriorityAndNameUsingServerData() throws InterruptedException {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("a", MapBuilder.of(".value", 1, ".priority", 1))
             .put("b", MapBuilder.of(".value", 2, ".priority", 1))
@@ -1022,7 +1022,7 @@ public class QueryTestIT {
       InterruptedException {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("c", MapBuilder.of(".value", 3, ".priority", 1))
             .put("d", MapBuilder.of(".value", 4, ".priority", 1))
@@ -1072,9 +1072,9 @@ public class QueryTestIT {
       }
     });
 
-    ref.child("a").setValue(1);
-    ref.child("c").setValue(3);
-    ref.child("b").setValue(2);
+    ref.child("a").setValueAsync(1);
+    ref.child("c").setValueAsync(3);
+    ref.child("b").setValueAsync(2);
     new WriteFuture(ref.child("d"), 4).timedGet();
 
     TestHelpers.assertDeepEquals(ImmutableList.of("a null", "c a", "b null", "d c"), names);
@@ -1115,14 +1115,14 @@ public class QueryTestIT {
       }
     });
 
-    ref.child("a").setValue("a", 10);
-    ref.child("b").setValue("b", 20);
-    ref.child("c").setValue("c", 30);
-    ref.child("d").setValue("d", 40);
+    ref.child("a").setValueAsync("a", 10);
+    ref.child("b").setValueAsync("b", 20);
+    ref.child("c").setValueAsync("c", 30);
+    ref.child("d").setValueAsync("d", 40);
 
     // Start moving things
-    ref.child("c").setPriority(50);
-    ref.child("c").setPriority(35);
+    ref.child("c").setPriorityAsync(50);
+    ref.child("c").setPriorityAsync(35);
     new WriteFuture(ref.child("b"), "b", 33).timedGet();
 
     TestHelpers.assertDeepEquals(ImmutableList.of("c d", "c null"), names);
@@ -1179,7 +1179,7 @@ public class QueryTestIT {
     future.timedGet();
 
     for (int i = 0; i < 4; ++i) {
-      writer.push().setValue(i);
+      writer.push().setValueAsync(i);
     }
     new WriteFuture(writer.push(), 4).timedGet();
     List<String> expected = ImmutableList.<String>builder().add(
@@ -1223,7 +1223,7 @@ public class QueryTestIT {
   public void testFilteringOnlyNullPriorities() throws InterruptedException {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder().put("a", new MapBuilder().put(".priority", null).put(".value", 0).build())
             .put("b", new MapBuilder().put(".priority", null).put(".value", 1).build())
             .put("c", new MapBuilder().put(".priority", "2").put(".value", 2).build())
@@ -1240,7 +1240,7 @@ public class QueryTestIT {
   public void testNullPrioritiesIncludedInEndAt() throws InterruptedException {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("a", MapBuilder.of(".priority", null, ".value", 0))
             .put("b", MapBuilder.of(".priority", null, ".value", 1))
@@ -1258,7 +1258,7 @@ public class QueryTestIT {
   public void testNullPrioritiesIncludedInStartAt() throws InterruptedException {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
-    ref.setValue(
+    ref.setValueAsync(
         new MapBuilder()
             .put("a", new MapBuilder().put(".priority", null).put(".value", 0).build())
             .put("b", new MapBuilder().put(".priority", null).put(".value", 1).build())
@@ -1289,7 +1289,7 @@ public class QueryTestIT {
         .put("Sally",
             new MapBuilder().put(".priority", -7.0).put("score", -7L).put("name", "Sally").build())
         .put("Fred", new MapBuilder().put("score", 0.0).put("name", "Fred").build()).build();
-    ref.setValue(toSet);
+    ref.setValueAsync(toSet);
     final Semaphore semaphore = new Semaphore(0);
     final List<String> names = new ArrayList<>();
     ref.limitToLast(5).addChildEventListener(new ChildEventListener() {
@@ -1399,7 +1399,7 @@ public class QueryTestIT {
             fail("Should not be cancelled");
           }
         });
-    ref.setValue(toSet);
+    ref.setValueAsync(toSet);
     TestHelpers.waitFor(semaphore, 5);
     TestHelpers.assertDeepEquals(ImmutableList.of("Sally", "James", "Andrew", "Mike", "Vikrum"),
         names);
@@ -1418,13 +1418,13 @@ public class QueryTestIT {
     // wait for null event
     TestHelpers.waitForRoundtrip(ref);
 
-    ref.setValue(
+    ref.setValueAsync(
         MapBuilder.of(
             "a", MapBuilder.of(".value", 1, ".priority", 1),
             "b", MapBuilder.of(".value", 2, ".priority", 2),
             "c", MapBuilder.of(".value", 3, ".priority", 3)));
 
-    ref.updateChildren(new MapBuilder().put("b", null).put("c", null).build());
+    ref.updateChildrenAsync(new MapBuilder().put("b", null).put("c", null).build());
     List<EventRecord> events = readFuture.timedGet();
     DataSnapshot snap = events.get(1).getSnapshot();
 
@@ -1460,7 +1460,7 @@ public class QueryTestIT {
 
     new WriteFuture(ref, MapBuilder.of("a", 1, "b", 2)).timedGet();
     assertEquals(1L, childSnaps.get(0).getValue());
-    ref.updateChildren(MapBuilder.of("c", 3));
+    ref.updateChildrenAsync(MapBuilder.of("c", 3));
     List<EventRecord> events = parentFuture.timedGet();
     DataSnapshot snap = events.get(0).getSnapshot();
     Object result = snap.getValue();
@@ -1607,8 +1607,8 @@ public class QueryTestIT {
       }
     });
 
-    ref.setValue(MapBuilder.of("a", 1, "b", 2));
-    ref.child("b").removeValue();
+    ref.setValueAsync(MapBuilder.of("a", 1, "b", 2));
+    ref.child("b").removeValueAsync();
     TestHelpers.waitFor(semaphore);
     TestHelpers.assertDeepEquals(ImmutableList.of(2L, 1L), values);
   }
@@ -1617,7 +1617,7 @@ public class QueryTestIT {
   public void testStartAtLimit() throws InterruptedException {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
-    ref.setValue(MapBuilder.of("a", 1, "b", 2));
+    ref.setValueAsync(MapBuilder.of("a", 1, "b", 2));
     DataSnapshot snap = TestHelpers.getSnap(ref.limitToFirst(1));
 
     assertEquals(1L, snap.child("a").getValue());
@@ -1627,7 +1627,7 @@ public class QueryTestIT {
   public void testStartAtLimitWhenChildIsRemoved() throws InterruptedException {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
-    ref.setValue(MapBuilder.of("a", 1, "b", 2));
+    ref.setValueAsync(MapBuilder.of("a", 1, "b", 2));
     final List<Long> values = new ArrayList<>();
     final Semaphore semaphore = new Semaphore(0);
     ref.limitToFirst(1).addChildEventListener(new ChildEventListener() {
@@ -1661,7 +1661,7 @@ public class QueryTestIT {
     // Wait for first value
     TestHelpers.waitFor(semaphore);
     assertEquals((Long) 1L, values.get(0));
-    ref.child("a").removeValue();
+    ref.child("a").removeValueAsync();
     TestHelpers.waitFor(semaphore);
     assertEquals((Long) 2L, values.get(1));
   }
@@ -1798,7 +1798,7 @@ public class QueryTestIT {
           @Override
           public boolean isComplete(List<EventRecord> events) {
             if (events.size() == 1) {
-              writer.child("c").removeValue();
+              writer.child("c").removeValueAsync();
             }
             return events.size() == 2;
           }
@@ -1854,7 +1854,7 @@ public class QueryTestIT {
     TestHelpers.waitFor(semaphore);
     Map<String, Object> update = new MapBuilder().put("b", null).put("c", "a").put("cc", "new")
         .put("cd", "new2").put("d", "gone").build();
-    writer.updateChildren(update);
+    writer.updateChildrenAsync(update);
     List<EventRecord> events = future.timedGet();
 
     Map<String, Object> expected = new MapBuilder().put("a", 1L).put("b", 2L).put("c", 3L)
@@ -1893,7 +1893,7 @@ public class QueryTestIT {
     TestHelpers.waitFor(semaphore);
     Map<String, Object> update = new MapBuilder().put("bar", "d").put("bam", null).put("bat", "e")
         .build();
-    writer.updateChildren(update);
+    writer.updateChildrenAsync(update);
     List<EventRecord> events = future.timedGet();
 
     Map<String, Object> expected = MapBuilder.of("bar", "a", "baz", "b", "bam",
@@ -1912,8 +1912,8 @@ public class QueryTestIT {
     List<DatabaseReference> refs = IntegrationTestUtils.getRandomNode(masterApp, 2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
-    writer.child("a").setValue(1);
-    writer.child("b").setValue("b");
+    writer.child("a").setValueAsync(1);
+    writer.child("b").setValueAsync("b");
     final Map<String, Object> deepObject = MapBuilder.of(
         "deep", "path",
         "of", MapBuilder.of("stuff", true));
@@ -2035,9 +2035,9 @@ public class QueryTestIT {
       }
     });
 
-    writer.child("a").setValue(1);
-    writer.child("b").setValue("b");
-    writer.child("c").setValue(deepObject);
+    writer.child("a").setValueAsync(1);
+    writer.child("b").setValueAsync("b");
+    writer.child("c").setValueAsync(deepObject);
 
     TestHelpers.waitFor(semaphore, 3);
   }
@@ -2048,8 +2048,8 @@ public class QueryTestIT {
     List<DatabaseReference> refs = IntegrationTestUtils.getRandomNode(masterApp, 2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
-    writer.child("a").setValue(1);
-    writer.child("b").setValue("b");
+    writer.child("a").setValueAsync(1);
+    writer.child("b").setValueAsync("b");
     final Map<String, Object> deepObject = MapBuilder.of(
         "deep", "path",
         "of", MapBuilder.of("stuff", true));
@@ -2111,9 +2111,9 @@ public class QueryTestIT {
       }
     });
 
-    writer.child("a").removeValue();
-    writer.child("b").removeValue();
-    writer.child("c").removeValue();
+    writer.child("a").removeValueAsync();
+    writer.child("b").removeValueAsync();
+    writer.child("c").removeValueAsync();
 
     TestHelpers.waitFor(semaphore, 3);
   }
@@ -2124,8 +2124,8 @@ public class QueryTestIT {
     List<DatabaseReference> refs = IntegrationTestUtils.getRandomNode(masterApp, 2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
-    writer.child("a").setValue(1);
-    writer.child("b").setValue("b");
+    writer.child("a").setValueAsync(1);
+    writer.child("b").setValueAsync("b");
     final Map<String, Object> deepObject = MapBuilder.of(
         "deep", "path",
         "of", MapBuilder.of("stuff", true));
@@ -2187,7 +2187,7 @@ public class QueryTestIT {
       }
     });
 
-    writer.removeValue();
+    writer.removeValueAsync();
 
     TestHelpers.waitFor(semaphore, 3);
   }
@@ -2198,8 +2198,8 @@ public class QueryTestIT {
     List<DatabaseReference> refs = IntegrationTestUtils.getRandomNode(masterApp, 2);
     DatabaseReference writer = refs.get(0);
     DatabaseReference reader = refs.get(1);
-    writer.child("a").setValue(1);
-    writer.child("b").setValue("b");
+    writer.child("a").setValueAsync(1);
+    writer.child("b").setValueAsync("b");
     final Map<String, Object> deepObject = MapBuilder.of(
         "deep", "path",
         "of", MapBuilder.of("stuff", true));
@@ -2261,7 +2261,7 @@ public class QueryTestIT {
       }
     });
 
-    writer.setValue("scalar");
+    writer.setValueAsync("scalar");
 
     TestHelpers.waitFor(semaphore, 3);
   }
@@ -2403,9 +2403,9 @@ public class QueryTestIT {
       }
     });
 
-    ref.child("a").setValue("a", 5);
-    ref.child("a").setValue("a", 15);
-    ref.child("a").setValue("a", 10);
+    ref.child("a").setValueAsync("a", 5);
+    ref.child("a").setValueAsync("a", 15);
+    ref.child("a").setValueAsync("a", 10);
     new WriteFuture(ref.child("a"), "a", 5).timedGet();
 
     assertEquals(2, addedFirst.size());
@@ -2457,7 +2457,7 @@ public class QueryTestIT {
         if (events.size() == 1) {
           TestHelpers.assertDeepEquals(toSet, events.get(0).getSnapshot().getValue());
           try {
-            writer.child("d").setValue(4);
+            writer.child("d").setValueAsync(4);
           } catch (DatabaseException e) { // ignore
             fail("Should not fail");
           }
@@ -2502,10 +2502,10 @@ public class QueryTestIT {
 
     TestHelpers.waitFor(ready);
     for (int i = 0; i < 4; ++i) {
-      writer.child("k" + i).setValue(i);
+      writer.child("k" + i).setValueAsync(i);
     }
 
-    writer.removeValue();
+    writer.removeValueAsync();
     future.timedGet();
   }
 
@@ -2698,10 +2698,10 @@ public class QueryTestIT {
     expectations.add(ref.equalTo(2, "no_key"), null);
     expectations.add(ref.equalTo(2, "b"), MapBuilder.of("b", "valb"));
 
-    ref.child("a").setValue("vala", 1);
-    ref.child("b").setValue("valb", 2);
-    ref.child("c").setValue("valc", 3);
-    ref.child("z").setValue("valz", "abc");
+    ref.child("a").setValueAsync("vala", 1);
+    ref.child("b").setValueAsync("valb", 2);
+    ref.child("c").setValueAsync("valc", 3);
+    ref.child("z").setValueAsync("valz", "abc");
 
     expectations.waitForEvents();
   }
@@ -2881,7 +2881,7 @@ public class QueryTestIT {
       }
     };
 
-    ref.child("child").setValue(TestHelpers.fromJsonString("{\"name\": \"John\"}"));
+    ref.child("child").setValueAsync(TestHelpers.fromJsonString("{\"name\": \"John\"}"));
 
     ref.orderByChild("name").equalTo("John").addValueEventListener(dummyListen);
     ref.child("child").addValueEventListener(dummyListen);

--- a/src/test/java/com/google/firebase/database/integration/RulesTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/RulesTestIT.java
@@ -41,7 +41,6 @@ import com.google.firebase.database.core.RepoManager;
 import com.google.firebase.database.future.ReadFuture;
 import com.google.firebase.database.future.WriteFuture;
 import com.google.firebase.database.util.JsonMapper;
-import com.google.firebase.tasks.Tasks;
 import com.google.firebase.testing.IntegrationTestUtils;
 import com.google.firebase.testing.TestUtils;
 
@@ -423,7 +422,7 @@ public class RulesTestIT {
     DatabaseReference root = FirebaseDatabase.getInstance(masterApp).getReference();
     DatabaseReference ref = root.child(writer.getPath().toString());
 
-    String token = Tasks.await(TestOnlyImplFirebaseTrampolines.getToken(masterApp, true),
+    String token = TestOnlyImplFirebaseTrampolines.getToken(masterApp, true).get(
         TestUtils.TEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS).getToken();
     provider.setToken(token);
 

--- a/src/test/java/com/google/firebase/database/integration/TransactionTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/TransactionTestIT.java
@@ -315,7 +315,7 @@ public class TransactionTestIT {
     EventHelper helper = new EventHelper().addValueExpectation(reader.child("a"))
         .addValueExpectation(reader.child("b")).startListening(true);
 
-    writer.child("a").setValue(42);
+    writer.child("a").setValueAsync(42);
     new WriteFuture(writer.child("b"), 42).timedGet();
 
     assertTrue(helper.waitForEvents());
@@ -561,7 +561,7 @@ public class TransactionTestIT {
     // However, a new value event won't be triggered until the listener is
     // complete,
     // so we're left with the last value event
-    ref.child("foo").setValue(0);
+    ref.child("foo").setValueAsync(0);
 
     TestHelpers.waitFor(semaphore);
 
@@ -594,8 +594,8 @@ public class TransactionTestIT {
       }
     });
 
-    ref.setValue("foo");
-    ref.setValue("bar");
+    ref.setValueAsync("foo");
+    ref.setValueAsync("bar");
     TestHelpers.waitFor(semaphore);
   }
 
@@ -617,7 +617,7 @@ public class TransactionTestIT {
       }
     });
 
-    ref.setValue("test", 5);
+    ref.setValueAsync("test", 5);
     ref.runTransaction(new Transaction.Handler() {
       @Override
       public Transaction.Result doTransaction(MutableData currentData) {
@@ -772,7 +772,7 @@ public class TransactionTestIT {
       }
     });
 
-    ref.setValue(32);
+    ref.setValueAsync(32);
     TestHelpers.waitFor(semaphore);
   }
 
@@ -1820,7 +1820,7 @@ public class TransactionTestIT {
     // runs.
     DatabaseConfig ctx = TestHelpers.getDatabaseConfig(masterApp);
     RepoManager.interrupt(ctx);
-    ref.updateChildren(new MapBuilder().put("foo", "bar").build());
+    ref.updateChildrenAsync(new MapBuilder().put("foo", "bar").build());
     ref.child("foo").runTransaction(new Transaction.Handler() {
 
       @Override
@@ -1846,7 +1846,7 @@ public class TransactionTestIT {
       throws InterruptedException, ExecutionException, TestFailure, TimeoutException {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp);
 
-    ref.setValue(new MapBuilder().put("foo", "bar").build());
+    ref.setValueAsync(new MapBuilder().put("foo", "bar").build());
     ref.runTransaction(new Transaction.Handler() {
       @Override
       public Transaction.Result doTransaction(MutableData currentData) {

--- a/src/test/java/com/google/firebase/testing/IntegrationTestUtils.java
+++ b/src/test/java/com/google/firebase/testing/IntegrationTestUtils.java
@@ -19,6 +19,7 @@ package com.google.firebase.testing;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.api.core.ApiFuture;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
@@ -28,8 +29,6 @@ import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.internal.GetTokenResult;
-import com.google.firebase.tasks.Task;
-import com.google.firebase.tasks.Tasks;
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -165,9 +164,9 @@ public class IntegrationTestUtils {
     private String getToken() {
       // TODO: We should consider exposing getToken (or similar) publicly for the
       // purpose of servers doing authenticated REST requests like this.
-      Task<GetTokenResult> task = TestOnlyImplFirebaseTrampolines.getToken(app, false);
+      ApiFuture<GetTokenResult> future = TestOnlyImplFirebaseTrampolines.getToken(app, false);
       try {
-        return Tasks.await(task).getToken();
+        return future.get().getToken();
       } catch (ExecutionException | InterruptedException e) {
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
This is the first phase of migration to `ApiFutures` (go/firebase-admin-java-threads). This PR:

1. Deprecates the `Task` API.
2. Adds a set of new methods to `FirebaseAuth` that returns `ApiFutures`. 
3. Updates the test cases to use `ApiFutures` where appropriate.

I'm not touching the `FirebaseCredential` interface, since that is going to be deprecated separately.

`DatabaseReference` and `OnDisconnect` classes also have some methods that return `Tasks`. Any ideas on how to deal with them will be appreciated. We can introduce a set of new methods that return `ApiFutures` here as well.  But that results in the following migration path which is not ideal:

```
// Phase 1 (No breaking changes)
class DatabaseReference {
   public Task<Void> setValue(Object value);
   public ApiFuture<Void> setValueAsync(Object value);
}
```

```
// Phase 2 (Breaking changes)
class DatabaseReference {
   public ApiFuture<Void> setValue(Object value);
}
```

The other option is to not touch them at the moment, and continue to support only `Tasks` in those APIs. We will simply switch them to return `ApiFutures` in phase 2.