### PR TITLE
Handling errors thrown by Transaction.Handler.onComplete()

### DIFF
--- a/src/main/java/com/google/firebase/database/core/Repo.java
+++ b/src/main/java/com/google/firebase/database/core/Repo.java
@@ -783,7 +783,7 @@ public class Repo implements PersistentConnection.Delegate {
           new Runnable() {
             @Override
             public void run() {
-              handler.onComplete(innerClassError, false, snap);
+              runTransactionOnComplete(handler, innerClassError, false, snap);
             }
           });
     } else {
@@ -929,7 +929,7 @@ public class Repo implements PersistentConnection.Delegate {
                     new Runnable() {
                       @Override
                       public void run() {
-                        txn.handler.onComplete(null, true, snap);
+                        runTransactionOnComplete(txn.handler, null, true, snap);
                       }
                     });
                 // Remove the outstanding value listener that we added
@@ -1141,7 +1141,7 @@ public class Repo implements PersistentConnection.Delegate {
             new Runnable() {
               @Override
               public void run() {
-                transaction.handler.onComplete(callbackError, false, snapshot);
+                runTransactionOnComplete(transaction.handler, callbackError, false, snapshot);
               }
             });
       }
@@ -1274,7 +1274,7 @@ public class Repo implements PersistentConnection.Delegate {
               new Runnable() {
                 @Override
                 public void run() {
-                  transaction.handler.onComplete(abortError, false, null);
+                  runTransactionOnComplete(transaction.handler, abortError, false, null);
                 }
               });
         }
@@ -1293,6 +1293,15 @@ public class Repo implements PersistentConnection.Delegate {
       for (Runnable r : callbacks) {
         postEvent(r);
       }
+    }
+  }
+
+  private void runTransactionOnComplete(Transaction.Handler handler, DatabaseError error,
+      boolean committed, DataSnapshot snapshot) {
+    try {
+      handler.onComplete(error, committed, snapshot);
+    } catch (Exception e) {
+      operationLogger.error("Exception in transaction onComplete callback", e);
     }
   }
 


### PR DESCRIPTION
Currently these errors are simply swallowed and ignored. This PR handles them by logging the errors. Resolves #69.

