### PR TITLE
Implemented IID Delete API

### DIFF
--- a/src/main/java/com/google/firebase/iid/FirebaseInstanceId.java
+++ b/src/main/java/com/google/firebase/iid/FirebaseInstanceId.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.iid;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpResponseInterceptor;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.JsonObjectParser;
+import com.google.api.core.ApiFuture;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.ImplFirebaseTrampolines;
+import com.google.firebase.internal.FirebaseService;
+import com.google.firebase.internal.NonNull;
+import com.google.firebase.internal.TaskToApiFuture;
+import com.google.firebase.tasks.Task;
+
+import java.util.concurrent.Callable;
+
+/**
+ * This class is the entry point for all server-side Firebase Instance ID actions.
+ *
+ * <p>Enables deleting instance IDs associated with Firebase projects.
+ */
+public class FirebaseInstanceId {
+
+  private static final String IID_SERVICE_URL = "https://console.firebase.google.com/v1";
+
+  private final FirebaseApp app;
+  private final HttpRequestFactory requestFactory;
+  private final JsonFactory jsonFactory;
+  private final String projectId;
+
+  private HttpResponseInterceptor interceptor;
+
+  private FirebaseInstanceId(FirebaseApp app) {
+    HttpTransport httpTransport = app.getOptions().getHttpTransport();
+    GoogleCredentials credentials = ImplFirebaseTrampolines.getCredentials(app);
+    this.app = app;
+    this.requestFactory = httpTransport.createRequestFactory(
+        new HttpCredentialsAdapter(credentials));
+    this.jsonFactory = app.getOptions().getJsonFactory();
+    this.projectId = ImplFirebaseTrampolines.getProjectId(app);
+    checkArgument(!Strings.isNullOrEmpty(projectId),
+        "Project ID is required to access instance ID service. Use a service account credential or "
+            + "set the project ID explicitly via FirebaseOptions. Alternatively you can also "
+            + "set the project ID via the GCLOUD_PROJECT environment variable.");
+  }
+
+  /**
+   * Gets the {@link FirebaseInstanceId} instance for the default {@link FirebaseApp}.
+   *
+   * @return The {@link FirebaseInstanceId} instance for the default {@link FirebaseApp}.
+   */
+  public static FirebaseInstanceId getInstance() {
+    return getInstance(FirebaseApp.getInstance());
+  }
+
+  /**
+   * Gets the {@link FirebaseInstanceId} instance for the specified {@link FirebaseApp}.
+   *
+   * @return The {@link FirebaseInstanceId} instance for the specified {@link FirebaseApp}.
+   */
+  public static synchronized FirebaseInstanceId getInstance(FirebaseApp app) {
+    FirebaseInstanceIdService service = ImplFirebaseTrampolines.getService(app, SERVICE_ID,
+        FirebaseInstanceIdService.class);
+    if (service == null) {
+      service = ImplFirebaseTrampolines.addService(app, new FirebaseInstanceIdService(app));
+    }
+    return service.getInstance();
+  }
+
+  @VisibleForTesting
+  void setInterceptor(HttpResponseInterceptor interceptor) {
+    this.interceptor = interceptor;
+  }
+
+  /**
+   * Deletes the specified instance ID from Firebase.
+   *
+   * <p>This can be used to delete an instance ID and associated user data from a Firebase project,
+   * pursuant to the General Data protection Regulation (GDPR).
+   *
+   * @param instanceId A non-null, non-empty instance ID string.
+   * @return An {@code ApiFuture} which will complete successfully when the instance ID is deleted,
+   *     or unsuccessfully with the failure Exception..
+   */
+  public ApiFuture<Void> deleteInstanceIdAsync(@NonNull String instanceId) {
+    return new TaskToApiFuture<>(deleteInstanceId(instanceId));
+  }
+
+  private Task<Void> deleteInstanceId(final String instanceId) {
+    checkArgument(!Strings.isNullOrEmpty(instanceId), "instance ID must not be null or empty");
+    return ImplFirebaseTrampolines.submitCallable(app, new Callable<Void>(){
+      @Override
+      public Void call() throws Exception {
+        String url = String.format(
+            "%s/project/%s/instanceId/%s", IID_SERVICE_URL, projectId, instanceId);
+        HttpRequest request = requestFactory.buildDeleteRequest(new GenericUrl(url));
+        request.setParser(new JsonObjectParser(jsonFactory));
+        request.setResponseInterceptor(interceptor);
+        HttpResponse response = null;
+        try {
+          response = request.execute();
+          response.parseAs(GenericJson.class);
+        } catch (Exception e) {
+          throw new FirebaseInstanceIdException("Error while invoking instance ID service", e);
+        } finally {
+          if (response != null) {
+            response.disconnect();
+          }
+        }
+        return null;
+      }
+    });
+  }
+
+  private static final String SERVICE_ID = FirebaseInstanceId.class.getName();
+
+  private static class FirebaseInstanceIdService extends FirebaseService<FirebaseInstanceId> {
+
+    FirebaseInstanceIdService(FirebaseApp app) {
+      super(SERVICE_ID, new FirebaseInstanceId(app));
+    }
+
+    @Override
+    public void destroy() {
+      // NOTE: We don't explicitly tear down anything here, but public methods of StorageClient
+      // will now fail because calls to getOptions() and getToken() will hit FirebaseApp,
+      // which will throw once the app is deleted.
+    }
+  }
+}

--- a/src/main/java/com/google/firebase/iid/FirebaseInstanceIdException.java
+++ b/src/main/java/com/google/firebase/iid/FirebaseInstanceIdException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.iid;
+
+import com.google.firebase.FirebaseException;
+
+/**
+ * Represents an exception encountered while interacting with the Firebase instance ID service.
+ */
+public class FirebaseInstanceIdException extends FirebaseException {
+
+  FirebaseInstanceIdException(String detailMessage, Throwable cause) {
+    super(detailMessage, cause);
+  }
+}

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -23,8 +23,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.api.client.http.HttpHeaders;
-import com.google.api.client.http.HttpResponse;
-import com.google.api.client.http.HttpResponseInterceptor;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
@@ -33,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.firebase.auth.UserRecord.CreateRequest;
 import com.google.firebase.auth.UserRecord.UpdateRequest;
 import com.google.firebase.internal.SdkUtils;
+import com.google.firebase.testing.TestResponseInterceptor;
 import com.google.firebase.testing.TestUtils;
 
 import java.io.IOException;
@@ -496,22 +495,12 @@ public class FirebaseUserManagerTest {
   }
 
   private void checkRequestHeaders(TestResponseInterceptor interceptor) {
-    HttpHeaders headers = interceptor.response.getRequest().getHeaders();
+    HttpHeaders headers = interceptor.getResponse().getRequest().getHeaders();
     String auth = "Bearer " + TEST_TOKEN;
     assertEquals(auth, headers.getFirstHeaderStringValue("Authorization"));
 
     String clientVersion = "Java/Admin/" + SdkUtils.getVersion();
     assertEquals(clientVersion, headers.getFirstHeaderStringValue("X-Client-Version"));
-  }
-
-  private static class TestResponseInterceptor implements HttpResponseInterceptor {
-
-    private HttpResponse response;
-
-    @Override
-    public void interceptResponse(HttpResponse response) throws IOException {
-      this.response = response;
-    }
   }
 
 }

--- a/src/test/java/com/google/firebase/iid/FirebaseInstanceIdIT.java
+++ b/src/test/java/com/google/firebase/iid/FirebaseInstanceIdIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.iid;
+
+import com.google.firebase.testing.IntegrationTestUtils;
+import java.util.concurrent.ExecutionException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class FirebaseInstanceIdIT {
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    IntegrationTestUtils.ensureDefaultApp();
+  }
+
+  @Test
+  public void testDeleteNonExisting() throws Exception {
+    FirebaseInstanceId instanceId = FirebaseInstanceId.getInstance();
+    try {
+      instanceId.deleteInstanceIdAsync("non-existing").get();
+    } catch (ExecutionException e) {
+      // TODO: Check for correct error message
+    }
+  }
+
+}

--- a/src/test/java/com/google/firebase/iid/FirebaseInstanceIdTest.java
+++ b/src/test/java/com/google/firebase/iid/FirebaseInstanceIdTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.iid;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.TestOnlyImplFirebaseTrampolines;
+import com.google.firebase.auth.MockGoogleCredentials;
+import com.google.firebase.testing.TestResponseInterceptor;
+import java.util.concurrent.ExecutionException;
+import org.junit.After;
+import org.junit.Test;
+
+public class FirebaseInstanceIdTest {
+
+  @After
+  public void tearDown() {
+    TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
+  }
+
+  @Test
+  public void testNoProjectId() {
+    FirebaseOptions options = new FirebaseOptions.Builder()
+        .setCredentials(new MockGoogleCredentials("test-token"))
+        .build();
+    FirebaseApp.initializeApp(options);
+    try {
+      FirebaseInstanceId.getInstance();
+      fail("No error thrown for missing project ID");
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testInvalidInstanceId() throws Exception {
+    FirebaseOptions options = new FirebaseOptions.Builder()
+        .setCredentials(new MockGoogleCredentials("test-token"))
+        .setProjectId("test-project")
+        .build();
+    FirebaseApp.initializeApp(options);
+
+    FirebaseInstanceId instanceId = FirebaseInstanceId.getInstance();
+    TestResponseInterceptor interceptor = new TestResponseInterceptor();
+    instanceId.setInterceptor(interceptor);
+    try {
+      instanceId.deleteInstanceIdAsync(null);
+      fail("No error thrown for null instance ID");
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+
+    try {
+      instanceId.deleteInstanceIdAsync("");
+      fail("No error thrown for empty instance ID");
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+
+    assertNull(interceptor.getResponse());
+  }
+
+  @Test
+  public void testDeleteInstanceId() throws Exception {
+    MockLowLevelHttpResponse response = new MockLowLevelHttpResponse().setContent("{}");
+    MockHttpTransport transport = new MockHttpTransport.Builder()
+        .setLowLevelHttpResponse(response)
+        .build();
+    FirebaseOptions options = new FirebaseOptions.Builder()
+        .setCredentials(new MockGoogleCredentials("test-token"))
+        .setProjectId("test-project")
+        .setHttpTransport(transport)
+        .build();
+    FirebaseApp app = FirebaseApp.initializeApp(options);
+
+    FirebaseInstanceId instanceId = FirebaseInstanceId.getInstance();
+    assertSame(instanceId, FirebaseInstanceId.getInstance(app));
+
+    TestResponseInterceptor interceptor = new TestResponseInterceptor();
+    instanceId.setInterceptor(interceptor);
+    instanceId.deleteInstanceIdAsync("test-iid").get();
+
+    assertNotNull(interceptor.getResponse());
+    HttpRequest request = interceptor.getResponse().getRequest();
+    assertEquals("DELETE", request.getRequestMethod());
+    String url = "https://console.firebase.google.com/v1/project/test-project/instanceId/test-iid";
+    assertEquals(url, request.getUrl().toString());
+    assertEquals("Bearer test-token", request.getHeaders().getAuthorization());
+  }
+
+  @Test
+  public void testDeleteInstanceIdError() throws Exception {
+    MockLowLevelHttpResponse response = new MockLowLevelHttpResponse()
+        .setStatusCode(500)
+        .setContent("{}");
+    MockHttpTransport transport = new MockHttpTransport.Builder()
+        .setLowLevelHttpResponse(response)
+        .build();
+    FirebaseOptions options = new FirebaseOptions.Builder()
+        .setCredentials(new MockGoogleCredentials("test-token"))
+        .setProjectId("test-project")
+        .setHttpTransport(transport)
+        .build();
+    FirebaseApp.initializeApp(options);
+
+    FirebaseInstanceId instanceId = FirebaseInstanceId.getInstance();
+    TestResponseInterceptor interceptor = new TestResponseInterceptor();
+    instanceId.setInterceptor(interceptor);
+    try {
+      instanceId.deleteInstanceIdAsync("test-iid").get();
+      fail("No error thrown for HTTP error");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof FirebaseInstanceIdException);
+      assertTrue(e.getCause().getCause() instanceof HttpResponseException);
+    }
+
+    assertNotNull(interceptor.getResponse());
+    HttpRequest request = interceptor.getResponse().getRequest();
+    assertEquals("DELETE", request.getRequestMethod());
+    String url = "https://console.firebase.google.com/v1/project/test-project/instanceId/test-iid";
+    assertEquals(url, request.getUrl().toString());
+    assertEquals("Bearer test-token", request.getHeaders().getAuthorization());
+  }
+
+
+}

--- a/src/test/java/com/google/firebase/testing/TestResponseInterceptor.java
+++ b/src/test/java/com/google/firebase/testing/TestResponseInterceptor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.testing;
+
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpResponseInterceptor;
+import java.io.IOException;
+
+/**
+ * Can be used to intercept HTTP requests and responses made by the SDK during tests.
+ */
+public class TestResponseInterceptor implements HttpResponseInterceptor {
+
+  private HttpResponse response;
+
+  @Override
+  public void interceptResponse(HttpResponse response) throws IOException {
+    this.response = response;
+  }
+
+  public HttpResponse getResponse() {
+    return response;
+  }
+}


### PR DESCRIPTION
A new API that enables deleting instance IDs associated with a Firebase project.

```
ApiFuture<Void> result = FirebaseInstanceId.getInstance().deleteInstanceIdAsync(iid);
```

go/firebase-admin-iid
