### PR TITLE
Updated documentation and sample snippet

### DIFF
--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -296,7 +296,8 @@ public final class FirebaseOptions {
     }
 
     /**
-     * Sets the <code>GoogleCredentials</code> to use to authenticate the SDK.
+     * Sets the <code>GoogleCredentials</code> to use to authenticate the SDK. This parameter
+     * must be specified when creating a new instance of {@link FirebaseOptions}.
      *
      * <p>See <a href="https://firebase.google.com/docs/admin/setup#initialize_the_sdk">
      * Initialize the SDK</a> for code samples and detailed documentation.

--- a/src/test/java/com/google/firebase/snippets/FirebaseAppSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseAppSnippets.java
@@ -121,9 +121,10 @@ public class FirebaseAppSnippets {
     // [END access_services_nondefault]
   }
 
-  public void initializeWithServiceAccountId() {
+  public void initializeWithServiceAccountId() throws IOException {
     // [START initialize_sdk_with_service_account_id]
     FirebaseOptions options = new FirebaseOptions.Builder()
+        .setCredentials(GoogleCredentials.getApplicationDefault())
         .setServiceAccountId("my-client-id@my-project-id.iam.gserviceaccount.com")
         .build();
     FirebaseApp.initializeApp(options);


### PR DESCRIPTION
`GoogleCredentials` are required when creating `FirebaseOptions`. This PR makes this requirement explicit in the documentation and samples.

Resolves #234 