### PR TITLE
Handling FCM canonical error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Unreleased
 
--
+- [fixed] Improved error handling in FCM by mapping more server-side
+  errors to client-side error codes.
 
 # v5.9.0
-
 
 ### Cloud Messaging
 

--- a/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
@@ -64,15 +64,15 @@ public class FirebaseMessaging {
   private static final Map<String, String> FCM_ERROR_CODES =
       ImmutableMap.<String, String>builder()
         // FCM v1 canonical error codes
-        .put("UNAUTHENTICATED", "invalid-apns-credentials")
         .put("NOT_FOUND", "registration-token-not-registered")
+        .put("PERMISSION_DENIED", "mismatched-credential")
         .put("RESOURCE_EXHAUSTED", "message-rate-exceeded")
+        .put("UNAUTHENTICATED", "invalid-apns-credentials")
 
         // FCM v1 new error codes
         .put("APNS_AUTH_ERROR", "invalid-apns-credentials")
         .put("INTERNAL", INTERNAL_ERROR)
         .put("INVALID_ARGUMENT", "invalid-argument")
-        .put("PERMISSION_DENIED", "mismatched-credential")
         .put("QUOTA_EXCEEDED", "message-rate-exceeded")
         .put("SENDER_ID_MISMATCH", "mismatched-credential")
         .put("UNAVAILABLE", "server-unavailable")

--- a/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
@@ -63,13 +63,20 @@ public class FirebaseMessaging {
   private static final String UNKNOWN_ERROR = "unknown-error";
   private static final Map<String, String> FCM_ERROR_CODES =
       ImmutableMap.<String, String>builder()
-        .put("APNS_AUTH_ERROR", "authentication-error")
+        // FCM v1 canonical error codes
+        .put("UNAUTHENTICATED", "invalid-apns-credentials")
+        .put("NOT_FOUND", "registration-token-not-registered")
+        .put("RESOURCE_EXHAUSTED", "message-rate-exceeded")
+
+        // FCM v1 new error codes
+        .put("APNS_AUTH_ERROR", "invalid-apns-credentials")
         .put("INTERNAL", INTERNAL_ERROR)
         .put("INVALID_ARGUMENT", "invalid-argument")
-        .put("UNREGISTERED", "registration-token-not-registered")
+        .put("PERMISSION_DENIED", "mismatched-credential")
         .put("QUOTA_EXCEEDED", "message-rate-exceeded")
-        .put("SENDER_ID_MISMATCH", "authentication-error")
+        .put("SENDER_ID_MISMATCH", "mismatched-credential")
         .put("UNAVAILABLE", "server-unavailable")
+        .put("UNREGISTERED", "registration-token-not-registered")
         .build();
   static final Map<Integer, String> IID_ERROR_CODES =
       ImmutableMap.<Integer, String>builder()


### PR DESCRIPTION
The error codes defined in https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode are embedded in the details section of the error response. The top-level error code (`status` field in the response) may take additional values such as `NOT_FOUND` and `UNAUTHENTICATED` (the so called canonical error codes):

```
{
  "error":{
    "code":404,
    "message":"Requested entity was not found.",
    "status":"NOT_FOUND",
    "details: [
      {
         "@type":"type.googleapis.com/google.firebase.fcm.v1.FcmError",
         "errorCode":"UNREGISTERED"
      }
    ]
  }
}
```

This PR updates the FCM implementation to handle these additional error codes and map them to correct client-side errors.