### PR TITLE
Improved error handling for user management API

### DIFF
--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -23,6 +23,7 @@ import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpResponseInterceptor;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.json.JsonHttpContent;
@@ -40,6 +41,7 @@ import com.google.firebase.auth.UserRecord.UpdateRequest;
 import com.google.firebase.auth.internal.DownloadAccountResponse;
 import com.google.firebase.auth.internal.GetAccountInfoResponse;
 
+import com.google.firebase.auth.internal.HttpErrorResponse;
 import com.google.firebase.internal.SdkUtils;
 import java.io.IOException;
 import java.util.List;
@@ -54,12 +56,27 @@ import java.util.Map;
  */
 class FirebaseUserManager {
 
-  static final String USER_NOT_FOUND_ERROR = "USER_NOT_FOUND_ERROR";
-  static final String USER_CREATE_ERROR = "USER_CREATE_ERROR";
-  static final String USER_UPDATE_ERROR = "USER_UPDATE_ERROR";
-  static final String USER_DELETE_ERROR = "USER_DELETE_ERROR";
-  static final String LIST_USERS_ERROR = "LIST_USERS_ERROR";
-  static final String INTERNAL_ERROR = "INTERNAL_ERROR";
+  static final String USER_NOT_FOUND_ERROR = "user-not-found";
+  static final String INTERNAL_ERROR = "internal-error";
+
+  // Map of server-side error codes to SDK error codes.
+  // SDK error codes defined at: https://firebase.google.com/docs/auth/admin/errors
+  private static final Map<String, String> ERROR_CODES = ImmutableMap.<String, String>builder()
+      .put("CLAIMS_TOO_LARGE", "claims-too-large")
+      .put("CONFIGURATION_NOT_FOUND", "project-not-found")
+      .put("INSUFFICIENT_PERMISSION", "insufficient-permission")
+      .put("DUPLICATE_EMAIL", "email-already-exists")
+      .put("DUPLICATE_LOCAL_ID", "uid-already-exists")
+      .put("EMAIL_EXISTS", "email-already-exists")
+      .put("INVALID_CLAIMS", "invalid-claims")
+      .put("INVALID_EMAIL", "invalid-email")
+      .put("INVALID_PAGE_SELECTION", "invalid-page-token")
+      .put("INVALID_PHONE_NUMBER", "invalid-phone-number")
+      .put("PHONE_NUMBER_EXISTS", "phone-number-already-exists")
+      .put("PROJECT_NOT_FOUND", "project-not-found")
+      .put("USER_NOT_FOUND", USER_NOT_FOUND_ERROR)
+      .put("WEAK_PASSWORD", "invalid-password")
+      .build();
 
   static final int MAX_LIST_USERS_RESULTS = 1000;
 
@@ -97,14 +114,8 @@ class FirebaseUserManager {
   UserRecord getUserById(String uid) throws FirebaseAuthException {
     final Map<String, Object> payload = ImmutableMap.<String, Object>of(
         "localId", ImmutableList.of(uid));
-    GetAccountInfoResponse response;
-    try {
-      response = post("getAccountInfo", payload, GetAccountInfoResponse.class);
-    } catch (IOException e) {
-      throw new FirebaseAuthException(INTERNAL_ERROR,
-          "IO error while retrieving user with ID: " + uid, e);
-    }
-
+    GetAccountInfoResponse response = post(
+        "getAccountInfo", payload, GetAccountInfoResponse.class);
     if (response == null || response.getUsers() == null || response.getUsers().isEmpty()) {
       throw new FirebaseAuthException(USER_NOT_FOUND_ERROR,
           "No user record found for the provided user ID: " + uid);
@@ -115,14 +126,8 @@ class FirebaseUserManager {
   UserRecord getUserByEmail(String email) throws FirebaseAuthException {
     final Map<String, Object> payload = ImmutableMap.<String, Object>of(
         "email", ImmutableList.of(email));
-    GetAccountInfoResponse response;
-    try {
-      response = post("getAccountInfo", payload, GetAccountInfoResponse.class);
-    } catch (IOException e) {
-      throw new FirebaseAuthException(INTERNAL_ERROR,
-          "IO error while retrieving user with email: " + email, e);
-    }
-
+    GetAccountInfoResponse response = post(
+        "getAccountInfo", payload, GetAccountInfoResponse.class);
     if (response == null || response.getUsers() == null || response.getUsers().isEmpty()) {
       throw new FirebaseAuthException(USER_NOT_FOUND_ERROR,
           "No user record found for the provided email: " + email);
@@ -133,14 +138,8 @@ class FirebaseUserManager {
   UserRecord getUserByPhoneNumber(String phoneNumber) throws FirebaseAuthException {
     final Map<String, Object> payload = ImmutableMap.<String, Object>of(
         "phoneNumber", ImmutableList.of(phoneNumber));
-    GetAccountInfoResponse response;
-    try {
-      response = post("getAccountInfo", payload, GetAccountInfoResponse.class);
-    } catch (IOException e) {
-      throw new FirebaseAuthException(INTERNAL_ERROR,
-          "IO error while retrieving user with phone number: " + phoneNumber, e);
-    }
-
+    GetAccountInfoResponse response = post(
+        "getAccountInfo", payload, GetAccountInfoResponse.class);
     if (response == null || response.getUsers() == null || response.getUsers().isEmpty()) {
       throw new FirebaseAuthException(USER_NOT_FOUND_ERROR,
           "No user record found for the provided phone number: " + phoneNumber);
@@ -149,50 +148,31 @@ class FirebaseUserManager {
   }
 
   String createUser(CreateRequest request) throws FirebaseAuthException {
-    GenericJson response;
-    try {
-      response = post("signupNewUser", request.getProperties(), GenericJson.class);
-    } catch (IOException e) {
-      throw new FirebaseAuthException(USER_CREATE_ERROR,
-          "IO error while creating user account", e);
-    }
-
+    GenericJson response = post(
+        "signupNewUser", request.getProperties(), GenericJson.class);
     if (response != null) {
       String uid = (String) response.get("localId");
       if (!Strings.isNullOrEmpty(uid)) {
         return uid;
       }
     }
-    throw new FirebaseAuthException(USER_CREATE_ERROR, "Failed to create new user");
+    throw new FirebaseAuthException(INTERNAL_ERROR, "Failed to create new user");
   }
 
   void updateUser(UpdateRequest request, JsonFactory jsonFactory) throws FirebaseAuthException {
-    GenericJson response;
-    try {
-      response = post("setAccountInfo", request.getProperties(jsonFactory), GenericJson.class);
-    } catch (IOException e) {
-      throw new FirebaseAuthException(USER_UPDATE_ERROR,
-          "IO error while updating user: " + request.getUid(), e);
-    }
-
+    GenericJson response = post(
+        "setAccountInfo", request.getProperties(jsonFactory), GenericJson.class);
     if (response == null || !request.getUid().equals(response.get("localId"))) {
-      throw new FirebaseAuthException(USER_UPDATE_ERROR,
-          "Failed to update user: " + request.getUid());
+      throw new FirebaseAuthException(INTERNAL_ERROR, "Failed to update user: " + request.getUid());
     }
   }
 
   void deleteUser(String uid) throws FirebaseAuthException {
     final Map<String, Object> payload = ImmutableMap.<String, Object>of("localId", uid);
-    GenericJson response;
-    try {
-      response = post("deleteAccount", payload, GenericJson.class);
-    } catch (IOException e) {
-      throw new FirebaseAuthException(USER_DELETE_ERROR,
-          "IO error while deleting user: " + uid, e);
-    }
+    GenericJson response = post(
+        "deleteAccount", payload, GenericJson.class);
     if (response == null || !response.containsKey("kind")) {
-      throw new FirebaseAuthException(USER_DELETE_ERROR,
-          "Failed to delete user: " + uid);
+      throw new FirebaseAuthException(INTERNAL_ERROR, "Failed to delete user: " + uid);
     }
   }
 
@@ -204,36 +184,61 @@ class FirebaseUserManager {
       builder.put("nextPageToken", pageToken);
     }
 
-    DownloadAccountResponse response;
-    try {
-      response = post("downloadAccount", builder.build(), DownloadAccountResponse.class);
-      if (response == null) {
-        throw new FirebaseAuthException(LIST_USERS_ERROR,
-            "Unexpected response from download user account API.");
-      }
-      return response;
-    } catch (IOException e) {
-      throw new FirebaseAuthException(LIST_USERS_ERROR,
-          "IO error while downloading user accounts.", e);
+    DownloadAccountResponse response = post(
+        "downloadAccount", builder.build(), DownloadAccountResponse.class);
+    if (response == null) {
+      throw new FirebaseAuthException(INTERNAL_ERROR,
+          "Unexpected response from download user account API.");
     }
+    return response;
   }
 
-  private <T> T post(String path, Object content, Class<T> clazz) throws IOException {
+  private <T> T post(String path, Object content, Class<T> clazz) throws FirebaseAuthException {
     checkArgument(!Strings.isNullOrEmpty(path), "path must not be null or empty");
     checkNotNull(content, "content must not be null");
     checkNotNull(clazz, "response class must not be null");
 
     GenericUrl url = new GenericUrl(ID_TOOLKIT_URL + path);
-    HttpRequest request = requestFactory.buildPostRequest(url,
-        new JsonHttpContent(jsonFactory, content));
-    request.setParser(new JsonObjectParser(jsonFactory));
-    request.getHeaders().set(CLIENT_VERSION_HEADER, clientVersion);
-    request.setResponseInterceptor(interceptor);
-    HttpResponse response = request.execute();
+    HttpResponse response = null;
     try {
+      HttpRequest request = requestFactory.buildPostRequest(url,
+          new JsonHttpContent(jsonFactory, content));
+      request.setParser(new JsonObjectParser(jsonFactory));
+      request.getHeaders().set(CLIENT_VERSION_HEADER, clientVersion);
+      request.setResponseInterceptor(interceptor);
+      response = request.execute();
       return response.parseAs(clazz);
+    } catch (HttpResponseException e) {
+      // Server responded with an HTTP error
+      handleHttpError(e);
+      return null;
+    } catch (IOException e) {
+      // All other IO errors (Connection refused, reset, parse error etc.)
+      throw new FirebaseAuthException(
+          INTERNAL_ERROR, "Error while calling user management backend service", e);
     } finally {
-      response.disconnect();
+      if (response != null) {
+        try {
+          response.disconnect();
+        } catch (IOException ignored) {
+          // Ignored
+        }
+      }
     }
+  }
+
+  private void handleHttpError(HttpResponseException e) throws FirebaseAuthException {
+    try {
+      HttpErrorResponse response = jsonFactory.fromString(e.getContent(), HttpErrorResponse.class);
+      String code = ERROR_CODES.get(response.getErrorCode());
+      if (code != null) {
+        throw new FirebaseAuthException(code, "User management service responded with an error", e);
+      }
+    } catch (IOException ignored) {
+      // Ignored
+    }
+    String msg = String.format(
+        "Unexpected HTTP response with status: %d; body: %s", e.getStatusCode(), e.getContent());
+    throw new FirebaseAuthException(INTERNAL_ERROR, msg, e);
   }
 }

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -187,8 +187,7 @@ class FirebaseUserManager {
     DownloadAccountResponse response = post(
         "downloadAccount", builder.build(), DownloadAccountResponse.class);
     if (response == null) {
-      throw new FirebaseAuthException(INTERNAL_ERROR,
-          "Unexpected response from download user account API.");
+      throw new FirebaseAuthException(INTERNAL_ERROR, "Failed to retrieve users.");
     }
     return response;
   }

--- a/src/main/java/com/google/firebase/auth/internal/HttpErrorResponse.java
+++ b/src/main/java/com/google/firebase/auth/internal/HttpErrorResponse.java
@@ -17,6 +17,7 @@
 package com.google.firebase.auth.internal;
 
 import com.google.api.client.util.Key;
+import com.google.common.base.Strings;
 
 /**
  * JSON data binding for JSON error messages sent by Google identity toolkit service.
@@ -28,7 +29,9 @@ public class HttpErrorResponse {
 
   public String getErrorCode() {
     if (error != null) {
-      return error.getCode();
+      if (!Strings.isNullOrEmpty(error.getCode())) {
+        return error.getCode();
+      }
     }
     return "unknown";
   }

--- a/src/main/java/com/google/firebase/auth/internal/HttpErrorResponse.java
+++ b/src/main/java/com/google/firebase/auth/internal/HttpErrorResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.auth.internal;
+
+import com.google.api.client.util.Key;
+
+/**
+ * JSON data binding for JSON error messages sent by Google identity toolkit service.
+ */
+public class HttpErrorResponse {
+
+  @Key("error")
+  private Error error;
+
+  public String getErrorCode() {
+    if (error != null) {
+      return error.getCode();
+    }
+    return "unknown";
+  }
+
+  public static class Error {
+
+    @Key("message")
+    private String code;
+
+    public String getCode() {
+      return code;
+    }
+  }
+
+}

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -100,7 +100,7 @@ public class FirebaseAuthIT {
       fail("No error thrown for non existing uid");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
-      assertEquals(FirebaseUserManager.USER_UPDATE_ERROR,
+      assertEquals(FirebaseUserManager.USER_NOT_FOUND_ERROR,
           ((FirebaseAuthException) e.getCause()).getErrorCode());
     }
   }
@@ -112,7 +112,7 @@ public class FirebaseAuthIT {
       fail("No error thrown for non existing uid");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
-      assertEquals(FirebaseUserManager.USER_DELETE_ERROR,
+      assertEquals(FirebaseUserManager.USER_NOT_FOUND_ERROR,
           ((FirebaseAuthException) e.getCause()).getErrorCode());
     }
   }
@@ -392,8 +392,7 @@ public class FirebaseAuthIT {
       fail("No error thrown for creating user with existing ID");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
-      assertEquals(FirebaseUserManager.USER_CREATE_ERROR,
-          ((FirebaseAuthException) e.getCause()).getErrorCode());
+      assertEquals("uid-already-exists", ((FirebaseAuthException) e.getCause()).getErrorCode());
     }
   }
 

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpResponseInterceptor;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
@@ -44,6 +45,7 @@ import com.google.firebase.testing.TestUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
@@ -295,66 +297,92 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testGetUserHttpError() throws Exception {
-    Map<UserManagerOp, String> operations = ImmutableMap.<UserManagerOp, String>builder()
-        .put(new UserManagerOp() {
+    List<UserManagerOp> operations = ImmutableList.<UserManagerOp>builder()
+        .add(new UserManagerOp() {
           @Override
           public void call(FirebaseUserManager userManager) throws Exception {
             userManager.getUserById("testuser");
           }
-        }, FirebaseUserManager.INTERNAL_ERROR)
-        .put(new UserManagerOp() {
+        })
+        .add(new UserManagerOp() {
           @Override
           public void call(FirebaseUserManager userManager) throws Exception {
             userManager.getUserByEmail("testuser@example.com");
           }
-        }, FirebaseUserManager.INTERNAL_ERROR)
-        .put(new UserManagerOp() {
+        })
+        .add(new UserManagerOp() {
           @Override
           public void call(FirebaseUserManager userManager) throws Exception {
             userManager.getUserByPhoneNumber("+1234567890");
           }
-        }, FirebaseUserManager.INTERNAL_ERROR)
-        .put(new UserManagerOp() {
+        })
+        .add(new UserManagerOp() {
           @Override
           public void call(FirebaseUserManager userManager) throws Exception {
             userManager.createUser(new CreateRequest());
           }
-        }, FirebaseUserManager.USER_CREATE_ERROR)
-        .put(new UserManagerOp() {
+        })
+        .add(new UserManagerOp() {
           @Override
           public void call(FirebaseUserManager userManager) throws Exception {
             userManager.updateUser(new UpdateRequest("test"), Utils.getDefaultJsonFactory());
           }
-        }, FirebaseUserManager.USER_UPDATE_ERROR)
-        .put(new UserManagerOp() {
+        })
+        .add(new UserManagerOp() {
           @Override
           public void call(FirebaseUserManager userManager) throws Exception {
             userManager.deleteUser("testuser");
           }
-        }, FirebaseUserManager.USER_DELETE_ERROR)
+        })
+        .add(new UserManagerOp() {
+          @Override
+          public void call(FirebaseUserManager userManager) throws Exception {
+            userManager.listUsers(1000, null);
+          }
+        })
         .build();
+
+    MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+    MockHttpTransport transport = new MockHttpTransport.Builder()
+        .setLowLevelHttpResponse(response)
+        .build();
+    FirebaseUserManager userManager = new FirebaseUserManager(gson, transport, credentials);
+
+    // Test for common HTTP error codes
     for (int code : ImmutableList.of(302, 400, 401, 404, 500)) {
-      MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
-      response.setContent("{}");
-      response.setStatusCode(code);
-      MockHttpTransport transport = new MockHttpTransport.Builder()
-          .setLowLevelHttpResponse(response)
-          .build();
-      FirebaseUserManager userManager = new FirebaseUserManager(gson, transport, credentials);
-      for (Map.Entry<UserManagerOp, String> entry : operations.entrySet()) {
+      for (UserManagerOp operation : operations) {
+        // Need to reset these every iteration
+        response.setContent("{}");
+        response.setStatusCode(code);
         try {
-          entry.getKey().call(userManager);
+          operation.call(userManager);
           fail("No error thrown for HTTP error");
         }  catch (FirebaseAuthException e) {
-          assertTrue(e.getCause() instanceof IOException);
-          assertEquals(entry.getValue(), e.getErrorCode());
+          String msg = String.format("Unexpected HTTP response with status: %d; body: {}", code);
+          assertEquals(msg, e.getMessage());
+          assertTrue(e.getCause() instanceof HttpResponseException);
+          assertEquals(FirebaseUserManager.INTERNAL_ERROR, e.getErrorCode());
         }
+      }
+    }
+
+    // Test error payload parsing
+    for (UserManagerOp operation : operations) {
+      response.setContent("{\"error\": {\"message\": \"USER_NOT_FOUND\"}}");
+      response.setStatusCode(500);
+      try {
+        operation.call(userManager);
+        fail("No error thrown for HTTP error");
+      }  catch (FirebaseAuthException e) {
+        assertEquals("User management service responded with an error", e.getMessage());
+        assertTrue(e.getCause() instanceof HttpResponseException);
+        assertEquals(FirebaseUserManager.USER_NOT_FOUND_ERROR, e.getErrorCode());
       }
     }
   }
 
   @Test
-  public void testGetUserJsonError() throws Exception {
+  public void testGetUserMalformedJsonError() throws Exception {
     MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
     response.setContent("{\"not\" json}");
     MockHttpTransport transport = new MockHttpTransport.Builder()
@@ -366,6 +394,27 @@ public class FirebaseUserManagerTest {
       fail("No error thrown for JSON error");
     }  catch (FirebaseAuthException e) {
       assertTrue(e.getCause() instanceof IOException);
+      assertEquals(FirebaseUserManager.INTERNAL_ERROR, e.getErrorCode());
+    }
+  }
+
+  @Test
+  public void testGetUserUnexpectedHttpError() throws Exception {
+    MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+    response.setContent("{\"not\" json}");
+    response.setStatusCode(500);
+    MockHttpTransport transport = new MockHttpTransport.Builder()
+        .setLowLevelHttpResponse(response)
+        .build();
+    FirebaseUserManager userManager = new FirebaseUserManager(gson, transport, credentials);
+    try {
+      userManager.getUserById("testuser");
+      fail("No error thrown for JSON error");
+    }  catch (FirebaseAuthException e) {
+      assertTrue(e.getCause() instanceof HttpResponseException);
+      assertEquals("Unexpected HTTP response with status: 500; body: {\"not\" json}",
+          e.getMessage());
+      assertEquals(FirebaseUserManager.INTERNAL_ERROR, e.getErrorCode());
     }
   }
 


### PR DESCRIPTION
User management API currently returns a set of custom error codes specific to Java Admin SDK. This PR changes the implementation to:
* parse the error messages/codes sent by the ID toolkit backend service, and
* map errors to [well-defined](https://firebase.google.com/docs/auth/admin/errors) Admin SDK error codes.


