### PR TITLE
Cleaning up some Firebase Auth Unit Tests

### DIFF
--- a/src/test/java/com/google/firebase/FirebaseAppTest.java
+++ b/src/test/java/com/google/firebase/FirebaseAppTest.java
@@ -19,6 +19,7 @@ package com.google.firebase;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -448,6 +449,19 @@ public class FirebaseAppTest {
     assertEquals(0, refresher.cancelCalls);
   }
 
+  @Test
+  public void testAppWithAuthVariableOverrides() {
+    Map<String, Object> authVariableOverrides = ImmutableMap.<String, Object>of("uid", "uid1");
+    FirebaseOptions options =
+        new FirebaseOptions.Builder(getMockCredentialOptions())
+            .setDatabaseAuthVariableOverride(authVariableOverrides)
+            .build();
+    FirebaseApp app = FirebaseApp.initializeApp(options, "testGetAppWithUid");
+    assertEquals("uid1", app.getOptions().getDatabaseAuthVariableOverride().get("uid"));
+    String token = TestOnlyImplFirebaseTrampolines.getToken(app, false);
+    Assert.assertTrue(!token.isEmpty());
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testEmptyFirebaseConfigFile() {
     setFirebaseConfigEnvironmentVariable("firebase_config_empty.json");
@@ -458,9 +472,9 @@ public class FirebaseAppTest {
   public void testEmptyFirebaseConfigString() {
     setFirebaseConfigEnvironmentVariable("");
     FirebaseApp firebaseApp = FirebaseApp.initializeApp();
-    assertEquals(null, firebaseApp.getOptions().getProjectId());
-    assertEquals(null, firebaseApp.getOptions().getStorageBucket());
-    assertEquals(null, firebaseApp.getOptions().getDatabaseUrl());
+    assertNull(firebaseApp.getOptions().getProjectId());
+    assertNull(firebaseApp.getOptions().getStorageBucket());
+    assertNull(firebaseApp.getOptions().getDatabaseUrl());
     assertTrue(firebaseApp.getOptions().getDatabaseAuthVariableOverride().isEmpty()); 
   }
 
@@ -468,9 +482,9 @@ public class FirebaseAppTest {
   public void testEmptyFirebaseConfigJSONObject() {
     setFirebaseConfigEnvironmentVariable("{}");
     FirebaseApp firebaseApp = FirebaseApp.initializeApp();
-    assertEquals(null, firebaseApp.getOptions().getProjectId());
-    assertEquals(null, firebaseApp.getOptions().getStorageBucket());
-    assertEquals(null, firebaseApp.getOptions().getDatabaseUrl());
+    assertNull(firebaseApp.getOptions().getProjectId());
+    assertNull(firebaseApp.getOptions().getStorageBucket());
+    assertNull(firebaseApp.getOptions().getDatabaseUrl());
     assertTrue(firebaseApp.getOptions().getDatabaseAuthVariableOverride().isEmpty());
   }
 
@@ -514,9 +528,9 @@ public class FirebaseAppTest {
   public void testEnvironmentVariableIgnored() {
     setFirebaseConfigEnvironmentVariable("firebase_config.json");
     FirebaseApp firebaseApp = FirebaseApp.initializeApp(OPTIONS);
-    assertEquals(null, firebaseApp.getOptions().getProjectId());
-    assertEquals(null, firebaseApp.getOptions().getStorageBucket());
-    assertEquals(null, firebaseApp.getOptions().getDatabaseUrl());
+    assertNull(firebaseApp.getOptions().getProjectId());
+    assertNull(firebaseApp.getOptions().getStorageBucket());
+    assertNull(firebaseApp.getOptions().getDatabaseUrl());
     assertTrue(firebaseApp.getOptions().getDatabaseAuthVariableOverride().isEmpty());
   }
 

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
@@ -19,42 +19,30 @@ package com.google.firebase.auth;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.api.client.googleapis.testing.auth.oauth2.MockTokenServerTransport;
-import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.core.ApiFuture;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
-import com.google.auth.oauth2.UserCredentials;
 import com.google.common.base.Defaults;
 import com.google.common.base.Strings;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.ImplFirebaseTrampolines;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
-import com.google.firebase.auth.internal.FirebaseCustomAuthToken;
-import com.google.firebase.database.MapBuilder;
 import com.google.firebase.testing.ServiceAccount;
 import com.google.firebase.testing.TestUtils;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -66,86 +54,12 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
-@RunWith(Parameterized.class)
 public class FirebaseAuthTest {
 
-  private static final String ACCESS_TOKEN = "mockaccesstoken";
-  private static final String CLIENT_SECRET = "mockclientsecret";
-  private static final String CLIENT_ID = "mockclientid";
-  private static final String REFRESH_TOKEN = "mockrefreshtoken";
-  private static final JsonFactory JSON_FACTORY = Utils.getDefaultJsonFactory();
-
-  private final FirebaseOptions firebaseOptions;
-  private final boolean isCertCredential;
-
-  public FirebaseAuthTest(FirebaseOptions baseOptions, boolean isCertCredential) {
-    this.firebaseOptions = baseOptions;
-    this.isCertCredential = isCertCredential;
-  }
-
-  @Parameters
-  public static Collection<Object[]> data() throws Exception {
-    // Initialize this test suite with all available credential implementations.
-    return Arrays.asList(
-        new Object[][] {
-          {
-            new FirebaseOptions.Builder().setCredentials(createCertificateCredential()).build(),
-            /* isCertCredential */ true
-          },
-          {
-            new FirebaseOptions.Builder()
-                .setCredentials(createRefreshTokenCredential())
-                .setProjectId("test-project-id")
-                .build(),
-            /* isCertCredential */ false
-          },
-          {
-            new FirebaseOptions.Builder()
-                .setCredentials(TestUtils.getApplicationDefaultCredentials())
-                .build(),
-            /* isCertCredential */ false
-          },
-        });
-  }
-
-  private static GoogleCredentials createRefreshTokenCredential() throws IOException {
-
-    final MockTokenServerTransport transport = new MockTokenServerTransport();
-    transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
-
-    Map<String, Object> secretJson = new HashMap<>();
-    secretJson.put("client_id", CLIENT_ID);
-    secretJson.put("client_secret", CLIENT_SECRET);
-    secretJson.put("refresh_token", REFRESH_TOKEN);
-    secretJson.put("type", "authorized_user");
-    InputStream refreshTokenStream =
-        new ByteArrayInputStream(JSON_FACTORY.toByteArray(secretJson));
-
-    return UserCredentials.fromStream(refreshTokenStream, new HttpTransportFactory() {
-      @Override
-      public HttpTransport create() {
-        return transport;
-      }
-    });
-  }
-
-  private static GoogleCredentials createCertificateCredential() throws IOException {
-    final MockTokenServerTransport transport = new MockTokenServerTransport(
-        "https://accounts.google.com/o/oauth2/token");
-    transport.addServiceAccount(ServiceAccount.EDITOR.getEmail(), ACCESS_TOKEN);
-    return ServiceAccountCredentials.fromStream(ServiceAccount.EDITOR.asStream(),
-        new HttpTransportFactory() {
-          @Override
-          public HttpTransport create() {
-            return transport;
-          }
-        });
-  }
+  private static final FirebaseOptions firebaseOptions = FirebaseOptions.builder()
+      .setCredentials(createCertificateCredential())
+      .build();
 
   @Before
   public void setup() {
@@ -234,15 +148,14 @@ public class FirebaseAuthTest {
     assertNotNull(auth2);
     assertNotSame(auth1, auth2);
 
-    if (isCertCredential) {
-      ApiFuture<String> future = auth2.createCustomTokenAsync("foo");
-      assertNotNull(future);
-      assertNotNull(future.get(TestUtils.TEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
-    }
+    ApiFuture<String> future = auth2.createCustomTokenAsync("foo");
+    assertNotNull(future);
+    assertNotNull(future.get(TestUtils.TEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
   }
 
   @Test
   public void testAppWithAuthVariableOverrides() {
+    // TODO: Move this to somewhere more appropriate
     Map<String, Object> authVariableOverrides = Collections.singletonMap("uid", (Object) "uid1");
     FirebaseOptions options =
         new FirebaseOptions.Builder(firebaseOptions)
@@ -255,105 +168,20 @@ public class FirebaseAuthTest {
   }
 
   @Test
-  public void testCreateCustomToken() throws Exception {
-    GoogleCredentials credentials = TestOnlyImplFirebaseTrampolines.getCredentials(firebaseOptions);
-    Assume.assumeTrue("Skipping testCredentialCertificateRequired for cert credential",
-        credentials instanceof ServiceAccountCredentials);
-
-    FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "testCreateCustomToken");
-    FirebaseAuth auth = FirebaseAuth.getInstance(app);
-
-    String token = auth.createCustomTokenAsync("user1").get();
-
-    FirebaseCustomAuthToken parsedToken = FirebaseCustomAuthToken.parse(new GsonFactory(), token);
-    assertEquals(parsedToken.getPayload().getUid(), "user1");
-    assertEquals(parsedToken.getPayload().getSubject(), ServiceAccount.EDITOR.getEmail());
-    assertEquals(parsedToken.getPayload().getIssuer(), ServiceAccount.EDITOR.getEmail());
-    assertNull(parsedToken.getPayload().getDeveloperClaims());
-    assertTrue(ServiceAccount.EDITOR.verifySignature(parsedToken));
-  }
-
-  @Test
-  public void testCreateCustomTokenWithDeveloperClaims() throws Exception {
-    GoogleCredentials credentials = TestOnlyImplFirebaseTrampolines.getCredentials(firebaseOptions);
-    Assume.assumeTrue("Skipping testCredentialCertificateRequired for cert credential",
-        credentials instanceof ServiceAccountCredentials);
-
-    FirebaseApp app =
-        FirebaseApp.initializeApp(firebaseOptions, "testCreateCustomTokenWithDeveloperClaims");
-    FirebaseAuth auth = FirebaseAuth.getInstance(app);
-
-    String token =
-        auth.createCustomTokenAsync("user1", MapBuilder.of("claim", "value")).get();
-
-    FirebaseCustomAuthToken parsedToken = FirebaseCustomAuthToken.parse(new GsonFactory(), token);
-    assertEquals(parsedToken.getPayload().getUid(), "user1");
-    assertEquals(parsedToken.getPayload().getSubject(), ServiceAccount.EDITOR.getEmail());
-    assertEquals(parsedToken.getPayload().getIssuer(), ServiceAccount.EDITOR.getEmail());
-    assertEquals(parsedToken.getPayload().getDeveloperClaims().keySet().size(), 1);
-    assertEquals(parsedToken.getPayload().getDeveloperClaims().get("claim"), "value");
-    assertTrue(ServiceAccount.EDITOR.verifySignature(parsedToken));
-  }
-
-  @Test
-  public void testServiceAccountRequired() throws Exception {
-    GoogleCredentials credentials = TestOnlyImplFirebaseTrampolines.getCredentials(firebaseOptions);
-    Assume.assumeFalse("Skipping testServiceAccountRequired for service account credentials",
-        credentials instanceof ServiceAccountCredentials);
-
-    FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "testServiceAccountRequired");
+  public void testProjectIdRequired() {
+    FirebaseOptions options = FirebaseOptions.builder()
+        .setCredentials(new MockGoogleCredentials())
+        .build();
+    FirebaseApp app = FirebaseApp.initializeApp(options, "testProjectIdRequired");
     try {
-      FirebaseAuth.getInstance(app).createCustomTokenAsync("foo").get();
-      fail("Expected exception.");
-    } catch (IllegalStateException expected) {
-      Assert.assertEquals(
-          "Failed to initialize FirebaseTokenFactory. Make sure to initialize the SDK with "
-              + "service account credentials or specify a service account ID with "
-              + "iam.serviceAccounts.signBlob permission. Please refer to "
-              + "https://firebase.google.com/docs/auth/admin/create-custom-tokens for more details "
-              + "on creating custom tokens.",
-          expected.getMessage());
-    }
-  }
-
-  @Test
-  public void testProjectIdRequired() throws Exception {
-    FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "testProjectIdRequired");
-    String projectId = ImplFirebaseTrampolines.getProjectId(app);
-    Assume.assumeTrue("Skipping testProjectIdRequired for settings with project ID",
-        Strings.isNullOrEmpty(projectId));
-
-    try {
-      FirebaseAuth.getInstance(app).verifyIdTokenAsync("foo").get();
+      FirebaseAuth.getInstance(app);
       fail("Expected exception.");
     } catch (IllegalArgumentException expected) {
       Assert.assertEquals(
-          "Must initialize FirebaseApp with a project ID to call verifyIdToken()",
+          "Project ID is required to access the auth service. Use a service account credential "
+              + "or set the project ID explicitly via FirebaseOptions. Alternatively you can "
+              + "also set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.",
           expected.getMessage());
-    }
-  }
-
-  @Test
-  public void testVerifyIdTokenWithExplicitProjectId() throws Exception {
-    GoogleCredentials credentials = TestOnlyImplFirebaseTrampolines.getCredentials(firebaseOptions);
-    Assume.assumeFalse(
-        "Skipping testVerifyIdTokenWithExplicitProjectId for service account credentials",
-        credentials instanceof ServiceAccountCredentials);
-
-    FirebaseOptions options =
-        new FirebaseOptions.Builder(firebaseOptions)
-            .setProjectId("mock-project-id")
-            .build();
-    FirebaseApp app = FirebaseApp.initializeApp(options, "testVerifyIdTokenWithExplicitProjectId");
-    try {
-      FirebaseAuth.getInstance(app).verifyIdTokenAsync("foo").get();
-      fail("Expected exception.");
-    } catch (ExecutionException expected) {
-      Assert.assertNotEquals(
-          "com.google.firebase.FirebaseException: Must initialize FirebaseApp with a project ID "
-              + "to call verifyIdToken()",
-          expected.getMessage());
-      assertTrue(expected.getCause() instanceof IllegalArgumentException);
     }
   }
 
@@ -365,5 +193,22 @@ public class FirebaseAuthTest {
   @Test(expected = IllegalArgumentException.class)
   public void testAuthExceptionEmptyErrorCode() {
     new FirebaseAuthException("", "test");
+  }
+
+  private static GoogleCredentials createCertificateCredential() {
+    final MockTokenServerTransport transport = new MockTokenServerTransport(
+        "https://accounts.google.com/o/oauth2/token");
+    transport.addServiceAccount(ServiceAccount.EDITOR.getEmail(), "test-token");
+    try {
+      return ServiceAccountCredentials.fromStream(ServiceAccount.EDITOR.asStream(),
+          new HttpTransportFactory() {
+            @Override
+            public HttpTransport create() {
+              return transport;
+            }
+          });
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to initialize service account credential", e);
+    }
   }
 }

--- a/src/test/java/com/google/firebase/auth/FirebaseCustomTokenTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseCustomTokenTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.auth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.api.client.googleapis.testing.auth.oauth2.MockTokenServerTransport;
+import com.google.api.client.googleapis.util.Utils;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.auth.oauth2.UserCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.TestOnlyImplFirebaseTrampolines;
+import com.google.firebase.auth.internal.FirebaseCustomAuthToken;
+import com.google.firebase.database.MapBuilder;
+import com.google.firebase.testing.ServiceAccount;
+import com.google.firebase.testing.TestUtils;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class FirebaseCustomTokenTest {
+
+  private static final String ACCESS_TOKEN = "mockaccesstoken";
+  private static final String CLIENT_SECRET = "mockclientsecret";
+  private static final String CLIENT_ID = "mockclientid";
+  private static final String REFRESH_TOKEN = "mockrefreshtoken";
+  private static final JsonFactory JSON_FACTORY = Utils.getDefaultJsonFactory();
+
+  private final FirebaseOptions firebaseOptions;
+
+  public FirebaseCustomTokenTest(FirebaseOptions baseOptions) {
+    this.firebaseOptions = baseOptions;
+  }
+
+  @Parameters
+  public static Collection<Object[]> data() throws Exception {
+    // Initialize this test suite with all available credential implementations.
+    return Arrays.asList(
+        new Object[][] {
+            {
+                new FirebaseOptions.Builder().setCredentials(createCertificateCredential()).build(),
+            },
+            {
+                new FirebaseOptions.Builder()
+                    .setCredentials(createRefreshTokenCredential())
+                    .setProjectId("test-project-id")
+                    .build(),
+            },
+            {
+                new FirebaseOptions.Builder()
+                    .setCredentials(TestUtils.getApplicationDefaultCredentials())
+                    .build(),
+            },
+        });
+  }
+
+  @Before
+  public void setup() {
+    TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
+    FirebaseApp.initializeApp(firebaseOptions);
+  }
+
+  @After
+  public void cleanup() {
+    TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
+  }
+
+  @Test
+  public void testCreateCustomToken() throws Exception {
+    GoogleCredentials credentials = TestOnlyImplFirebaseTrampolines.getCredentials(firebaseOptions);
+    Assume.assumeTrue("Skipping testCredentialCertificateRequired for cert credential",
+        credentials instanceof ServiceAccountCredentials);
+
+    FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "testCreateCustomToken");
+    FirebaseAuth auth = FirebaseAuth.getInstance(app);
+
+    String token = auth.createCustomTokenAsync("user1").get();
+
+    FirebaseCustomAuthToken parsedToken = FirebaseCustomAuthToken.parse(new GsonFactory(), token);
+    assertEquals(parsedToken.getPayload().getUid(), "user1");
+    assertEquals(parsedToken.getPayload().getSubject(), ServiceAccount.EDITOR.getEmail());
+    assertEquals(parsedToken.getPayload().getIssuer(), ServiceAccount.EDITOR.getEmail());
+    assertNull(parsedToken.getPayload().getDeveloperClaims());
+    assertTrue(ServiceAccount.EDITOR.verifySignature(parsedToken));
+  }
+
+  @Test
+  public void testCreateCustomTokenWithDeveloperClaims() throws Exception {
+    GoogleCredentials credentials = TestOnlyImplFirebaseTrampolines.getCredentials(firebaseOptions);
+    Assume.assumeTrue("Skipping testCredentialCertificateRequired for cert credential",
+        credentials instanceof ServiceAccountCredentials);
+
+    FirebaseApp app =
+        FirebaseApp.initializeApp(firebaseOptions, "testCreateCustomTokenWithDeveloperClaims");
+    FirebaseAuth auth = FirebaseAuth.getInstance(app);
+
+    String token =
+        auth.createCustomTokenAsync("user1", MapBuilder.of("claim", "value")).get();
+
+    FirebaseCustomAuthToken parsedToken = FirebaseCustomAuthToken.parse(new GsonFactory(), token);
+    assertEquals(parsedToken.getPayload().getUid(), "user1");
+    assertEquals(parsedToken.getPayload().getSubject(), ServiceAccount.EDITOR.getEmail());
+    assertEquals(parsedToken.getPayload().getIssuer(), ServiceAccount.EDITOR.getEmail());
+    assertEquals(parsedToken.getPayload().getDeveloperClaims().keySet().size(), 1);
+    assertEquals(parsedToken.getPayload().getDeveloperClaims().get("claim"), "value");
+    assertTrue(ServiceAccount.EDITOR.verifySignature(parsedToken));
+  }
+
+  @Test
+  public void testServiceAccountRequired() throws Exception {
+    GoogleCredentials credentials = TestOnlyImplFirebaseTrampolines.getCredentials(firebaseOptions);
+    Assume.assumeFalse("Skipping testServiceAccountRequired for service account credentials",
+        credentials instanceof ServiceAccountCredentials);
+
+    FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "testServiceAccountRequired");
+    try {
+      FirebaseAuth.getInstance(app).createCustomTokenAsync("foo").get();
+      fail("Expected exception.");
+    } catch (IllegalStateException expected) {
+      Assert.assertEquals(
+          "Failed to initialize FirebaseTokenFactory. Make sure to initialize the SDK with "
+              + "service account credentials or specify a service account ID with "
+              + "iam.serviceAccounts.signBlob permission. Please refer to "
+              + "https://firebase.google.com/docs/auth/admin/create-custom-tokens for more details "
+              + "on creating custom tokens.",
+          expected.getMessage());
+    }
+  }
+
+  @Test
+  public void testVerifyIdTokenWithExplicitProjectId() throws Exception {
+    GoogleCredentials credentials = TestOnlyImplFirebaseTrampolines.getCredentials(firebaseOptions);
+    Assume.assumeFalse(
+        "Skipping testVerifyIdTokenWithExplicitProjectId for service account credentials",
+        credentials instanceof ServiceAccountCredentials);
+
+    FirebaseOptions options =
+        new FirebaseOptions.Builder(firebaseOptions)
+            .setProjectId("mock-project-id")
+            .build();
+    FirebaseApp app = FirebaseApp.initializeApp(options, "testVerifyIdTokenWithExplicitProjectId");
+    try {
+      FirebaseAuth.getInstance(app).verifyIdTokenAsync("foo").get();
+      fail("Expected exception.");
+    } catch (ExecutionException expected) {
+      Assert.assertNotEquals(
+          "com.google.firebase.FirebaseException: Must initialize FirebaseApp with a project ID "
+              + "to call verifyIdToken()",
+          expected.getMessage());
+      assertTrue(expected.getCause() instanceof IllegalArgumentException);
+    }
+  }
+
+  private static GoogleCredentials createRefreshTokenCredential() throws IOException {
+
+    final MockTokenServerTransport transport = new MockTokenServerTransport();
+    transport.addClient(CLIENT_ID, CLIENT_SECRET);
+    transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
+
+    Map<String, Object> secretJson = new HashMap<>();
+    secretJson.put("client_id", CLIENT_ID);
+    secretJson.put("client_secret", CLIENT_SECRET);
+    secretJson.put("refresh_token", REFRESH_TOKEN);
+    secretJson.put("type", "authorized_user");
+    InputStream refreshTokenStream =
+        new ByteArrayInputStream(JSON_FACTORY.toByteArray(secretJson));
+
+    return UserCredentials.fromStream(refreshTokenStream, new HttpTransportFactory() {
+      @Override
+      public HttpTransport create() {
+        return transport;
+      }
+    });
+  }
+
+  private static GoogleCredentials createCertificateCredential() throws IOException {
+    final MockTokenServerTransport transport = new MockTokenServerTransport(
+        "https://accounts.google.com/o/oauth2/token");
+    transport.addServiceAccount(ServiceAccount.EDITOR.getEmail(), ACCESS_TOKEN);
+    return ServiceAccountCredentials.fromStream(ServiceAccount.EDITOR.asStream(),
+        new HttpTransportFactory() {
+          @Override
+          public HttpTransport create() {
+            return transport;
+          }
+        });
+  }
+
+}

--- a/src/test/java/com/google/firebase/auth/FirebaseCustomTokenTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseCustomTokenTest.java
@@ -44,7 +44,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -164,30 +163,6 @@ public class FirebaseCustomTokenTest {
     }
   }
 
-  @Test
-  public void testVerifyIdTokenWithExplicitProjectId() throws Exception {
-    GoogleCredentials credentials = TestOnlyImplFirebaseTrampolines.getCredentials(firebaseOptions);
-    Assume.assumeFalse(
-        "Skipping testVerifyIdTokenWithExplicitProjectId for service account credentials",
-        credentials instanceof ServiceAccountCredentials);
-
-    FirebaseOptions options =
-        new FirebaseOptions.Builder(firebaseOptions)
-            .setProjectId("mock-project-id")
-            .build();
-    FirebaseApp app = FirebaseApp.initializeApp(options, "testVerifyIdTokenWithExplicitProjectId");
-    try {
-      FirebaseAuth.getInstance(app).verifyIdTokenAsync("foo").get();
-      fail("Expected exception.");
-    } catch (ExecutionException expected) {
-      Assert.assertNotEquals(
-          "com.google.firebase.FirebaseException: Must initialize FirebaseApp with a project ID "
-              + "to call verifyIdToken()",
-          expected.getMessage());
-      assertTrue(expected.getCause() instanceof IllegalArgumentException);
-    }
-  }
-
   private static GoogleCredentials createRefreshTokenCredential() throws IOException {
 
     final MockTokenServerTransport transport = new MockTokenServerTransport();
@@ -222,5 +197,4 @@ public class FirebaseCustomTokenTest {
           }
         });
   }
-
 }


### PR DESCRIPTION
* Moved custom token creation tests to a separate class (and added additional test cases to cover all cases)
* Moved one test case, which had nothing to do with auth, into `FirebaseAppTest` where it fits better