### PR TITLE
Logging any errors encountered while executing a DB event handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   method now throws a clear exception when invoked with a bucket URL
   instead of the name.
 
+### Realtime Database
+
+- [fixed] Exceptions thrown by database event handlers are now logged.
+
 # v5.8.0
 
 ### Initialization

--- a/src/main/java/com/google/firebase/database/core/ThreadPoolEventTarget.java
+++ b/src/main/java/com/google/firebase/database/core/ThreadPoolEventTarget.java
@@ -24,9 +24,13 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** ThreadPoolEventTarget is an event target using a configurable threadpool. */
 class ThreadPoolEventTarget implements EventTarget, UncaughtExceptionHandler {
+
+  private static final Logger logger = LoggerFactory.getLogger(ThreadPoolEventTarget.class);
 
   private final ThreadPoolExecutor executor;
   private UncaughtExceptionHandler exceptionHandler;
@@ -92,8 +96,12 @@ class ThreadPoolEventTarget implements EventTarget, UncaughtExceptionHandler {
     synchronized (this) {
       delegate = exceptionHandler;
     }
-    if (delegate != null) {
-      delegate.uncaughtException(t, e);
+    try {
+      if (delegate != null) {
+        delegate.uncaughtException(t, e);
+      }
+    } finally {
+      logger.error("Event handler threw an exception", e);
     }
   }
 }

--- a/src/main/java/com/google/firebase/database/core/ThreadPoolEventTarget.java
+++ b/src/main/java/com/google/firebase/database/core/ThreadPoolEventTarget.java
@@ -92,11 +92,11 @@ class ThreadPoolEventTarget implements EventTarget, UncaughtExceptionHandler {
 
   @Override
   public void uncaughtException(Thread t, Throwable e) {
-    UncaughtExceptionHandler delegate;
-    synchronized (this) {
-      delegate = exceptionHandler;
-    }
     try {
+      UncaughtExceptionHandler delegate;
+      synchronized (this) {
+        delegate = exceptionHandler;
+      }
       if (delegate != null) {
         delegate.uncaughtException(t, e);
       }

--- a/src/test/java/com/google/firebase/database/TestHelpers.java
+++ b/src/test/java/com/google/firebase/database/TestHelpers.java
@@ -34,7 +34,6 @@ import com.google.firebase.database.future.WriteFuture;
 import com.google.firebase.database.logging.DefaultLogger;
 import com.google.firebase.database.logging.Logger.Level;
 import com.google.firebase.database.snapshot.ChildKey;
-import com.google.firebase.database.util.GAuthToken;
 import com.google.firebase.database.util.JsonMapper;
 import com.google.firebase.database.utilities.DefaultRunLoop;
 import com.google.firebase.internal.NonNull;
@@ -283,7 +282,7 @@ public class TestHelpers {
    * the wrapForErrorHandling method. Invoke this method in integration tests from an After
    * test fixture.
    *
-   * @param app AFireabseApp instance already instrumented by wrapForErrorHandling
+   * @param app A FirebaseApp instance already instrumented by wrapForErrorHandling
    */
   public static void assertAndUnwrapErrorHandlers(FirebaseApp app) {
     DatabaseConfig context = getDatabaseConfig(app);


### PR DESCRIPTION
Logging errors thrown by event handlers. Resolves #79. Without this errors thrown by event handlers are silently discarded.

### Example code:
```
ref.addListenerForSingleValueEvent(new ValueEventListener() {
      @Override
      public void onDataChange(DataSnapshot snapshot) {
        throw new RuntimeException("test error");
      }

      @Override
      public void onCancelled(DatabaseError error) {
      }
    });
```

### Log:
```
[FirebaseDatabaseEventTarget] ERROR com.google.firebase.database.core.ThreadPoolEventTarget - Event handler threw an exception
java.lang.RuntimeException: test error
	at com.google.firebase.database.integration.EventTestIT$17.onDataChange(EventTestIT.java:1160)
	at com.google.firebase.database.Query$1.onDataChange(Query.java:182)
	at com.google.firebase.database.core.ValueEventRegistration.fireEvent(ValueEventRegistration.java:77)
	at com.google.firebase.database.core.view.DataEvent.fire(DataEvent.java:65)
	at com.google.firebase.database.core.view.EventRaiser$1.run(EventRaiser.java:58)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```