### PR TITLE
Fixing a javadoc generator failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,9 +116,9 @@
                             <bootclasspath>${sun.boot.class.path}</bootclasspath>
                             <additionalDependencies>
                                 <additionalDependency>
-                                    <groupId>com.google.errorprone</groupId>
-                                    <artifactId>error_prone_annotations</artifactId>
-                                    <version>2.0.15</version>
+                                    <groupId>com.google.j2objc</groupId>
+                                    <artifactId>j2objc-annotations</artifactId>
+                                    <version>1.3</version>
                                 </additionalDependency>
                             </additionalDependencies>
                             <additionalparam>
@@ -186,9 +186,9 @@
                             <bootclasspath>${sun.boot.class.path}</bootclasspath>
                             <additionalDependencies>
                                 <additionalDependency>
-                                    <groupId>com.google.errorprone</groupId>
-                                    <artifactId>error_prone_annotations</artifactId>
-                                    <version>2.0.15</version>
+                                    <groupId>com.google.j2objc</groupId>
+                                    <artifactId>j2objc-annotations</artifactId>
+                                    <version>1.3</version>
                                 </additionalDependency>
                             </additionalDependencies>
                             <additionalparam>


### PR DESCRIPTION
Making yet another config change to get the Javadoc generation working (this is starting to become a problem). The `error_prone` library is now in our classpath (transitive dependency via gRPC). But now we need to add `j2objc-annotations` to get the javadoc plugin working.

I did some additional testing, and this seems to be a bug in `doclava`. The regular Maven javadoc plugin works fine without these additional configs. I've reached out to the doclava team to get some help.