### PR TITLE
Add given httpTransport in GooglePublicKeysManager

### DIFF
--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -66,7 +66,10 @@ public class FirebaseAuth {
   private final Object lock;
 
   private FirebaseAuth(FirebaseApp firebaseApp) {
-    this(firebaseApp, FirebaseTokenVerifier.DEFAULT_KEY_MANAGER, Clock.SYSTEM);
+    this(firebaseApp,
+         FirebaseTokenVerifier.buildGooglePublicKeysManager(
+                 firebaseApp.getOptions().getHttpTransport()),
+         Clock.SYSTEM);
   }
 
   /**
@@ -210,12 +213,14 @@ public class FirebaseAuth {
     return call(new Callable<FirebaseToken>() {
       @Override
       public FirebaseToken call() throws Exception {
+
         FirebaseTokenVerifier firebaseTokenVerifier =
             new FirebaseTokenVerifier.Builder()
                 .setProjectId(projectId)
                 .setPublicKeysManager(googlePublicKeysManager)
                 .setClock(clock)
                 .build();
+
         FirebaseToken firebaseToken = FirebaseToken.parse(jsonFactory, token);
 
         // This will throw a FirebaseAuthException with details on how the token is invalid.

--- a/src/main/java/com/google/firebase/auth/internal/FirebaseTokenVerifier.java
+++ b/src/main/java/com/google/firebase/auth/internal/FirebaseTokenVerifier.java
@@ -20,6 +20,7 @@ import com.google.api.client.auth.openidconnect.IdToken;
 import com.google.api.client.auth.openidconnect.IdToken.Payload;
 import com.google.api.client.auth.openidconnect.IdTokenVerifier;
 import com.google.api.client.googleapis.auth.oauth2.GooglePublicKeysManager;
+import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature.Header;
@@ -181,6 +182,13 @@ public final class FirebaseTokenVerifier extends IdTokenVerifier {
 
   public String getProjectId() {
     return projectId;
+  }
+
+  public static GooglePublicKeysManager buildGooglePublicKeysManager(HttpTransport transport) {
+    return new GooglePublicKeysManager.Builder(transport, new GsonFactory())
+            .setClock(Clock.SYSTEM)
+            .setPublicCertsEncodedUrl(FirebaseTokenVerifier.CLIENT_CERT_URL)
+            .build();
   }
 
   /** 


### PR DESCRIPTION
Construct the default GooglePublicKeysManager with the custom
httpTransport. This avoid error due to proxy.
Fixes #150

