### PR TITLE
Upgraded google-cloud-firestore to the latest version (0.61.0-beta) …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,6 +399,11 @@
             <version>1.2.0</version>
         </dependency>
         <dependency>
+            <groupId>com.google.api</groupId>
+            <artifactId>gax</artifactId>
+            <version>1.30.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
             <version>0.8.0</version>
@@ -411,7 +416,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-firestore</artifactId>
-            <version>0.45.0-beta</version>
+            <version>0.61.0-beta</version>
         </dependency>
 
         <!-- Utilities -->

--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -66,6 +66,7 @@ public final class FirebaseOptions {
   private final int readTimeout;
   private final JsonFactory jsonFactory;
   private final ThreadManager threadManager;
+  private final boolean firestoreTimestampsInSnapshotsEnabled;
 
   private FirebaseOptions(@NonNull FirebaseOptions.Builder builder) {
     this.credentials = checkNotNull(builder.credentials,
@@ -94,6 +95,8 @@ public final class FirebaseOptions {
     this.connectTimeout = builder.connectTimeout;
     checkArgument(builder.readTimeout >= 0);
     this.readTimeout = builder.readTimeout;
+    this.firestoreTimestampsInSnapshotsEnabled =
+        builder.firestoreTimestampsInSnapshotsEnabled;
   }
 
   /**
@@ -188,6 +191,14 @@ public final class FirebaseOptions {
     return readTimeout;
   }
 
+  /**
+   * Returns whether or not {@link com.google.cloud.firestore.DocumentSnapshot DocumentSnapshots}
+   * return timestamp fields as {@link com.google.cloud.Timestamp Timestamps}.
+   */
+  public boolean areFirestoreTimestampsInSnapshotsEnabled() {
+    return firestoreTimestampsInSnapshotsEnabled;
+  }
+
   @NonNull
   ThreadManager getThreadManager() {
     return threadManager;
@@ -218,6 +229,7 @@ public final class FirebaseOptions {
     private ThreadManager threadManager = FirebaseThreadManagers.DEFAULT_THREAD_MANAGER;
     private int connectTimeout;
     private int readTimeout;
+    private boolean firestoreTimestampsInSnapshotsEnabled;
 
     /** Constructs an empty builder. */
     public Builder() {}
@@ -239,6 +251,7 @@ public final class FirebaseOptions {
       threadManager = options.threadManager;
       connectTimeout = options.connectTimeout;
       readTimeout = options.readTimeout;
+      firestoreTimestampsInSnapshotsEnabled = options.firestoreTimestampsInSnapshotsEnabled;
     }
 
     /**
@@ -408,6 +421,20 @@ public final class FirebaseOptions {
      */
     public Builder setReadTimeout(int readTimeout) {
       this.readTimeout = readTimeout;
+      return this;
+    }
+
+    /**
+     * Sets whether timestamps are enabled in Firestore
+     * {@link com.google.cloud.firestore.DocumentSnapshot DocumentSnapshots}.
+     *
+     * @param firestoreTimestampsInSnapshotsEnabled If true, timestamps are enabled in Firestore
+     *     DocumentSnapshots.
+     * @return This <code>Builder</code> instance is returned so subsequent calls can be chained.
+     */
+    public Builder setFirestoreTimestampsInSnapshotsEnabled(
+        boolean firestoreTimestampsInSnapshotsEnabled) {
+      this.firestoreTimestampsInSnapshotsEnabled = firestoreTimestampsInSnapshotsEnabled;
       return this;
     }
 

--- a/src/main/java/com/google/firebase/cloud/FirestoreClient.java
+++ b/src/main/java/com/google/firebase/cloud/FirestoreClient.java
@@ -35,6 +35,8 @@ public class FirestoreClient {
             + "set the project ID explicitly via FirebaseOptions. Alternatively you can also "
             + "set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.");
     this.firestore = FirestoreOptions.newBuilder()
+        .setTimestampsInSnapshotsEnabled(
+            app.getOptions().areFirestoreTimestampsInSnapshotsEnabled())
         .setCredentials(ImplFirebaseTrampolines.getCredentials(app))
         .setProjectId(projectId)
         .build()

--- a/src/test/java/com/google/firebase/cloud/FirestoreClientTest.java
+++ b/src/test/java/com/google/firebase/cloud/FirestoreClientTest.java
@@ -47,6 +47,33 @@ public class FirestoreClientTest {
   }
 
   @Test
+  public void testFirestoreTimestampsInSnapshotsEnabled_defaultsToFalse() throws IOException {
+    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+        .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
+        .setProjectId("explicit-project-id")
+        .build());
+    Firestore firestore = FirestoreClient.getFirestore(app);
+    assertEquals(false, firestore.getOptions().areTimestampsInSnapshotsEnabled());
+
+    firestore = FirestoreClient.getFirestore();
+    assertEquals(false, firestore.getOptions().areTimestampsInSnapshotsEnabled());
+  }
+
+  @Test
+  public void testFirestoreTimestampsInSnapshotsEnabled_setToTrue() throws IOException {
+    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+        .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
+        .setProjectId("explicit-project-id")
+        .setFirestoreTimestampsInSnapshotsEnabled(true)
+        .build());
+    Firestore firestore = FirestoreClient.getFirestore(app);
+    assertEquals(true, firestore.getOptions().areTimestampsInSnapshotsEnabled());
+
+    firestore = FirestoreClient.getFirestore();
+    assertEquals(true, firestore.getOptions().areTimestampsInSnapshotsEnabled());
+  }
+
+  @Test
   public void testAppDelete() throws IOException {
     FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))


### PR DESCRIPTION
…and added a FirebaseOptions#setFireStoreTimestampsInSnapshotsEnabled(boolean) method.

The FirestoreOptions#setTimestampsInSnapshotsEnabled(boolean) method is then called in the FirestoreClient constructor with the value passed to the FirebaseOptions#setFireStoreTimestampsInSnapshotsEnabled(boolean) method.

This allows for firebase-admin-java users to adapt to the Timestamps being returned in DocumentSnapshots as added in https://github.com/GoogleCloudPlatform/google-cloud-java/pull/3317

com.google.api:gax was added as a dependency to the pom.xml file as there were "java.lang.NoClassDefFoundError: com/google/api/gax/rpc/ClientStream" errors when running "mvn test" without this dependency.

A couple of tests were also added to the FirestoreClientTest class.

See also issue #204.