### PR TITLE
Accept prefixed topic names

### DIFF
--- a/src/main/java/com/google/firebase/messaging/Message.java
+++ b/src/main/java/com/google/firebase/messaging/Message.java
@@ -68,19 +68,25 @@ public class Message {
     this.androidConfig = builder.androidConfig;
     this.webpushConfig = builder.webpushConfig;
     this.apnsConfig = builder.apnsConfig;
+
+    String unprefixedTopic = null;
+    if (builder.topic != null) {
+      if (builder.topic.startsWith("/topics/")) {
+        unprefixedTopic = builder.topic.replaceFirst("^/topics/", "");
+      } else {
+        unprefixedTopic = builder.topic;
+      }
+      checkArgument(unprefixedTopic.matches("[a-zA-Z0-9-_.~%]+"), "Malformed topic name");
+    }
+
     int count = Booleans.countTrue(
         !Strings.isNullOrEmpty(builder.token),
-        !Strings.isNullOrEmpty(builder.topic),
+        !Strings.isNullOrEmpty(unprefixedTopic),
         !Strings.isNullOrEmpty(builder.condition)
     );
     checkArgument(count == 1, "Exactly one of token, topic or condition must be specified");
-    if (builder.topic != null) {
-      checkArgument(!builder.topic.startsWith("/topics/"),
-          "Topic name must not contain the /topics/ prefix");
-      checkArgument(builder.topic.matches("[a-zA-Z0-9-_.~%]+"), "Malformed topic name");
-    }
     this.token = builder.token;
-    this.topic = builder.topic;
+    this.topic = unprefixedTopic;
     this.condition = builder.condition;
   }
 

--- a/src/main/java/com/google/firebase/messaging/Message.java
+++ b/src/main/java/com/google/firebase/messaging/Message.java
@@ -169,10 +169,10 @@ public class Message {
     }
 
     /**
-     * Sets the name of the FCM topic to which the message should be sent. Topic names must
-     * not contain the {@code /topics/} prefix.
+     * Sets the name of the FCM topic to which the message should be sent. Topic names may
+     * contain the {@code /topics/} prefix.
      *
-     * @param topic A valid topic name excluding the {@code /topics/} prefix.
+     * @param topic A valid topic name.
      * @return This builder.
      */
     public Builder setTopic(String topic) {

--- a/src/main/java/com/google/firebase/messaging/Message.java
+++ b/src/main/java/com/google/firebase/messaging/Message.java
@@ -68,26 +68,27 @@ public class Message {
     this.androidConfig = builder.androidConfig;
     this.webpushConfig = builder.webpushConfig;
     this.apnsConfig = builder.apnsConfig;
-
-    String unprefixedTopic = null;
-    if (builder.topic != null) {
-      if (builder.topic.startsWith("/topics/")) {
-        unprefixedTopic = builder.topic.replaceFirst("^/topics/", "");
-      } else {
-        unprefixedTopic = builder.topic;
-      }
-      checkArgument(unprefixedTopic.matches("[a-zA-Z0-9-_.~%]+"), "Malformed topic name");
-    }
-
     int count = Booleans.countTrue(
         !Strings.isNullOrEmpty(builder.token),
-        !Strings.isNullOrEmpty(unprefixedTopic),
+        !Strings.isNullOrEmpty(builder.topic),
         !Strings.isNullOrEmpty(builder.condition)
     );
     checkArgument(count == 1, "Exactly one of token, topic or condition must be specified");
     this.token = builder.token;
-    this.topic = unprefixedTopic;
+    this.topic = stripPrefix(builder.topic);
     this.condition = builder.condition;
+  }
+
+  private static String stripPrefix(String topic) {
+    if (Strings.isNullOrEmpty(topic)) {
+      return null;
+    }
+    if (topic.startsWith("/topics/")) {
+      topic = topic.replaceFirst("^/topics/", "");
+    }
+    // Checks for illegal characters and empty string.
+    checkArgument(topic.matches("[a-zA-Z0-9-_.~%]+"), "Malformed topic name");
+    return topic;
   }
 
   /**

--- a/src/test/java/com/google/firebase/messaging/MessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MessageTest.java
@@ -63,6 +63,18 @@ public class MessageTest {
   }
 
   @Test
+  public void testInvalidTopicNames() {
+    List<String> invalidTopicNames = ImmutableList.of("/topics/", "/foo/bar", "foo bar");
+    for (String topicName : invalidTopicNames) {
+      try {
+        Message.builder().setTopic(topicName).build();
+      } catch (IllegalArgumentException expected) {
+        // expected
+      }
+    }
+  }
+
+  @Test
   public void testPrefixedTopicName() throws IOException {
     Message message = Message.builder()
         .setTopic("/topics/test-topic")

--- a/src/test/java/com/google/firebase/messaging/MessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MessageTest.java
@@ -63,6 +63,14 @@ public class MessageTest {
   }
 
   @Test
+  public void testPrefixedTopicName() throws IOException {
+    Message message = Message.builder()
+        .setTopic("/topics/test-topic")
+        .build();
+    assertJsonEquals(ImmutableMap.of("topic", "test-topic"), message);
+  }
+
+  @Test
   public void testNotificationMessage() throws IOException {
     Message message = Message.builder()
         .setNotification(new Notification("title", "body"))


### PR DESCRIPTION
The new FCM API does not accept topic names prefixed with `/topics/`. But we can easily check for this in the SDK and remove it. This results in a better and consistent dev experience since the other methods in this API accepts prefixed topic names.
