### PR TITLE
Improved Auth Unit Test Coverage

### DIFF
--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -40,7 +40,6 @@ import com.google.firebase.internal.FirebaseService;
 import com.google.firebase.internal.Nullable;
 import com.google.firebase.internal.TaskToApiFuture;
 import com.google.firebase.tasks.Task;
-import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -606,6 +605,11 @@ public class FirebaseAuth {
 
   private <T> Task<T> call(Callable<T> command) {
     return ImplFirebaseTrampolines.submitCallable(firebaseApp, command);
+  }
+
+  @VisibleForTesting
+  FirebaseUserManager getUserManager() {
+    return this.userManager;
   }
 
   private void checkNotDestroyed() {

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -67,12 +67,9 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testGetUser() throws Exception {
-    initializeAppForUserManagement(TestUtils.loadResource("getUser.json"));
-    FirebaseAuth auth = FirebaseAuth.getInstance();
-    FirebaseUserManager userManager = auth.getUserManager();
-    TestResponseInterceptor interceptor = new TestResponseInterceptor();
-    userManager.setInterceptor(interceptor);
-    UserRecord userRecord = auth.getUserAsync("testuser").get();
+    TestResponseInterceptor interceptor = initializeAppForUserManagement(
+        TestUtils.loadResource("getUser.json"));
+    UserRecord userRecord = FirebaseAuth.getInstance().getUserAsync("testuser").get();
     checkUserRecord(userRecord);
     checkRequestHeaders(interceptor);
   }
@@ -80,9 +77,8 @@ public class FirebaseUserManagerTest {
   @Test
   public void testGetUserWithNotFoundError() throws Exception {
     initializeAppForUserManagement(TestUtils.loadResource("getUserError.json"));
-    FirebaseAuth auth = FirebaseAuth.getInstance();
     try {
-      auth.getUserAsync("testuser").get();
+      FirebaseAuth.getInstance().getUserAsync("testuser").get();
       fail("No error thrown for invalid response");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -93,12 +89,10 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testGetUserByEmail() throws Exception {
-    initializeAppForUserManagement(TestUtils.loadResource("getUser.json"));
-    FirebaseAuth auth = FirebaseAuth.getInstance();
-    FirebaseUserManager userManager = auth.getUserManager();
-    TestResponseInterceptor interceptor = new TestResponseInterceptor();
-    userManager.setInterceptor(interceptor);
-    UserRecord userRecord = auth.getUserByEmailAsync("testuser@example.com").get();
+    TestResponseInterceptor interceptor = initializeAppForUserManagement(
+        TestUtils.loadResource("getUser.json"));
+    UserRecord userRecord = FirebaseAuth.getInstance()
+        .getUserByEmailAsync("testuser@example.com").get();
     checkUserRecord(userRecord);
     checkRequestHeaders(interceptor);
   }
@@ -106,9 +100,8 @@ public class FirebaseUserManagerTest {
   @Test
   public void testGetUserByEmailWithNotFoundError() throws Exception {
     initializeAppForUserManagement(TestUtils.loadResource("getUserError.json"));
-    FirebaseAuth auth = FirebaseAuth.getInstance();
     try {
-      auth.getUserByEmailAsync("testuser@example.com").get();
+      FirebaseAuth.getInstance().getUserByEmailAsync("testuser@example.com").get();
       fail("No error thrown for invalid response");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -119,12 +112,10 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testGetUserByPhoneNumber() throws Exception {
-    initializeAppForUserManagement(TestUtils.loadResource("getUser.json"));
-    FirebaseAuth auth = FirebaseAuth.getInstance();
-    FirebaseUserManager userManager = auth.getUserManager();
-    TestResponseInterceptor interceptor = new TestResponseInterceptor();
-    userManager.setInterceptor(interceptor);
-    UserRecord userRecord = auth.getUserByPhoneNumberAsync("+1234567890").get();
+    TestResponseInterceptor interceptor = initializeAppForUserManagement(
+        TestUtils.loadResource("getUser.json"));
+    UserRecord userRecord = FirebaseAuth.getInstance()
+        .getUserByPhoneNumberAsync("+1234567890").get();
     checkUserRecord(userRecord);
     checkRequestHeaders(interceptor);
   }
@@ -132,9 +123,8 @@ public class FirebaseUserManagerTest {
   @Test
   public void testGetUserByPhoneNumberWithNotFoundError() throws Exception {
     initializeAppForUserManagement(TestUtils.loadResource("getUserError.json"));
-    FirebaseAuth auth = FirebaseAuth.getInstance();
     try {
-      auth.getUserByPhoneNumberAsync("+1234567890").get();
+      FirebaseAuth.getInstance().getUserByPhoneNumberAsync("+1234567890").get();
       fail("No error thrown for invalid response");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -145,13 +135,9 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testListUsers() throws Exception {
-    initializeAppForUserManagement(TestUtils.loadResource("listUsers.json"));
-    FirebaseAuth auth = FirebaseAuth.getInstance();
-    FirebaseUserManager userManager = auth.getUserManager();
-    TestResponseInterceptor interceptor = new TestResponseInterceptor();
-    userManager.setInterceptor(interceptor);
-
-    ListUsersPage page = auth.listUsersAsync(null, 999).get();
+    final TestResponseInterceptor interceptor = initializeAppForUserManagement(
+        TestUtils.loadResource("listUsers.json"));
+    ListUsersPage page = FirebaseAuth.getInstance().listUsersAsync(null, 999).get();
     assertEquals(2, Iterables.size(page.getValues()));
     for (ExportedUserRecord userRecord : page.getValues()) {
       checkUserRecord(userRecord);
@@ -171,13 +157,9 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testListUsersWithPageToken() throws Exception {
-    initializeAppForUserManagement(TestUtils.loadResource("listUsers.json"));
-    FirebaseAuth auth = FirebaseAuth.getInstance();
-    FirebaseUserManager userManager = auth.getUserManager();
-    TestResponseInterceptor interceptor = new TestResponseInterceptor();
-    userManager.setInterceptor(interceptor);
-
-    ListUsersPage page = auth.listUsersAsync("token", 999).get();
+    final TestResponseInterceptor interceptor = initializeAppForUserManagement(
+        TestUtils.loadResource("listUsers.json"));
+    ListUsersPage page = FirebaseAuth.getInstance().listUsersAsync("token", 999).get();
     assertEquals(2, Iterables.size(page.getValues()));
     for (ExportedUserRecord userRecord : page.getValues()) {
       checkUserRecord(userRecord);
@@ -197,56 +179,42 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testListZeroUsers() throws Exception {
-    initializeAppForUserManagement("{}");
-    FirebaseAuth auth = FirebaseAuth.getInstance();
-    FirebaseUserManager userManager = auth.getUserManager();
-    TestResponseInterceptor interceptor = new TestResponseInterceptor();
-    userManager.setInterceptor(interceptor);
-    ListUsersPage page = auth.listUsersAsync(null).get();
-    assertEquals(0, Iterables.size(page.getValues()));
+    TestResponseInterceptor interceptor = initializeAppForUserManagement("{}");
+    ListUsersPage page = FirebaseAuth.getInstance().listUsersAsync(null).get();
+    assertTrue(Iterables.isEmpty(page.getValues()));
     assertEquals("", page.getNextPageToken());
     checkRequestHeaders(interceptor);
   }
 
   @Test
   public void testCreateUser() throws Exception {
-    initializeAppForUserManagement(
+    TestResponseInterceptor interceptor = initializeAppForUserManagement(
         TestUtils.loadResource("createUser.json"),
         TestUtils.loadResource("getUser.json"));
-    FirebaseAuth auth = FirebaseAuth.getInstance();
-    FirebaseUserManager userManager = auth.getUserManager();
-    TestResponseInterceptor interceptor = new TestResponseInterceptor();
-    userManager.setInterceptor(interceptor);
-    UserRecord user = auth.createUserAsync(new CreateRequest()).get();
+    UserRecord user = FirebaseAuth.getInstance().createUserAsync(new CreateRequest()).get();
     checkUserRecord(user);
     checkRequestHeaders(interceptor);
   }
 
   @Test
   public void testUpdateUser() throws Exception {
-    initializeAppForUserManagement(
+    TestResponseInterceptor interceptor = initializeAppForUserManagement(
         TestUtils.loadResource("createUser.json"),
         TestUtils.loadResource("getUser.json"));
-    FirebaseAuth auth = FirebaseAuth.getInstance();
-    FirebaseUserManager userManager = auth.getUserManager();
-    TestResponseInterceptor interceptor = new TestResponseInterceptor();
-    userManager.setInterceptor(interceptor);
-    UserRecord user = auth.updateUserAsync(new UpdateRequest("testuser")).get();
+    UserRecord user = FirebaseAuth.getInstance()
+        .updateUserAsync(new UpdateRequest("testuser")).get();
     checkUserRecord(user);
     checkRequestHeaders(interceptor);
   }
 
   @Test
   public void testSetCustomAttributes() throws Exception {
-    initializeAppForUserManagement(TestUtils.loadResource("createUser.json"));
-    FirebaseAuth auth = FirebaseAuth.getInstance();
-    FirebaseUserManager userManager = auth.getUserManager();
-    TestResponseInterceptor interceptor = new TestResponseInterceptor();
-    userManager.setInterceptor(interceptor);
+    TestResponseInterceptor interceptor = initializeAppForUserManagement(
+        TestUtils.loadResource("createUser.json"));
     // should not throw
     ImmutableMap<String, Object> claims = ImmutableMap.<String, Object>of(
         "admin", true, "package", "gold");
-    auth.setCustomUserClaimsAsync("testuser", claims).get();
+    FirebaseAuth.getInstance().setCustomUserClaimsAsync("testuser", claims).get();
     checkRequestHeaders(interceptor);
 
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -259,15 +227,10 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testRevokeRefreshTokens() throws Exception {
-    initializeAppForUserManagement(TestUtils.loadResource("createUser.json"));
-    FirebaseAuth auth = FirebaseAuth.getInstance();
-    FirebaseUserManager userManager = auth.getUserManager();
-    TestResponseInterceptor interceptor = new TestResponseInterceptor();
-    userManager.setInterceptor(interceptor);
+    TestResponseInterceptor interceptor = initializeAppForUserManagement(
+        TestUtils.loadResource("createUser.json"));
     // should not throw
-    ImmutableMap<String, Object> claims = ImmutableMap.<String, Object>of(
-        "admin", true, "package", "gold");
-    auth.revokeRefreshTokensAsync("testuser").get();
+    FirebaseAuth.getInstance().revokeRefreshTokensAsync("testuser").get();
     checkRequestHeaders(interceptor);
 
     ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -280,13 +243,10 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testDeleteUser() throws Exception {
-    initializeAppForUserManagement(TestUtils.loadResource("deleteUser.json"));
-    FirebaseAuth auth = FirebaseAuth.getInstance();
-    FirebaseUserManager userManager = auth.getUserManager();
-    TestResponseInterceptor interceptor = new TestResponseInterceptor();
-    userManager.setInterceptor(interceptor);
+    TestResponseInterceptor interceptor = initializeAppForUserManagement(
+        TestUtils.loadResource("deleteUser.json"));
     // should not throw
-    auth.deleteUserAsync("testuser").get();
+    FirebaseAuth.getInstance().deleteUserAsync("testuser").get();
     checkRequestHeaders(interceptor);
   }
 
@@ -386,9 +346,8 @@ public class FirebaseUserManagerTest {
   @Test
   public void testGetUserMalformedJsonError() throws Exception {
     initializeAppForUserManagement("{\"not\" json}");
-    FirebaseAuth auth = FirebaseAuth.getInstance();
     try {
-      auth.getUserAsync("testuser").get();
+      FirebaseAuth.getInstance().getUserAsync("testuser").get();
       fail("No error thrown for JSON error");
     }  catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -771,16 +730,21 @@ public class FirebaseUserManagerTest {
     }
   }
 
-  private static FirebaseApp initializeAppForUserManagement(String ...responses) {
+  private static TestResponseInterceptor initializeAppForUserManagement(String ...responses) {
     List<MockLowLevelHttpResponse> mocks = new ArrayList<>();
     for (String response : responses) {
       mocks.add(new MockLowLevelHttpResponse().setContent(response));
     }
     MockHttpTransport transport = new MultiRequestMockHttpTransport(mocks);
-    return FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp.initializeApp(new FirebaseOptions.Builder()
         .setCredentials(credentials)
         .setHttpTransport(transport)
         .build());
+    FirebaseAuth auth = FirebaseAuth.getInstance();
+    FirebaseUserManager userManager = auth.getUserManager();
+    TestResponseInterceptor interceptor = new TestResponseInterceptor();
+    userManager.setInterceptor(interceptor);
+    return interceptor;
   }
 
   private static void checkUserRecord(UserRecord userRecord) {

--- a/src/test/java/com/google/firebase/auth/ListUsersPageTest.java
+++ b/src/test/java/com/google/firebase/auth/ListUsersPageTest.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 public class ListUsersPageTest {
 
   @Test
-  public void testSinglePage() throws IOException {
+  public void testSinglePage() throws FirebaseAuthException, IOException {
     TestUserSource source = new TestUserSource(3);
     ListUsersPage page = new ListUsersPage.PageFactory(source).create();
     assertFalse(page.hasNextPage());
@@ -56,7 +56,7 @@ public class ListUsersPageTest {
   }
 
   @Test
-  public void testMultiplePages() throws IOException {
+  public void testMultiplePages() throws FirebaseAuthException, IOException {
     ListUsersResult result = new ListUsersResult(
         ImmutableList.of(newUser("user0"), newUser("user1"), newUser("user2")),
         "token");
@@ -106,7 +106,7 @@ public class ListUsersPageTest {
   }
 
   @Test
-  public void testListUsersIterable() throws IOException {
+  public void testListUsersIterable() throws FirebaseAuthException, IOException {
     TestUserSource source = new TestUserSource(3);
     ListUsersPage page = new ListUsersPage.PageFactory(source).create();
     Iterable<ExportedUserRecord> users = page.iterateAll();
@@ -132,7 +132,7 @@ public class ListUsersPageTest {
   }
 
   @Test
-  public void testListUsersIterator() throws IOException {
+  public void testListUsersIterator() throws FirebaseAuthException, IOException {
     TestUserSource source = new TestUserSource(3);
     ListUsersPage page = new ListUsersPage.PageFactory(source).create();
     Iterable<ExportedUserRecord> users = page.iterateAll();
@@ -159,7 +159,7 @@ public class ListUsersPageTest {
   }
 
   @Test
-  public void testListUsersPagedIterable() throws IOException {
+  public void testListUsersPagedIterable() throws FirebaseAuthException, IOException {
     ListUsersResult result = new ListUsersResult(
         ImmutableList.of(newUser("user0"), newUser("user1"), newUser("user2")),
         "token");
@@ -185,7 +185,7 @@ public class ListUsersPageTest {
   }
 
   @Test
-  public void testListUsersPagedIterator() throws IOException {
+  public void testListUsersPagedIterator() throws FirebaseAuthException, IOException {
     ListUsersResult result = new ListUsersResult(
         ImmutableList.of(newUser("user0"), newUser("user1"), newUser("user2")),
         "token");
@@ -218,7 +218,7 @@ public class ListUsersPageTest {
   }
 
   @Test
-  public void testPageWithNoUsers() {
+  public void testPageWithNoUsers() throws FirebaseAuthException {
     ListUsersResult result = new ListUsersResult(
         ImmutableList.<ExportedUserRecord>of(),
         ListUsersPage.END_OF_LIST);
@@ -232,7 +232,7 @@ public class ListUsersPageTest {
   }
 
   @Test
-  public void testIterableWithNoUsers() {
+  public void testIterableWithNoUsers() throws FirebaseAuthException {
     ListUsersResult result = new ListUsersResult(
         ImmutableList.<ExportedUserRecord>of(),
         ListUsersPage.END_OF_LIST);
@@ -245,7 +245,7 @@ public class ListUsersPageTest {
   }
 
   @Test
-  public void testIteratorWithNoUsers() {
+  public void testIteratorWithNoUsers() throws FirebaseAuthException {
     ListUsersResult result = new ListUsersResult(
         ImmutableList.<ExportedUserRecord>of(),
         ListUsersPage.END_OF_LIST);
@@ -260,7 +260,7 @@ public class ListUsersPageTest {
   }
 
   @Test
-  public void testRemove() throws IOException {
+  public void testRemove() throws FirebaseAuthException, IOException {
     ListUsersResult result = new ListUsersResult(
         ImmutableList.of(newUser("user1")),
         ListUsersPage.END_OF_LIST);

--- a/src/test/java/com/google/firebase/testing/MultiRequestMockHttpTransport.java
+++ b/src/test/java/com/google/firebase/testing/MultiRequestMockHttpTransport.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.testing;
+
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+
+public class MultiRequestMockHttpTransport extends MockHttpTransport {
+
+  private final List<MockLowLevelHttpResponse> responses;
+  private int index = 0;
+
+  public MultiRequestMockHttpTransport(List<MockLowLevelHttpResponse> responses) {
+    this.responses = ImmutableList.copyOf(responses);
+  }
+
+  @Override
+  public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+    LowLevelHttpRequest request = super.buildRequest(method, url);
+    ((MockLowLevelHttpRequest) request).setResponse(responses.get(index++));
+    return request;
+  }
+}

--- a/src/test/java/com/google/firebase/testing/MultiRequestMockHttpTransport.java
+++ b/src/test/java/com/google/firebase/testing/MultiRequestMockHttpTransport.java
@@ -22,7 +22,9 @@ import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 
 /**
  * A mock HttpTransport that can simulate multiple (sequential) HTTP interactions. This can be
@@ -30,17 +32,16 @@ import java.util.List;
  */
 public class MultiRequestMockHttpTransport extends MockHttpTransport {
 
-  private final List<MockLowLevelHttpResponse> responses;
-  private int index = 0;
+  private final Queue<MockLowLevelHttpResponse> responses;
 
   public MultiRequestMockHttpTransport(List<MockLowLevelHttpResponse> responses) {
-    this.responses = ImmutableList.copyOf(responses);
+    this.responses = new  LinkedList<>(responses);
   }
 
   @Override
   public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
     LowLevelHttpRequest request = super.buildRequest(method, url);
-    ((MockLowLevelHttpRequest) request).setResponse(responses.get(index++));
+    ((MockLowLevelHttpRequest) request).setResponse(responses.remove());
     return request;
   }
 }

--- a/src/test/java/com/google/firebase/testing/MultiRequestMockHttpTransport.java
+++ b/src/test/java/com/google/firebase/testing/MultiRequestMockHttpTransport.java
@@ -35,7 +35,7 @@ public class MultiRequestMockHttpTransport extends MockHttpTransport {
   private final Queue<MockLowLevelHttpResponse> responses;
 
   public MultiRequestMockHttpTransport(List<MockLowLevelHttpResponse> responses) {
-    this.responses = new  LinkedList<>(responses);
+    this.responses = new LinkedList<>(responses);
   }
 
   @Override

--- a/src/test/java/com/google/firebase/testing/MultiRequestMockHttpTransport.java
+++ b/src/test/java/com/google/firebase/testing/MultiRequestMockHttpTransport.java
@@ -24,6 +24,10 @@ import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * A mock HttpTransport that can simulate multiple (sequential) HTTP interactions. This can be
+ * used when an SDK operation makes multiple backend calls.
+ */
 public class MultiRequestMockHttpTransport extends MockHttpTransport {
 
   private final List<MockLowLevelHttpResponse> responses;

--- a/src/test/java/com/google/firebase/testing/TestResponseInterceptor.java
+++ b/src/test/java/com/google/firebase/testing/TestResponseInterceptor.java
@@ -18,21 +18,31 @@ package com.google.firebase.testing;
 
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpResponseInterceptor;
+import com.google.common.collect.Iterables;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Can be used to intercept HTTP requests and responses made by the SDK during tests.
  */
 public class TestResponseInterceptor implements HttpResponseInterceptor {
 
-  private HttpResponse response;
+  private List<HttpResponse> responses = new ArrayList<>();
 
   @Override
   public void interceptResponse(HttpResponse response) throws IOException {
-    this.response = response;
+    this.responses.add(response);
   }
 
   public HttpResponse getResponse() {
-    return response;
+    if (responses.isEmpty()) {
+      return null;
+    }
+    return Iterables.getLast(responses);
+  }
+
+  public HttpResponse getResponse(int index) {
+    return responses.get(index);
   }
 }

--- a/src/test/java/com/google/firebase/testing/TestResponseInterceptor.java
+++ b/src/test/java/com/google/firebase/testing/TestResponseInterceptor.java
@@ -18,27 +18,21 @@ package com.google.firebase.testing;
 
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpResponseInterceptor;
-import com.google.common.collect.Iterables;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Can be used to intercept HTTP requests and responses made by the SDK during tests.
  */
 public class TestResponseInterceptor implements HttpResponseInterceptor {
 
-  private List<HttpResponse> responses = new ArrayList<>();
+  private HttpResponse response;
 
   @Override
   public void interceptResponse(HttpResponse response) throws IOException {
-    this.responses.add(response);
+    this.response = response;
   }
 
   public HttpResponse getResponse() {
-    if (responses.isEmpty()) {
-      return null;
-    }
-    return Iterables.getLast(responses);
+    return response;
   }
 }

--- a/src/test/java/com/google/firebase/testing/TestResponseInterceptor.java
+++ b/src/test/java/com/google/firebase/testing/TestResponseInterceptor.java
@@ -41,8 +41,4 @@ public class TestResponseInterceptor implements HttpResponseInterceptor {
     }
     return Iterables.getLast(responses);
   }
-
-  public HttpResponse getResponse(int index) {
-    return responses.get(index);
-  }
 }


### PR DESCRIPTION
Unit tests currently test the `FirebaseUserManager` internal class, but does not test the public API surface in `FirebaseAuth`. As a result the `com.google.firebase.auth` package has a test coverage of only 69%. This PR modifies the tests so that we test the public API surface, bringing the package test coverage to 91%. 

The overall test coverage goes from 81% to 82%.