### PR TITLE
Fixing an incorrect RTDB snippet

### DIFF
--- a/src/test/java/com/google/firebase/snippets/FirebaseDatabaseSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseDatabaseSnippets.java
@@ -145,7 +145,7 @@ public class FirebaseDatabaseSnippets {
 
     // [START adding_completion_callback]
     DatabaseReference dataRef = ref.child("data");
-    dataRef.setValueAsync("I'm writing data", new DatabaseReference.CompletionListener() {
+    dataRef.setValue("I'm writing data", new DatabaseReference.CompletionListener() {
       @Override
       public void onComplete(DatabaseError databaseError, DatabaseReference databaseReference) {
         if (databaseError != null) {


### PR DESCRIPTION
Second argument to `setValueAsync()` is a priority (type `Object`). Therefore the current snippet compiles, but does not work as expected. 