### PR TITLE
Session Cookie Management API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Unreleased
 
+- [added] A new `FirebaseAuth.createSessionCookieAsync()` method for
+  creating a long-lived session cookie given a valid ID token.
+- [added] A new `FirebaseAuth.verifySessionCookieAsync()` method for
+  verifying a given cookie string is valid.
+- [fixed] Using the `HttpTransport` specified at `FirebaseOptions` in
+  `GooglePublicKeysManager`. This enables developers to use a custom
+  transport to fetch public keys when verifying ID tokens and session
+  cookies.
 - [fixed] Improved error handling in FCM by mapping more server-side
   errors to client-side error codes.
 

--- a/pom.xml
+++ b/pom.xml
@@ -471,5 +471,12 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <!-- Used for some snippets -->
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -116,7 +116,8 @@ public class FirebaseAuth {
     return service.getInstance();
   }
 
-  private Task<String> createSessionCookie(final String idToken, final SessionCookieOptions options) {
+  private Task<String> createSessionCookie(
+      final String idToken, final SessionCookieOptions options) {
     checkNotDestroyed();
     checkArgument(!Strings.isNullOrEmpty(idToken), "idToken must not be null or empty");
     checkNotNull(options, "options must not be null");

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -37,6 +37,7 @@ import com.google.firebase.auth.UserRecord.UpdateRequest;
 import com.google.firebase.auth.internal.FirebaseTokenFactory;
 import com.google.firebase.auth.internal.FirebaseTokenVerifier;
 import com.google.firebase.internal.FirebaseService;
+import com.google.firebase.internal.NonNull;
 import com.google.firebase.internal.Nullable;
 import com.google.firebase.internal.TaskToApiFuture;
 import com.google.firebase.tasks.Task;
@@ -113,6 +114,34 @@ public class FirebaseAuth {
       service = ImplFirebaseTrampolines.addService(app, new FirebaseAuthService(app));
     }
     return service.getInstance();
+  }
+
+  private Task<String> createSessionCookie(final String idToken, final SessionCookieOptions options) {
+    checkNotDestroyed();
+    checkArgument(!Strings.isNullOrEmpty(idToken), "idToken must not be null or empty");
+    checkNotNull(options, "options must not be null");
+    return call(new Callable<String>() {
+      @Override
+      public String call() throws Exception {
+        return userManager.createSessionCookie(idToken, options);
+      }
+    });
+  }
+
+  /**
+   * Creates a new Firebase session cookie from the given ID token and options. The returned JWT
+   * can be set as a server-side session cookie with a custom cookie policy.
+   *
+   * @param idToken The Firebase ID token to exchange for a session cookie.
+   * @param options Additional options required to create the cookie.
+   * @return An {@code ApiFuture} which will complete successfully with a session cookie string.
+   *     If an error occurs while generating the cookie or if the specified ID token is invalid,
+   *     the future throws a {@link FirebaseAuthException}.
+   * @throws IllegalArgumentException If the ID token is null or empty, or if options is null.
+   */
+  public ApiFuture<String> createSessionCookieAsync(
+      @NonNull String idToken, @NonNull SessionCookieOptions options) {
+    return new TaskToApiFuture<>(createSessionCookie(idToken, options));
   }
 
   /**

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.api.client.googleapis.auth.oauth2.GooglePublicKeysManager;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.util.Clock;
 import com.google.api.core.ApiFuture;
@@ -36,6 +35,7 @@ import com.google.firebase.auth.UserRecord.CreateRequest;
 import com.google.firebase.auth.UserRecord.UpdateRequest;
 import com.google.firebase.auth.internal.FirebaseTokenFactory;
 import com.google.firebase.auth.internal.FirebaseTokenVerifier;
+import com.google.firebase.auth.internal.KeyManagers;
 import com.google.firebase.internal.FirebaseService;
 import com.google.firebase.internal.NonNull;
 import com.google.firebase.internal.Nullable;
@@ -55,10 +55,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class FirebaseAuth {
 
-  private final GooglePublicKeysManager googlePublicKeysManager;
   private final Clock clock;
 
   private final FirebaseApp firebaseApp;
+  private final KeyManagers keyManagers;
   private final GoogleCredentials credentials;
   private final String projectId;
   private final JsonFactory jsonFactory;
@@ -67,10 +67,7 @@ public class FirebaseAuth {
   private final Object lock;
 
   private FirebaseAuth(FirebaseApp firebaseApp) {
-    this(firebaseApp,
-         FirebaseTokenVerifier.buildGooglePublicKeysManager(
-                 firebaseApp.getOptions().getHttpTransport()),
-         Clock.SYSTEM);
+    this(firebaseApp, KeyManagers.getDefault(firebaseApp, Clock.SYSTEM), Clock.SYSTEM);
   }
 
   /**
@@ -78,10 +75,9 @@ public class FirebaseAuth {
    * correctly signed. This should only be used for testing to override the default key manager.
    */
   @VisibleForTesting
-  FirebaseAuth(
-      FirebaseApp firebaseApp, GooglePublicKeysManager googlePublicKeysManager, Clock clock) {
+  FirebaseAuth(FirebaseApp firebaseApp, KeyManagers keyManagers, Clock clock) {
     this.firebaseApp = checkNotNull(firebaseApp);
-    this.googlePublicKeysManager = checkNotNull(googlePublicKeysManager);
+    this.keyManagers = checkNotNull(keyManagers);
     this.clock = checkNotNull(clock);
     this.credentials = ImplFirebaseTrampolines.getCredentials(firebaseApp);
     this.projectId = ImplFirebaseTrampolines.getProjectId(firebaseApp);
@@ -143,6 +139,79 @@ public class FirebaseAuth {
   public ApiFuture<String> createSessionCookieAsync(
       @NonNull String idToken, @NonNull SessionCookieOptions options) {
     return new TaskToApiFuture<>(createSessionCookie(idToken, options));
+  }
+
+  /**
+   * Parses and verifies a Firebase session cookie.
+   *
+   * <p>If the cookie is valid, the returned Future will complete successfully and provide a
+   * parsed version of the cookie from which the UID and other claims can be read.
+   * If the cookie is invalid, the future throws an exception indicating the failure.
+   *
+   * <p>This does not check whether the cookie has been revoked. See
+   * {@link #verifySessionCookie(String, boolean)}.
+   *
+   * @param cookie A Firebase session cookie string to verify and parse.
+   * @return An {@code ApiFuture} which will complete successfully with the parsed cookie, or
+   *     unsuccessfully with the failure Exception.
+   */
+  public ApiFuture<FirebaseToken> verifySessionCookieAsync(String cookie) {
+    return new TaskToApiFuture<>(verifySessionCookie(cookie, false));
+  }
+
+  /**
+   * Parses and verifies a Firebase session cookie.
+   *
+   * <p>If the cookie is valid, the returned Future will complete successfully and provide a
+   * parsed version of the cookie from which the UID and other claims can be inspected.
+   * If the cookie is invalid, the future throws an exception indicating the failure.
+   *
+   * <p>If {@code checkRevoked} is true, additionally checks if the cookie has been revoked.
+   *
+   * <p>If the cookie is valid, and not revoked, the returned Future will complete successfully and
+   * provide a parsed version of the cookie from which the UID and other claims can be read.
+   * If the cookie is invalid or has been revoked, the future throws an exception indicating the
+   * failure.
+   *
+   * @param cookie A Firebase session cookie string to verify and parse.
+   * @param checkRevoked A boolean indicating whether to check if the cookie was revoked.
+   * @return An {@code ApiFuture} which will complete successfully with the parsed cookie, or
+   *     unsuccessfully with the failure Exception.
+   */
+  public ApiFuture<FirebaseToken> verifySessionCookieAsync(String cookie, boolean checkRevoked) {
+    return new TaskToApiFuture<>(verifySessionCookie(cookie, checkRevoked));
+  }
+
+  private Task<FirebaseToken> verifySessionCookie(final String cookie, final boolean checkRevoked) {
+    checkNotDestroyed();
+    checkState(!Strings.isNullOrEmpty(projectId),
+        "Must initialize FirebaseApp with a project ID to call verifySessionCookie()");
+    return call(new Callable<FirebaseToken>() {
+      @Override
+      public FirebaseToken call() throws Exception {
+        FirebaseTokenVerifier firebaseTokenVerifier =
+            FirebaseTokenVerifier.createSessionCookieVerifier(projectId, keyManagers, clock);
+        FirebaseToken firebaseToken = FirebaseToken.parse(jsonFactory, cookie);
+        // This will throw a FirebaseAuthException with details on how the token is invalid.
+        firebaseTokenVerifier.verifyTokenAndSignature(firebaseToken.getToken());
+
+        if (checkRevoked) {
+          checkRevoked(firebaseToken, "session cookie",
+              FirebaseUserManager.SESSION_COOKIE_REVOKED_ERROR);
+        }
+        return firebaseToken;
+      }
+    });
+  }
+
+  private void checkRevoked(
+      FirebaseToken firebaseToken, String label, String errorCode) throws FirebaseAuthException {
+    String uid = firebaseToken.getUid();
+    UserRecord user = userManager.getUserById(uid);
+    long issuedAt = (long) firebaseToken.getClaims().get("iat");
+    if (user.getTokensValidAfterTimestamp() > issuedAt * 1000) {
+      throw new FirebaseAuthException(errorCode, "Firebase " + label + " revoked");
+    }
   }
 
   /**
@@ -243,27 +312,14 @@ public class FirebaseAuth {
     return call(new Callable<FirebaseToken>() {
       @Override
       public FirebaseToken call() throws Exception {
-
         FirebaseTokenVerifier firebaseTokenVerifier =
-            new FirebaseTokenVerifier.Builder()
-                .setProjectId(projectId)
-                .setPublicKeysManager(googlePublicKeysManager)
-                .setClock(clock)
-                .build();
-
+            FirebaseTokenVerifier.createIdTokenVerifier(projectId, keyManagers, clock);
         FirebaseToken firebaseToken = FirebaseToken.parse(jsonFactory, token);
-
         // This will throw a FirebaseAuthException with details on how the token is invalid.
         firebaseTokenVerifier.verifyTokenAndSignature(firebaseToken.getToken());
-        
+
         if (checkRevoked) {
-          String uid = firebaseToken.getUid();
-          UserRecord user = userManager.getUserById(uid);
-          long issuedAt = (long) firebaseToken.getClaims().get("iat");
-          if (user.getTokensValidAfterTimestamp() > issuedAt * 1000) {
-              throw new FirebaseAuthException(FirebaseUserManager.ID_TOKEN_REVOKED_ERROR,
-                                              "Firebase auth token revoked");
-          }        
+          checkRevoked(firebaseToken, "auth token", FirebaseUserManager.ID_TOKEN_REVOKED_ERROR);
         }       
         return firebaseToken;
       }
@@ -351,7 +407,7 @@ public class FirebaseAuth {
    * failure.
    *
    * @param token A Firebase ID Token to verify and parse.
-   * @param checkRevoked A boolean denoting whether to check if the tokens were revoked.
+   * @param checkRevoked A boolean indicating whether to check if the tokens were revoked.
    * @return An {@code ApiFuture} which will complete successfully with the parsed token, or
    *     unsuccessfully with the failure Exception.
    */

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -193,6 +193,21 @@ class FirebaseUserManager {
     return response;
   }
 
+  String createSessionCookie(String idToken,
+      SessionCookieOptions options) throws FirebaseAuthException {
+    final Map<String, Object> payload = ImmutableMap.<String, Object>of(
+        "idToken", idToken, "validDuration", options.getExpiresInSeconds());
+    GenericJson response = post(
+        "createSessionCookie", payload, GenericJson.class);
+    if (response != null || !response.containsKey("sessionCookie")) {
+      String cookie = (String) response.get("sessionCookie");
+      if (!Strings.isNullOrEmpty(cookie)) {
+        return cookie;
+      }
+    }
+    throw new FirebaseAuthException(INTERNAL_ERROR, "Failed to create session cookie");
+  }
+
   private <T> T post(String path, Object content, Class<T> clazz) throws FirebaseAuthException {
     checkArgument(!Strings.isNullOrEmpty(path), "path must not be null or empty");
     checkNotNull(content, "content must not be null");

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -59,6 +59,7 @@ class FirebaseUserManager {
   static final String USER_NOT_FOUND_ERROR = "user-not-found";
   static final String INTERNAL_ERROR = "internal-error";
   static final String ID_TOKEN_REVOKED_ERROR = "id-token-revoked";
+  static final String SESSION_COOKIE_REVOKED_ERROR = "session-cookie-revoked";
 
   // Map of server-side error codes to SDK error codes.
   // SDK error codes defined at: https://firebase.google.com/docs/auth/admin/errors

--- a/src/main/java/com/google/firebase/auth/SessionCookieOptions.java
+++ b/src/main/java/com/google/firebase/auth/SessionCookieOptions.java
@@ -20,6 +20,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A set of additional options that can be passed to
+ * {@link FirebaseAuth#createSessionCookieAsync(String, SessionCookieOptions)}.
+ */
 public class SessionCookieOptions {
 
   private final long expiresIn;
@@ -36,6 +40,9 @@ public class SessionCookieOptions {
     return TimeUnit.MILLISECONDS.toSeconds(expiresIn);
   }
 
+  /**
+   * Creates a new {@link Builder}.
+   */
   public static Builder builder() {
     return new Builder();
   }
@@ -46,11 +53,21 @@ public class SessionCookieOptions {
 
     private Builder() {}
 
+    /**
+     * Sets the duration until the cookie is expired in milliseconds. Must be between 5 minutes
+     * and 14 days.
+     *
+     * @param expiresIn Time duration in milliseconds.
+     * @return This builder.
+     */
     public Builder setExpiresIn(long expiresIn) {
       this.expiresIn = expiresIn;
       return this;
     }
 
+    /**
+     * Creates a new {@link SessionCookieOptions} instance.
+     */
     public SessionCookieOptions build() {
       return new SessionCookieOptions(this);
     }

--- a/src/main/java/com/google/firebase/auth/SessionCookieOptions.java
+++ b/src/main/java/com/google/firebase/auth/SessionCookieOptions.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.auth;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.concurrent.TimeUnit;
+
+public class SessionCookieOptions {
+
+  private final long expiresIn;
+
+  private SessionCookieOptions(Builder builder) {
+    checkArgument(builder.expiresIn > TimeUnit.MINUTES.toMillis(5),
+        "expiresIn duration must be at least 5 minutes");
+    checkArgument(builder.expiresIn < TimeUnit.DAYS.toMillis(14),
+        "expiresIn duration must be at most 14 days");
+    this.expiresIn = builder.expiresIn;
+  }
+
+  long getExpiresInSeconds() {
+    return TimeUnit.MILLISECONDS.toSeconds(expiresIn);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+
+    private long expiresIn;
+
+    private Builder() {}
+
+    public Builder setExpiresIn(long expiresIn) {
+      this.expiresIn = expiresIn;
+      return this;
+    }
+
+    public SessionCookieOptions build() {
+      return new SessionCookieOptions(this);
+    }
+  }
+
+}

--- a/src/main/java/com/google/firebase/auth/internal/FirebaseTokenFactory.java
+++ b/src/main/java/com/google/firebase/auth/internal/FirebaseTokenFactory.java
@@ -83,7 +83,7 @@ public class FirebaseTokenFactory {
       for (String key : developerClaims.keySet()) {
         if (reservedNames.contains(key)) {
           throw new IllegalArgumentException(
-              String.format("developer_claims can not contain a reserved key: %s", key));
+              String.format("developerClaims must not contain a reserved key: %s", key));
         }
       }
       GenericJson jsonObject = new GenericJson();

--- a/src/main/java/com/google/firebase/auth/internal/KeyManagers.java
+++ b/src/main/java/com/google/firebase/auth/internal/KeyManagers.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.auth.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.api.client.googleapis.auth.oauth2.GooglePublicKeysManager;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.util.Clock;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.internal.NonNull;
+
+/**
+ * A utility for initializing and keeping tack of the various public key manager instances
+ * used by {@link com.google.firebase.auth.FirebaseAuth}.
+ */
+public class KeyManagers {
+
+  private final GooglePublicKeysManager idTokenKeysManager;
+  private final GooglePublicKeysManager sessionCookieKeysManager;
+
+  private KeyManagers(Builder builder) {
+    this.idTokenKeysManager = checkNotNull(builder.idTokenKeysManager);
+    this.sessionCookieKeysManager = checkNotNull(builder.sessionCookieKeysManager);
+  }
+
+  /**
+   * Returns the key manager that should be used for ID token verification.
+   */
+  GooglePublicKeysManager getIdTokenKeysManager() {
+    return idTokenKeysManager;
+  }
+
+  /**
+   * Returns the key manager that should be used for session cookie verification.
+   */
+  GooglePublicKeysManager getSessionCookieKeysManager() {
+    return sessionCookieKeysManager;
+  }
+
+  /**
+   * Initialize a new set of key managers for the specified app using the given clock.
+   *
+   * @param app A {@link FirebaseApp} instance.
+   * @param clock A {@code Clock} to be used with Google API client.
+   * @return A new {@link KeyManagers} instance.
+   */
+  public static KeyManagers getDefault(@NonNull FirebaseApp app, @NonNull Clock clock) {
+    HttpTransport transport = app.getOptions().getHttpTransport();
+    return getDefault(transport, clock);
+  }
+
+  @VisibleForTesting
+  static KeyManagers getDefault(HttpTransport transport, Clock clock) {
+    return new Builder()
+        .setIdTokenKeysManager(FirebaseTokenVerifier.createKeysManager(
+            transport, clock, FirebaseTokenVerifier.ID_TOKEN_CERT_URL))
+        .setSessionCookieKeysManager(FirebaseTokenVerifier.createKeysManager(
+            transport, clock, FirebaseTokenVerifier.SESSION_COOKIE_CERT_URL))
+        .build();
+  }
+
+  public static class Builder {
+
+    private GooglePublicKeysManager idTokenKeysManager;
+    private GooglePublicKeysManager sessionCookieKeysManager;
+
+    public Builder setIdTokenKeysManager(
+        GooglePublicKeysManager idTokenKeysManager) {
+      this.idTokenKeysManager = idTokenKeysManager;
+      return this;
+    }
+
+    public Builder setSessionCookieKeysManager(
+        GooglePublicKeysManager sessionCookieKeysManager) {
+      this.sessionCookieKeysManager = sessionCookieKeysManager;
+      return this;
+    }
+
+    public KeyManagers build() {
+      return new KeyManagers(this);
+    }
+  }
+}

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -35,6 +35,7 @@ import com.google.api.client.json.JsonObjectParser;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.UserRecord.CreateRequest;
@@ -48,6 +49,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -64,7 +66,7 @@ public class FirebaseAuthIT {
   private static FirebaseAuth auth;
 
   @BeforeClass
-  public static void setUpClass() throws Exception {
+  public static void setUpClass() {
     FirebaseApp masterApp = IntegrationTestUtils.ensureDefaultApp();
     auth = FirebaseAuth.getInstance(masterApp);
   }
@@ -370,7 +372,7 @@ public class FirebaseAuthIT {
     decoded = auth.verifyIdTokenAsync(idToken, false).get();
     assertEquals("user2", decoded.getUid());
     try {
-      decoded = auth.verifyIdTokenAsync(idToken, true).get();
+      auth.verifyIdTokenAsync(idToken, true).get();
       fail("expecting exception");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
@@ -381,6 +383,42 @@ public class FirebaseAuthIT {
     decoded = auth.verifyIdTokenAsync(idToken, true).get();
     assertEquals("user2", decoded.getUid());    
     auth.deleteUserAsync("user2");
+  }
+
+  @Test
+  public void testVerifySessionCookie() throws Exception {
+    String customToken = auth.createCustomTokenAsync("user3").get();
+    String idToken = signInWithCustomToken(customToken);
+
+    SessionCookieOptions options = SessionCookieOptions.builder()
+        .setExpiresIn(TimeUnit.HOURS.toMillis(1))
+        .build();
+    String sessionCookie = auth.createSessionCookieAsync(idToken, options).get();
+    assertTrue(!Strings.isNullOrEmpty(sessionCookie));
+
+    FirebaseToken decoded = auth.verifySessionCookieAsync(sessionCookie).get();
+    assertEquals("user3", decoded.getUid());
+    decoded = auth.verifySessionCookieAsync(sessionCookie, true).get();
+    assertEquals("user3", decoded.getUid());
+    Thread.sleep(1000);
+
+    auth.revokeRefreshTokensAsync("user3").get();
+    decoded = auth.verifySessionCookieAsync(sessionCookie, false).get();
+    assertEquals("user3", decoded.getUid());
+    try {
+      auth.verifySessionCookieAsync(sessionCookie, true).get();
+      fail("expecting exception");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof FirebaseAuthException);
+      assertEquals(FirebaseUserManager.SESSION_COOKIE_REVOKED_ERROR,
+          ((FirebaseAuthException) e.getCause()).getErrorCode());
+    }
+
+    idToken = signInWithCustomToken(customToken);
+    sessionCookie = auth.createSessionCookieAsync(idToken, options).get();
+    decoded = auth.verifySessionCookieAsync(sessionCookie, true).get();
+    assertEquals("user3", decoded.getUid());
+    auth.deleteUserAsync("user3");
   }
 
   @Test

--- a/src/test/java/com/google/firebase/snippets/FirebaseAuthSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseAuthSnippets.java
@@ -21,14 +21,25 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.auth.FirebaseToken;
 import com.google.firebase.auth.ListUsersPage;
+import com.google.firebase.auth.SessionCookieOptions;
 import com.google.firebase.auth.UserRecord;
 import com.google.firebase.auth.UserRecord.CreateRequest;
 import com.google.firebase.auth.UserRecord.UpdateRequest;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 /**
  * Auth snippets for documentation.
@@ -259,6 +270,137 @@ public class FirebaseAuthSnippets {
     userData.put("revokeTime", revocationSecond);
     ref.setValueAsync(userData).get();
     // [END save_revocation_in_db]
-
   }
+
+  static class LoginRequest {
+    String idToken;
+
+    String getIdToken() {
+      return idToken;
+    }
+  }
+
+  // [START session_login]
+  @POST
+  @Path("/sessionLogin")
+  @Consumes("application/json")
+  public Response createSessionCookie(LoginRequest request) {
+    // Get the ID token sent by the client
+    String idToken = request.getIdToken();
+    // Set session expiration to 5 days.
+    long expiresIn = TimeUnit.DAYS.toMillis(5);
+    SessionCookieOptions options = SessionCookieOptions.builder()
+        .setExpiresIn(expiresIn)
+        .build();
+    try {
+      // Create the session cookie. This will also verify the ID token in the process.
+      // The session cookie will have the same claims as the ID token.
+      String sessionCookie = FirebaseAuth.getInstance().createSessionCookieAsync(
+          idToken, options).get();
+      // Set cookie policy parameters as required.
+      NewCookie cookie = new NewCookie("session", sessionCookie /* ... other parameters */);
+      return Response.ok().cookie(cookie).build();
+    } catch (Exception e) {
+      return Response.status(Status.UNAUTHORIZED).entity("Failed to create a session cookie")
+          .build();
+    }
+  }
+  // [END session_login]
+
+  public Response checkAuthTime(String idToken) throws Exception {
+    // [START check_auth_time]
+    // To ensure that cookies are set only on recently signed in users, check auth_time in
+    // ID token before creating a cookie.
+    FirebaseToken decodedToken = FirebaseAuth.getInstance().verifyIdTokenAsync(idToken).get();
+    long authTimeMillis = (long) decodedToken.getClaims().get("auth_time") * 1000L;
+
+    // Only process if the user signed in within the last 5 minutes.
+    if (System.currentTimeMillis() - authTimeMillis < TimeUnit.MINUTES.toMillis(5)) {
+      long expiresIn = TimeUnit.DAYS.toMillis(5);
+      SessionCookieOptions options = SessionCookieOptions.builder()
+          .setExpiresIn(expiresIn)
+          .build();
+      String sessionCookie = FirebaseAuth.getInstance().createSessionCookieAsync(
+          idToken, options).get();
+      // Set cookie policy parameters as required.
+      NewCookie cookie = new NewCookie("session", sessionCookie);
+      return Response.ok().cookie(cookie).build();
+    }
+    // User did not sign in recently. To guard against ID token theft, require
+    // re-authentication.
+    return Response.status(Status.UNAUTHORIZED).entity("Recent sign in required").build();
+    // [END check_auth_time]
+  }
+
+  private Response serveContentForUser(FirebaseToken decodedToken) {
+    return null;
+  }
+
+  private Response serveContentForAdmin(FirebaseToken decodedToken) {
+    return null;
+  }
+
+  // [START session_verify]
+  @POST
+  @Path("/profile")
+  public Response verifySessionCookie(@CookieParam("session") Cookie cookie) {
+    String sessionCookie = cookie.getValue();
+    try {
+      // Verify the session cookie. In this case an additional check is added to detect
+      // if the user's Firebase session was revoked, user deleted/disabled, etc.
+      final boolean checkRevoked = true;
+      FirebaseToken decodedToken = FirebaseAuth.getInstance().verifySessionCookieAsync(
+          sessionCookie, checkRevoked).get();
+      return serveContentForUser(decodedToken);
+    } catch (Exception e) {
+      // Session cookie is unavailable, invalid or revoked. Force user to login.
+      return Response.temporaryRedirect(URI.create("/login")).build();
+    }
+  }
+  // [END session_verify]
+
+  public Response checkPermissions(String sessionCookie) {
+    // [START session_verify_with_permission_check]
+    try {
+      final boolean checkRevoked = true;
+      FirebaseToken decodedToken = FirebaseAuth.getInstance().verifySessionCookieAsync(
+          sessionCookie, checkRevoked).get();
+      if (Boolean.TRUE.equals(decodedToken.getClaims().get("admin"))) {
+        return serveContentForAdmin(decodedToken);
+      }
+      return Response.status(Status.UNAUTHORIZED).entity("Insufficient permissions").build();
+    } catch (Exception e) {
+      // Session cookie is unavailable, invalid or revoked. Force user to login.
+      return Response.temporaryRedirect(URI.create("/login")).build();
+    }
+    // [END session_verify_with_permission_check]
+  }
+
+  // [START session_clear]
+  @POST
+  @Path("/sessionLogout")
+  public Response clearSessionCookie(@CookieParam("session") Cookie cookie) {
+    final int maxAge = 0;
+    NewCookie newCookie = new NewCookie(cookie, null, maxAge, true);
+    return Response.temporaryRedirect(URI.create("/login")).cookie(newCookie).build();
+  }
+  // [END session_clear]
+
+  // [START session_clear_and_revoke]
+  @POST
+  @Path("/sessionLogout")
+  public Response clearSessionCookieAndRevoke(@CookieParam("session") Cookie cookie) {
+    String sessionCookie = cookie.getValue();
+    try {
+      FirebaseToken decodedToken = FirebaseAuth.getInstance().verifySessionCookieAsync(
+          sessionCookie).get();
+      FirebaseAuth.getInstance().revokeRefreshTokensAsync(decodedToken.getUid()).get();
+      final int maxAge = 0;
+      NewCookie newCookie = new NewCookie(cookie, null, maxAge, true);
+      return Response.temporaryRedirect(URI.create("/login")).cookie(newCookie).build();
+    } catch (Exception e) {
+      return Response.temporaryRedirect(URI.create("/login")).build();
+    }
+  }
+  // [END session_clear_and_revoke]
 }

--- a/src/test/resources/createSessionCookie.json
+++ b/src/test/resources/createSessionCookie.json
@@ -1,0 +1,3 @@
+{
+  "sessionCookie": "MockCookieString"
+}


### PR DESCRIPTION
* Added 3 new method to `FirebaseAuth` class:

```
ApiFuture<String> createSessionCookieAsync(String idToken, SessionCookieOptions options)
ApiFuture<FirebaseToken> verifySessionCookieAsync(String cookie)
ApiFuture<FirebaseToken> verifySessionCookieAsync(String cookie, boolean checkRevoked)
```

* Snippets demonstrate the JAXRS webapp environment. They will appear in https://firebase.google.com/docs/auth/admin/manage-cookies