### PR TITLE
Reading project ID from GOOGLE_CLOUD_PROJECT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
--
+- [added] The SDK can now read the Firebase/GCP project ID from both
+  `GCLOUD_PROJECT` and `GOOGLE_CLOUD_PROJECT` environment variables.
 
 # v6.2.0
 

--- a/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/src/main/java/com/google/firebase/FirebaseApp.java
@@ -305,6 +305,9 @@ public class FirebaseApp {
 
     // Try to get project ID from the environment.
     if (Strings.isNullOrEmpty(projectId)) {
+      projectId = System.getenv("GOOGLE_CLOUD_PROJECT");
+    }
+    if (Strings.isNullOrEmpty(projectId)) {
       projectId = System.getenv("GCLOUD_PROJECT");
     }
     return projectId;

--- a/src/main/java/com/google/firebase/cloud/FirestoreClient.java
+++ b/src/main/java/com/google/firebase/cloud/FirestoreClient.java
@@ -19,9 +19,9 @@ import com.google.firebase.internal.NonNull;
  * <p>A Google Cloud project ID is required to access Firestore. FirestoreClient determines the
  * project ID from the {@link com.google.firebase.FirebaseOptions} used to initialize the underlying
  * {@link FirebaseApp}. If that is not available, it examines the credentials used to initialize
- * the app. Finally it attempts to get the project ID by looking up the GCLOUD_PROJECT environment
- * variable. If a project ID cannot be determined by any of these methods, this API will throw
- * a runtime exception.
+ * the app. Finally it attempts to get the project ID by looking up the GOOGLE_CLOUD_PROJECT and
+ * GCLOUD_PROJECT environment variables. If a project ID cannot be determined by any of these
+ * methods, this API will throw a runtime exception.
  */
 public class FirestoreClient {
 
@@ -33,7 +33,7 @@ public class FirestoreClient {
     checkArgument(!Strings.isNullOrEmpty(projectId),
         "Project ID is required for accessing Firestore. Use a service account credential or "
             + "set the project ID explicitly via FirebaseOptions. Alternatively you can also "
-            + "set the project ID via the GCLOUD_PROJECT environment variable.");
+            + "set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.");
     this.firestore = FirestoreOptions.newBuilder()
         .setCredentials(ImplFirebaseTrampolines.getCredentials(app))
         .setProjectId(projectId)

--- a/src/main/java/com/google/firebase/iid/FirebaseInstanceId.java
+++ b/src/main/java/com/google/firebase/iid/FirebaseInstanceId.java
@@ -79,7 +79,7 @@ public class FirebaseInstanceId {
     checkArgument(!Strings.isNullOrEmpty(projectId),
         "Project ID is required to access instance ID service. Use a service account credential or "
             + "set the project ID explicitly via FirebaseOptions. Alternatively you can also "
-            + "set the project ID via the GCLOUD_PROJECT environment variable.");
+            + "set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.");
   }
 
   /**

--- a/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
@@ -106,7 +106,7 @@ public class FirebaseMessaging {
     checkArgument(!Strings.isNullOrEmpty(projectId),
         "Project ID is required to access messaging service. Use a service account credential or "
             + "set the project ID explicitly via FirebaseOptions. Alternatively you can also "
-            + "set the project ID via the GCLOUD_PROJECT environment variable.");
+            + "set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.");
     this.url = String.format(FCM_URL, projectId);
   }
 

--- a/src/test/java/com/google/firebase/FirebaseAppTest.java
+++ b/src/test/java/com/google/firebase/FirebaseAppTest.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -131,6 +132,28 @@ public class FirebaseAppTest {
         TestUtils.setEnvironmentVariables(ImmutableMap.of(
             variable, Strings.nullToEmpty(gcloudProject)));
       }
+    }
+  }
+
+  @Test
+  public void testProjectIdEnvironmentVariablePrecedence() {
+    Map<String, String> currentValues = new HashMap<>();
+    currentValues.put("GCLOUD_PROJECT", Strings.nullToEmpty(
+        System.getenv("GCLOUD_PROJECT")));
+    currentValues.put("GOOGLE_CLOUD_PROJECT", Strings.nullToEmpty(
+        System.getenv("GOOGLE_CLOUD_PROJECT")));
+
+    TestUtils.setEnvironmentVariables(ImmutableMap.of(
+        "GCLOUD_PROJECT", "project-id-1", "GOOGLE_CLOUD_PROJECT", "project-id-2"));
+    FirebaseOptions options = new FirebaseOptions.Builder()
+        .setCredentials(new MockGoogleCredentials())
+        .build();
+    try {
+      FirebaseApp app = FirebaseApp.initializeApp(options,"myApp");
+      String projectId = ImplFirebaseTrampolines.getProjectId(app);
+      assertEquals("project-id-2", projectId);
+    } finally {
+      TestUtils.setEnvironmentVariables(currentValues);
     }
   }
 

--- a/src/test/java/com/google/firebase/FirebaseAppTest.java
+++ b/src/test/java/com/google/firebase/FirebaseAppTest.java
@@ -33,6 +33,8 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.auth.oauth2.OAuth2Credentials.CredentialsChangedListener;
 import com.google.common.base.Defaults;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.FirebaseApp.TokenRefresher;
 import com.google.firebase.FirebaseOptions.Builder;
@@ -53,7 +55,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -97,7 +98,7 @@ public class FirebaseAppTest {
   }
 
   @Test
-  public void testGetProjectIdFromOptions() throws Exception {
+  public void testGetProjectIdFromOptions() {
     FirebaseOptions options = new FirebaseOptions.Builder(OPTIONS)
         .setProjectId("explicit-project-id")
         .build();
@@ -107,10 +108,30 @@ public class FirebaseAppTest {
   }
 
   @Test
-  public void testGetProjectIdFromCredential() throws Exception {
+  public void testGetProjectIdFromCredential() {
     FirebaseApp app = FirebaseApp.initializeApp(OPTIONS, "myApp");
     String projectId = ImplFirebaseTrampolines.getProjectId(app);
     assertEquals("mock-project-id", projectId);
+  }
+
+  @Test
+  public void testGetProjectIdFromEnvironment() {
+    List<String> variables = ImmutableList.of("GCLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT");
+    for (String variable : variables) {
+      String gcloudProject = System.getenv(variable);
+      TestUtils.setEnvironmentVariables(ImmutableMap.of(variable, "project-id-1"));
+      FirebaseOptions options = new FirebaseOptions.Builder()
+          .setCredentials(new MockGoogleCredentials())
+          .build();
+      try {
+        FirebaseApp app = FirebaseApp.initializeApp(options,"myApp_" + variable);
+        String projectId = ImplFirebaseTrampolines.getProjectId(app);
+        assertEquals("project-id-1", projectId);
+      } finally {
+        TestUtils.setEnvironmentVariables(ImmutableMap.of(
+            variable, Strings.nullToEmpty(gcloudProject)));
+      }
+    }
   }
 
   @Test(expected = IllegalStateException.class)
@@ -251,7 +272,7 @@ public class FirebaseAppTest {
   }
 
   @Test
-  public void testTokenCaching() throws ExecutionException, InterruptedException, IOException {
+  public void testTokenCaching() {
     FirebaseApp firebaseApp = FirebaseApp.initializeApp(getMockCredentialOptions(), "myApp");
     String token1 = TestOnlyImplFirebaseTrampolines.getToken(
         firebaseApp, false);
@@ -263,7 +284,7 @@ public class FirebaseAppTest {
   }
 
   @Test
-  public void testTokenForceRefresh() throws ExecutionException, InterruptedException, IOException {
+  public void testTokenForceRefresh() {
     FirebaseApp firebaseApp = FirebaseApp.initializeApp(getMockCredentialOptions(), "myApp");
     String token1 = TestOnlyImplFirebaseTrampolines.getToken(firebaseApp, false);
     String token2 = TestOnlyImplFirebaseTrampolines.getToken(firebaseApp, true);
@@ -618,7 +639,7 @@ public class FirebaseAppTest {
   private static class MockGoogleCredentials extends GoogleCredentials {
 
     @Override
-    public AccessToken refreshAccessToken() throws IOException {
+    public AccessToken refreshAccessToken() {
       Date expiry = new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1));
       return new AccessToken(UUID.randomUUID().toString(), expiry);
     }


### PR DESCRIPTION
`GCLOUD_PROJECT` is no longer supported in some managed Google runtimes. `GOOGLE_CLOUD_PROJECT` is the new recommended environment variable.