### PR TITLE
Updating GCS dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,17 +347,12 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <version>1.2.1</version>
+            <version>1.7.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-firestore</artifactId>
             <version>0.25.0-beta</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.api</groupId>
-            <artifactId>gax</artifactId>
-            <version>1.8.1</version>
         </dependency>
 
         <!-- Utilities -->


### PR DESCRIPTION
This also picks up the latest version of gax, so we no longer have to specify it explicitly.

Related to https://github.com/GoogleCloudPlatform/google-cloud-java/issues/2496