### PR TITLE
Fix for the uploadAccountResponse for correct error message/reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [changed] Removed org.json dependency and replaced with com.google.code.gson.
 - [changed] Upgraded Mockito dependency, and fixed the build on Java 11.
+- [fixed] UploadAccountResponse now has the correct error message/reason.
 
 # v6.7.0
 

--- a/src/main/java/com/google/firebase/auth/internal/UploadAccountResponse.java
+++ b/src/main/java/com/google/firebase/auth/internal/UploadAccountResponse.java
@@ -35,7 +35,7 @@ public class UploadAccountResponse {
     @Key("index")
     private int index;
 
-    @Key("message")
+    @Key("errorMessage")
     private String message;
 
     public int getIndex() {

--- a/src/test/resources/importUsersError.json
+++ b/src/test/resources/importUsersError.json
@@ -1,6 +1,6 @@
 {
   "error": [
-    {"index": 0, "message": "Some error occurred in user1"},
-    {"index": 2, "message": "Another error occurred in user3"}
+    {"index": 0, "errorMessage": "Some error occurred in user1"},
+    {"index": 2, "errorMessage": "Another error occurred in user3"}
   ]
 }


### PR DESCRIPTION
Fix in the UploadAccountResponse object for mapping the error message.