### PR TITLE
Fixing an issue with application default credentials during tests

### DIFF
--- a/src/test/java/com/google/firebase/FirebaseAppTest.java
+++ b/src/test/java/com/google/firebase/FirebaseAppTest.java
@@ -58,6 +58,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -74,17 +75,9 @@ public class FirebaseAppTest {
 
   @Rule public FirebaseAppRule firebaseAppRule = new FirebaseAppRule();
 
-  private static FirebaseOptions getMockCredentialOptions() {
-    return new Builder().setCredentials(new MockGoogleCredentials()).build();
-  }
-
-  private static void invokePublicInstanceMethodWithDefaultValues(Object instance, Method method)
-      throws InvocationTargetException, IllegalAccessException {
-    List<Object> parameters = new ArrayList<>(method.getParameterTypes().length);
-    for (Class<?> parameterType : method.getParameterTypes()) {
-      parameters.add(Defaults.defaultValue(parameterType));
-    }
-    method.invoke(instance, parameters.toArray());
+  @BeforeClass
+  public static void setupClass() throws IOException {
+    TestUtils.getApplicationDefaultCredentials();
   }
 
   @Test(expected = NullPointerException.class)
@@ -539,19 +532,30 @@ public class FirebaseAppTest {
   public void testFirebaseExceptionEmptyDetail() {
     new FirebaseException("");
   }
-  
 
-  private void setFirebaseConfigEnvironmentVariable(String configJSON) {
-    String configValue = "";
+  private static void setFirebaseConfigEnvironmentVariable(String configJSON) {
+    String configValue;
     if (configJSON.isEmpty() || configJSON.startsWith("{")) {
       configValue = configJSON;
     } else {
-      configValue  = new File("src/test/resources/" + configJSON)
-                   .getAbsolutePath();
+      configValue = new File("src/test/resources", configJSON).getAbsolutePath();
     }
     Map<String, String> environmentVariables =
         ImmutableMap.of(FirebaseApp.FIREBASE_CONFIG_ENV_VAR , configValue);
     TestUtils.setEnvironmentVariables(environmentVariables);
+  }
+
+  private static FirebaseOptions getMockCredentialOptions() {
+    return new Builder().setCredentials(new MockGoogleCredentials()).build();
+  }
+
+  private static void invokePublicInstanceMethodWithDefaultValues(Object instance, Method method)
+      throws InvocationTargetException, IllegalAccessException {
+    List<Object> parameters = new ArrayList<>(method.getParameterTypes().length);
+    for (Class<?> parameterType : method.getParameterTypes()) {
+      parameters.add(Defaults.defaultValue(parameterType));
+    }
+    method.invoke(instance, parameters.toArray());
   }
 
   private static class MockTokenRefresher extends TokenRefresher {

--- a/src/test/java/com/google/firebase/auth/FirebaseCredentialsTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseCredentialsTest.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -59,6 +60,11 @@ public class FirebaseCredentialsTest {
   private static final JsonFactory JSON_FACTORY = Utils.getDefaultJsonFactory();
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @BeforeClass
+  public static void setupClass() throws IOException {
+    TestUtils.getApplicationDefaultCredentials();
+  }
 
   @Test(expected = NullPointerException.class)
   public void testNullCertificate() throws IOException {
@@ -88,7 +94,7 @@ public class FirebaseCredentialsTest {
     FirebaseCredential credential = FirebaseCredentials.applicationDefault(
         transport, Utils.getDefaultJsonFactory());
     GoogleOAuthAccessToken token = Tasks.await(credential.getAccessToken());
-    Assert.assertEquals(ACCESS_TOKEN, token.getAccessToken());
+    Assert.assertEquals(TestUtils.TEST_ADC_ACCESS_TOKEN, token.getAccessToken());
     Assert.assertNotNull(((BaseCredential) credential).getGoogleCredentials());
 
     // We should still be able to fetch the token since the certificate is cached
@@ -96,7 +102,7 @@ public class FirebaseCredentialsTest {
     credential = FirebaseCredentials.applicationDefault(transport, Utils.getDefaultJsonFactory());
     token = Tasks.await(credential.getAccessToken());
     Assert.assertNotNull(token);
-    Assert.assertEquals(ACCESS_TOKEN, token.getAccessToken());
+    Assert.assertEquals(TestUtils.TEST_ADC_ACCESS_TOKEN, token.getAccessToken());
     Assert.assertNotNull(((BaseCredential) credential).getGoogleCredentials());
   }
 

--- a/src/test/java/com/google/firebase/auth/FirebaseCredentialsTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseCredentialsTest.java
@@ -78,28 +78,14 @@ public class FirebaseCredentialsTest {
 
   @Test
   public void defaultCredentialDoesntRefetch() throws Exception {
-    MockTokenServerTransport transport = new MockTokenServerTransport();
-    transport.addServiceAccount(ServiceAccount.EDITOR.getEmail(), ACCESS_TOKEN);
-
-    File credentialsFile = File.createTempFile("google-test-credentials", "json");
-    PrintWriter writer = new PrintWriter(Files.newBufferedWriter(credentialsFile.toPath(), UTF_8));
-    writer.print(ServiceAccount.EDITOR.asString());
-    writer.close();
-    Map<String, String> environmentVariables =
-        ImmutableMap.<String, String>builder()
-            .put("GOOGLE_APPLICATION_CREDENTIALS", credentialsFile.getAbsolutePath())
-            .build();
-    TestUtils.setEnvironmentVariables(environmentVariables);
-
     FirebaseCredential credential = FirebaseCredentials.applicationDefault(
-        transport, Utils.getDefaultJsonFactory());
+        Utils.getDefaultTransport(), Utils.getDefaultJsonFactory());
     GoogleOAuthAccessToken token = Tasks.await(credential.getAccessToken());
     Assert.assertEquals(TestUtils.TEST_ADC_ACCESS_TOKEN, token.getAccessToken());
     Assert.assertNotNull(((BaseCredential) credential).getGoogleCredentials());
 
     // We should still be able to fetch the token since the certificate is cached
-    Assert.assertTrue(credentialsFile.delete());
-    credential = FirebaseCredentials.applicationDefault(transport, Utils.getDefaultJsonFactory());
+    credential = FirebaseCredentials.applicationDefault();
     token = Tasks.await(credential.getAccessToken());
     Assert.assertNotNull(token);
     Assert.assertEquals(TestUtils.TEST_ADC_ACCESS_TOKEN, token.getAccessToken());


### PR DESCRIPTION
ADC are essentially singletons. Therefore whatever the test case that initializes it first wins. Now that we have at least 2 separate test classes that use ADC, we need a way to ensure that they don't conflict. This fix takes care of that.