### PR TITLE
Add handling of null response content

### DIFF
--- a/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
@@ -253,13 +253,14 @@ public class FirebaseMessaging {
 
   private void handleSendHttpError(HttpResponseException e) throws FirebaseMessagingException {
     MessagingServiceErrorResponse response = new MessagingServiceErrorResponse();
-    try {
-      JsonParser parser = jsonFactory.createJsonParser(e.getContent());
-      parser.parseAndClose(response);
-    } catch (IOException | NullPointerException ignored) {
-      // ignored
+    if (e.getContent() != null) {
+      try {
+        JsonParser parser = jsonFactory.createJsonParser(e.getContent());
+        parser.parseAndClose(response);
+      } catch (IOException ignored) {
+        // ignored
+      }
     }
-
     String code = FCM_ERROR_CODES.get(response.getErrorCode());
     if (code == null) {
       code = UNKNOWN_ERROR;

--- a/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
@@ -256,7 +256,7 @@ public class FirebaseMessaging {
     try {
       JsonParser parser = jsonFactory.createJsonParser(e.getContent());
       parser.parseAndClose(response);
-    } catch (IOException ignored) {
+    } catch (IOException | NullPointerException ignored) {
       // ignored
     }
 


### PR DESCRIPTION
If an error response comes back with no content, the json factory throws a
NullPointerException when it attempts to read the response, which hides the
response code from the client.

fixes #166 