### PR TITLE
Load integration test credentials from well-known files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/
 .project
 .checkstyle
 release.properties
+integration_cert.json
+integration_apikey.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,9 +136,9 @@ Create a new project in the [Firebase console](https://console.firebase.google.c
 not already have one. Use a separate, dedicated project for integration tests since the test suite
 makes a large number of writes to the Firebase realtime database. Download the service account
 private key from the "Settings > Service Accounts" page of the project, and save it as
-`integration_cert.json` at the root of the project. Also obtain the web API key of the project
-from the "Settings > General" page, and save it as `integration_apikey.txt` at the project root.
-Now run the following command to invoke the integration test suite:
+`integration_cert.json` at the root of the codebase. Also obtain the web API key of the project
+from the "Settings > General" page, and save it as `integration_apikey.txt` at the root of the
+codebase. Now run the following command to invoke the integration test suite:
 
 ```
 mvn verify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,20 +130,19 @@ Integration tests are also written using Junit4. They coexist with the unit test
 subdirectory. Integration tests follow the naming convention `*IT.java` (e.g. `DataTestIT.java`),
 which enables the Maven Surefire and Failsafe plugins to differentiate between the two types of
 tests. Integration tests are executed against a real life Firebase project, and therefore
-requires an Internet connection. Create a new project in the
-[Firebase console](https://console.firebase.google.com/) if you do not already have one. Use a 
-separate, dedicated project for integration tests since the test suite makes a large number of
-writes to the Firebase realtime database. Download the service account private key from the 
-"Settings > Service Accounts" page of the project. Also obtain the web API key of the project
-from the "Settings > General" page. Now run the following command to invoke the integration
-test suite:
+requires an Internet connection.
+
+Create a new project in the [Firebase console](https://console.firebase.google.com/) if you do
+not already have one. Use a separate, dedicated project for integration tests since the test suite
+makes a large number of writes to the Firebase realtime database. Download the service account
+private key from the "Settings > Service Accounts" page of the project, and save it as
+`integration_cert.json` at the root of the project. Also obtain the web API key of the project
+from the "Settings > General" page, and save it as `integration_apikey.txt` at the project root.
+Now run the following command to invoke the integration test suite:
 
 ```
-mvn verify -Dfirebase.it.certificate=path/to/serviceAccount.json -Dfirebase.it.apikey=API-Key
+mvn verify
 ```
-
-Make sure to specify the correct path to your downloaded service account key file as the
-`firebase.it.certificate` system property. 
 
 The above command invokes both unit and integration test suites. To execute only the integration
 tests, specify the `-DskipUTs` flag.

--- a/src/test/java/com/google/firebase/testing/IntegrationTestUtils.java
+++ b/src/test/java/com/google/firebase/testing/IntegrationTestUtils.java
@@ -16,10 +16,10 @@
 
 package com.google.firebase.testing;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Strings;
+import com.google.api.client.googleapis.util.Utils;
+import com.google.api.client.json.GenericJson;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
 import com.google.firebase.FirebaseApp;
@@ -40,26 +40,25 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
-import org.json.JSONObject;
 
 public class IntegrationTestUtils {
 
-  private static JSONObject IT_SERVICE_ACCOUNT;
+  private static final String IT_SERVICE_ACCOUNT_PATH = "integration_cert.json";
+  private static final String IT_API_KEY_PATH = "integration_apikey.txt";
+
+  private static GenericJson serviceAccount;
+  private static String apiKey;
   private static FirebaseApp masterApp;
 
-  private static synchronized JSONObject ensureServiceAccount() {
-    if (IT_SERVICE_ACCOUNT == null) {
-      String certificatePath = System.getProperty("firebase.it.certificate");
-      checkArgument(!Strings.isNullOrEmpty(certificatePath),
-          "Service account certificate path not set. Set the "
-              + "firebase.it.certificate system property and try again.");
-      try (InputStreamReader reader = new InputStreamReader(new FileInputStream(certificatePath))) {
-        IT_SERVICE_ACCOUNT = new JSONObject(CharStreams.toString(reader));
+  private static synchronized GenericJson ensureServiceAccount() {
+    if (serviceAccount == null) {
+      try (InputStream stream = new FileInputStream(IT_SERVICE_ACCOUNT_PATH)) {
+        serviceAccount = Utils.getDefaultJsonFactory().fromInputStream(stream, GenericJson.class);
       } catch (IOException e) {
         throw new RuntimeException("Failed to read service account certificate", e);
       }
     }
-    return IT_SERVICE_ACCOUNT;
+    return serviceAccount;
   }
 
   public static InputStream getServiceAccountCertificate() {
@@ -78,10 +77,14 @@ public class IntegrationTestUtils {
     return getProjectId() + ".appspot.com";
   }
 
-  public static String getApiKey() {
-    String apiKey = System.getProperty("firebase.it.apikey");
-    checkArgument(!Strings.isNullOrEmpty(apiKey), "API key not specified. Set the "
-        + "firebase.it.apikey system property and try again.");
+  public static synchronized String getApiKey() {
+    if (apiKey == null) {
+      try (InputStream stream = new FileInputStream(IT_API_KEY_PATH)) {
+        apiKey = CharStreams.toString(new InputStreamReader(stream)).trim();
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to read api key file", e);
+      }
+    }
     return apiKey;
   }
 

--- a/src/test/java/com/google/firebase/testing/IntegrationTestUtils.java
+++ b/src/test/java/com/google/firebase/testing/IntegrationTestUtils.java
@@ -55,7 +55,10 @@ public class IntegrationTestUtils {
       try (InputStream stream = new FileInputStream(IT_SERVICE_ACCOUNT_PATH)) {
         serviceAccount = Utils.getDefaultJsonFactory().fromInputStream(stream, GenericJson.class);
       } catch (IOException e) {
-        throw new RuntimeException("Failed to read service account certificate", e);
+        String msg = String.format("Failed to read service account certificate from %s. "
+            + "Integration tests require a service account credential obtained from a Firebase "
+            + "project. See CONTRIBUTING.md for more details.", IT_SERVICE_ACCOUNT_PATH);
+        throw new RuntimeException(msg, e);
       }
     }
     return serviceAccount;
@@ -82,7 +85,10 @@ public class IntegrationTestUtils {
       try (InputStream stream = new FileInputStream(IT_API_KEY_PATH)) {
         apiKey = CharStreams.toString(new InputStreamReader(stream)).trim();
       } catch (IOException e) {
-        throw new RuntimeException("Failed to read api key file", e);
+        String msg = String.format("Failed to read API key from %s. "
+            + "Integration tests require an API key obtained from a Firebase "
+            + "project. See CONTRIBUTING.md for more details.", IT_API_KEY_PATH);
+        throw new RuntimeException(msg, e);
       }
     }
     return apiKey;


### PR DESCRIPTION
Up until now we have required passing integration test credentials explicitly as system properties:

```
-Difrebase.it.certificate=path/to/key.json -Dfirebase.it.apikey=my_api_key
```

However, it is much easier if the test suite can simply load these parameters implicitly, from well-known files in the local file system. That way the development environment can be set up once with the required files, and the test suite can be invoked without additional parameters from there on.

This PR modifies the test suite to load the integration test credentials from `integration_cert.json` and `integration_apikey.txt` files. We've been following a similar convention in other admin SDKs, which has proven to be a lot easier to manage.