### PR TITLE
Closing Firestore instance on FirebaseApp.delete()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
--
+- [fixed] `Firestore` instances initialized by the SDK are now cleaned
+  up, when `FirebaseApp.delete()` is called.
 
 # v6.6.0
 

--- a/src/main/java/com/google/firebase/cloud/FirestoreClient.java
+++ b/src/main/java/com/google/firebase/cloud/FirestoreClient.java
@@ -11,6 +11,8 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.ImplFirebaseTrampolines;
 import com.google.firebase.internal.FirebaseService;
 import com.google.firebase.internal.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@code FirestoreClient} provides access to Google Cloud Firestore. Use this API to obtain a
@@ -25,6 +27,8 @@ import com.google.firebase.internal.NonNull;
  * methods, this API will throw a runtime exception.
  */
 public class FirestoreClient {
+
+  private static final Logger logger = LoggerFactory.getLogger(FirestoreClient.class);
 
   private final Firestore firestore;
 
@@ -89,10 +93,11 @@ public class FirestoreClient {
 
     @Override
     public void destroy() {
-      // NOTE: We don't explicitly tear down anything here (for now). User won't be able to call
-      // FirestoreClient.getFirestore() any more, but already created Firestore instances will
-      // continue to work. Request Firestore team to provide a cleanup/teardown method on the
-      // Firestore object.
+      try {
+        instance.firestore.close();
+      } catch (Exception e) {
+        logger.warn("Error while closing the Firestore instance", e);
+      }
     }
   }
 

--- a/src/test/java/com/google/firebase/cloud/FirestoreClientTest.java
+++ b/src/test/java/com/google/firebase/cloud/FirestoreClientTest.java
@@ -14,12 +14,20 @@ import com.google.firebase.FirebaseOptions;
 import com.google.firebase.FirebaseOptions.Builder;
 import com.google.firebase.ImplFirebaseTrampolines;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
+import com.google.firebase.auth.MockGoogleCredentials;
 import com.google.firebase.testing.ServiceAccount;
 import java.io.IOException;
 import org.junit.After;
 import org.junit.Test;
 
 public class FirestoreClientTest {
+
+  public static final FirestoreOptions FIRESTORE_OPTIONS = FirestoreOptions.newBuilder()
+      // Setting credentials is not required (they get overridden by Admin SDK), but without
+      // this Firestore logs an ugly warning during tests.
+      .setCredentials(new MockGoogleCredentials("test-token"))
+      .setTimestampsInSnapshotsEnabled(true)
+      .build();
 
   @After
   public void tearDown() {
@@ -31,9 +39,7 @@ public class FirestoreClientTest {
     FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .setProjectId("explicit-project-id")
-        .setFirestoreOptions(FirestoreOptions.newBuilder()
-            .setTimestampsInSnapshotsEnabled(true)
-            .build())
+        .setFirestoreOptions(FIRESTORE_OPTIONS)
         .build());
     Firestore firestore = FirestoreClient.getFirestore(app);
     assertEquals("explicit-project-id", firestore.getOptions().getProjectId());
@@ -46,9 +52,7 @@ public class FirestoreClientTest {
   public void testServiceAccountProjectId() throws IOException {
     FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
-        .setFirestoreOptions(FirestoreOptions.newBuilder()
-            .setTimestampsInSnapshotsEnabled(true)
-            .build())
+        .setFirestoreOptions(FIRESTORE_OPTIONS)
         .build());
     Firestore firestore = FirestoreClient.getFirestore(app);
     assertEquals("mock-project-id", firestore.getOptions().getProjectId());
@@ -62,9 +66,7 @@ public class FirestoreClientTest {
     FirebaseApp app = FirebaseApp.initializeApp(new Builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .setProjectId("explicit-project-id")
-        .setFirestoreOptions(FirestoreOptions.newBuilder()
-            .setTimestampsInSnapshotsEnabled(true)
-            .build())
+        .setFirestoreOptions(FIRESTORE_OPTIONS)
         .build());
     Firestore firestore = FirestoreClient.getFirestore(app);
     assertEquals("explicit-project-id", firestore.getOptions().getProjectId());
@@ -104,9 +106,7 @@ public class FirestoreClientTest {
     FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .setProjectId("mock-project-id")
-        .setFirestoreOptions(FirestoreOptions.newBuilder()
-            .setTimestampsInSnapshotsEnabled(true)
-            .build())
+        .setFirestoreOptions(FIRESTORE_OPTIONS)
         .build());
 
     assertNotNull(FirestoreClient.getFirestore(app));


### PR DESCRIPTION
Ensures proper clean up of Firestore instance. Helps avoid warnings such as the following during tests:

```
Nov 28, 2018 4:46:23 PM io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference cleanQueue
SEVERE: *~*~*~ Channel ManagedChannelImpl{logId=1, target=firestore.googleapis.com:443} was not shutdown properly!!! ~*~*~*
    Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
java.lang.RuntimeException: ManagedChannel allocation site
	at io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference.<init>(ManagedChannelOrphanWrapper.java:103)
```