### PR TITLE
Fixed integration tests for auth

### DIFF
--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -183,7 +183,7 @@ public class FirebaseAuthIT {
     assertTrue(userRecord.getUserMetadata().getCreationTimestamp() > 0);
     assertEquals(0, userRecord.getUserMetadata().getLastSignInTimestamp());
     assertEquals(0, userRecord.getProviderData().length);
-    assertNull(userRecord.getCustomClaims());
+    assertTrue(userRecord.getCustomClaims().isEmpty());
 
     // Update user
     String randomId = UUID.randomUUID().toString().replaceAll("-", "");
@@ -206,7 +206,7 @@ public class FirebaseAuthIT {
     assertTrue(userRecord.isEmailVerified());
     assertFalse(userRecord.isDisabled());
     assertEquals(2, userRecord.getProviderData().length);
-    assertNull(userRecord.getCustomClaims());
+    assertTrue(userRecord.getCustomClaims().isEmpty());
 
     // Get user by email
     userRecord = auth.getUserByEmailAsync(userRecord.getEmail()).get();
@@ -227,7 +227,7 @@ public class FirebaseAuthIT {
     assertTrue(userRecord.isEmailVerified());
     assertTrue(userRecord.isDisabled());
     assertEquals(1, userRecord.getProviderData().length);
-    assertNull(userRecord.getCustomClaims());
+    assertTrue(userRecord.getCustomClaims().isEmpty());
 
     // Delete user
     auth.deleteUserAsync(userRecord.getUid()).get();
@@ -318,7 +318,7 @@ public class FirebaseAuthIT {
 
     try {
       // New user should not have any claims
-      assertNull(userRecord.getCustomClaims());
+      assertTrue(userRecord.getCustomClaims().isEmpty());
 
       Map<String, Object> expected = ImmutableMap.<String, Object>of(
           "admin", true, "package", "gold");
@@ -343,7 +343,7 @@ public class FirebaseAuthIT {
       // Should be able to remove custom claims
       auth.setCustomClaimsAsync(uid, null).get();
       updatedUser = auth.getUserAsync(uid).get();
-      assertNull(updatedUser.getCustomClaims());
+      assertTrue(updatedUser.getCustomClaims().isEmpty());
     } finally {
       auth.deleteUserAsync(uid).get();
     }


### PR DESCRIPTION
`getCustomClaims()` returns an empty map (not null) when there are no claims.