### PR TITLE
Always re-run all transactions for server updates

### DIFF
--- a/src/main/java/com/google/firebase/database/core/Repo.java
+++ b/src/main/java/com/google/firebase/database/core/Repo.java
@@ -290,12 +290,8 @@ public class Repo implements PersistentConnection.Delegate {
         Node snap = NodeUtilities.NodeFromJSON(message);
         events = this.serverSyncTree.applyServerOverwrite(path, snap);
       }
-      if (events.size() > 0) {
-        // Since we have a listener outstanding for each transaction, receiving any events
-        // is a proxy for some change having occurred.
-        this.rerunTransactions(path);
-      }
 
+      this.rerunTransactions(path);
       postEvents(events);
     } catch (DatabaseException e) {
       logger.error("Firebase internal error", e);

--- a/src/test/java/com/google/firebase/database/integration/TransactionTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/TransactionTestIT.java
@@ -592,7 +592,8 @@ public class TransactionTestIT {
     // Write data to the backend from a secondary instance. The primary instance receives this data
     // when it goes online during the first transaction.
     FirebaseApp secondaryApp = IntegrationTestUtils.initApp("secondaryApp");
-    DatabaseReference initialData = FirebaseDatabase.getInstance(secondaryApp).getReference(ref.getKey());
+    DatabaseReference initialData =
+        FirebaseDatabase.getInstance(secondaryApp).getReference(ref.getKey());
     initialData.setValueAsync(new MapBuilder().put("a", "a").build()).get();
     secondaryApp.delete();
 


### PR DESCRIPTION
This PR addresses a dataloss issue that is reproducible when two transactions run at the same time and there is data on the backend that the client doesn't know about. 

The test fails reliably with the old code and passes with the new code.

Fixes: https://github.com/firebase/firebase-admin-java/issues/178