### PR TITLE
Handling some WebSocket connection errors gracefully

### DIFF
--- a/src/main/java/com/google/firebase/database/connection/NettyWebSocketClient.java
+++ b/src/main/java/com/google/firebase/database/connection/NettyWebSocketClient.java
@@ -130,8 +130,13 @@ class NettyWebSocketClient implements WebsocketConnection.WSClient {
 
   @Override
   public void send(String msg) {
-    checkState(channel != null && channel.isActive(), "channel not connected for sending");
-    channel.writeAndFlush(new TextWebSocketFrame(msg));
+    if (channel == null) {
+      eventHandler.onError(new IllegalStateException("Channel not initialized"));
+    } else if (!channel.isActive()) {
+      eventHandler.onError(new IllegalStateException("Channel not connected for sending"));
+    } else {
+      channel.writeAndFlush(new TextWebSocketFrame(msg));
+    }
   }
 
   /**

--- a/src/main/java/com/google/firebase/database/connection/NettyWebSocketClient.java
+++ b/src/main/java/com/google/firebase/database/connection/NettyWebSocketClient.java
@@ -33,6 +33,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 
+import java.io.EOFException;
 import java.net.URI;
 import java.security.KeyStore;
 import java.util.concurrent.ExecutorService;
@@ -130,10 +131,9 @@ class NettyWebSocketClient implements WebsocketConnection.WSClient {
 
   @Override
   public void send(String msg) {
-    if (channel == null) {
-      eventHandler.onError(new IllegalStateException("Channel not initialized"));
-    } else if (!channel.isActive()) {
-      eventHandler.onError(new IllegalStateException("Channel not connected for sending"));
+    checkState(channel != null, "Channel not initialized");
+    if (!channel.isActive()) {
+      eventHandler.onError(new EOFException("WebSocket channel became inactive"));
     } else {
       channel.writeAndFlush(new TextWebSocketFrame(msg));
     }

--- a/src/main/java/com/google/firebase/database/connection/WebsocketConnection.java
+++ b/src/main/java/com/google/firebase/database/connection/WebsocketConnection.java
@@ -324,8 +324,7 @@ class WebsocketConnection {
 
     @Override
     public void onError(final Throwable e) {
-      if (e instanceof EOFException
-          || (e.getCause() != null && e.getCause() instanceof EOFException)) {
+      if (e instanceof EOFException || e.getCause() instanceof EOFException) {
         logger.debug("WebSocket reached EOF", e);
       } else {
         logger.error("WebSocket error", e);

--- a/src/main/java/com/google/firebase/database/connection/WebsocketConnection.java
+++ b/src/main/java/com/google/firebase/database/connection/WebsocketConnection.java
@@ -325,9 +325,9 @@ class WebsocketConnection {
     @Override
     public void onError(final Throwable e) {
       if (e.getCause() != null && e.getCause() instanceof EOFException) {
-        logger.error("WebSocket reached EOF", e);
+        logger.debug("WebSocket reached EOF", e);
       } else {
-        logger.error("WebSocket error", e);
+        logger.debug("WebSocket error", e);
       }
       executorService.execute(
           new Runnable() {

--- a/src/main/java/com/google/firebase/database/connection/WebsocketConnection.java
+++ b/src/main/java/com/google/firebase/database/connection/WebsocketConnection.java
@@ -324,10 +324,11 @@ class WebsocketConnection {
 
     @Override
     public void onError(final Throwable e) {
-      if (e.getCause() != null && e.getCause() instanceof EOFException) {
+      if (e instanceof EOFException
+          || (e.getCause() != null && e.getCause() instanceof EOFException)) {
         logger.debug("WebSocket reached EOF", e);
       } else {
-        logger.debug("WebSocket error", e);
+        logger.error("WebSocket error", e);
       }
       executorService.execute(
           new Runnable() {


### PR DESCRIPTION
There's a small delay between `channelInactive()` low-level event, and us calling `channel.close()`. The former executes on a Netty worker thread, while the latter is on the runloop. An outgoing `send()` may sneak through this window to cause a hard assertion failure. 

The old tubesock implementation handled this type of race conditions more gracefully, by simply logging the error and closing the connection for good. This PR essentially implements the same semantics on top of Netty.

b/74831164