### PR TITLE
Add SLF4J-simple dependency for tests execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,6 +465,11 @@
 
         <!-- Test Dependencies -->
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.7.21</version>


### PR DESCRIPTION
Without the `slf4j-simple` dependency, log-statements during tests
are ignored and the following warning is printed instead:

> SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
> SLF4J: Defaulting to no-operation (NOP) logger implementation
> SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

The error is documented here too:
https://www.slf4j.org/codes.html#StaticLoggerBinder

--- Currently:

$ mvn verify
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.google.firebase.iid.FirebaseInstanceIdIT
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.494 sec - in com.google.firebase.iid.FirebaseInstanceIdIT

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

--- With the dependency:

$ mvn verify
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.google.firebase.iid.FirebaseInstanceIdIT
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.536 sec - in com.google.firebase.iid.FirebaseInstanceIdIT

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0