### PR TITLE
Preventing possible runtime errors due to Guava version conflicts

### DIFF
--- a/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/src/main/java/com/google/firebase/FirebaseApp.java
@@ -371,6 +371,10 @@ public class FirebaseApp {
   }
 
   private void checkNotDeleted() {
+    // Wrap the name argument in an array to ensure the invocation gets bound to the commonly
+    // available checkState(boolean, String, Object...) overload. Otherwise the invocation may
+    // get bound to the checkState(boolean, String, Object) overload, which is not present in older
+    // guava versions.
     checkState(!deleted.get(), "FirebaseApp '%s' was deleted", new Object[]{name});
   }
 

--- a/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/src/main/java/com/google/firebase/FirebaseApp.java
@@ -371,7 +371,7 @@ public class FirebaseApp {
   }
 
   private void checkNotDeleted() {
-    checkState(!deleted.get(), "FirebaseApp was deleted %s", this);
+    checkState(!deleted.get(), "FirebaseApp '%s' was deleted", new Object[]{name});
   }
 
   private ScheduledExecutorService ensureScheduledExecutorService() {


### PR DESCRIPTION
We currently have the following state assertion in the `FirebaseApp` class:

```
checkState(!deleted.get(), "FirebaseApp '%s' was deleted", this);
```

With guava 20.0 (which is what we depend on), the above invocation gets bound to the following method signature at the compile time:

```
checkState(boolean, String, Object)
```
[API ref](https://google.github.io/guava/releases/20.0/api/docs/com/google/common/base/Preconditions.html#checkState-boolean-java.lang.String-java.lang.Object-)

This signature, it seems, is not present in some of the guava versions out there. It is notably absent in all guava distributions older than 20.0, and also from some of the other backports in circulation such as `guava-jdk5`. As a result, when there are conflicting guava binaries in an application classpath a developer may experience the following error:

```
Exception in thread "main" java.lang.NoSuchMethodError: com.google.common.base.Preconditions.checkState(ZLjava/lang/String;Ljava/lang/Object;)V
	at com.google.firebase.FirebaseApp.checkNotDeleted(FirebaseApp.java:374)
	at com.google.firebase.FirebaseApp.getOptions(FirebaseApp.java:289)
	at com.google.firebase.FirebaseApp$TokenRefresher.<init>(FirebaseApp.java:456)
	at com.google.firebase.FirebaseApp$TokenRefresher$Factory.create(FirebaseApp.java:557)
	at com.google.firebase.FirebaseApp.<init>(FirebaseApp.java:120)
	at com.google.firebase.FirebaseApp.initializeApp(FirebaseApp.java:223)
	at com.google.firebase.FirebaseApp.initializeApp(FirebaseApp.java:210)
	at com.google.firebase.FirebaseApp.initializeApp(FirebaseApp.java:190)
	at com.test.Main.main(Main.java:12)
```

Note: I reproduced the above easily by adding both `firebase-admin` and `google-api-client` into the classpath. The latter depends on `guava-jdk5`.

While it is often possible to resolve this error by curating the project classpath (i.e. excluding the conflicting guava versions from the project), this is tedious as well as results in a piss poor getting started experience for some developers.

The suggested fix forces the state assertion to get bound to the following signature:

```
checkState(boolean, String, Object...)
```
[API ref](https://google.github.io/guava/releases/20.0/api/docs/com/google/common/base/Preconditions.html#checkState-boolean-java.lang.String-java.lang.Object...-)

This signature is present in guava versions as old as 12.0, and also present in the common backports like `guava-jdk5`. Therefore it doesn't result in the `NoSuchMethodError` that many developers appear to be hitting. I was able to resolve the error in my repro with this fix, without having to use any Maven dependency exclusions.