### PR TITLE
Deferring the initialization of FirebaseUserManager

### DIFF
--- a/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
@@ -46,7 +46,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class FirebaseAuthTest {
@@ -139,21 +138,12 @@ public class FirebaseAuthTest {
   }
 
   @Test
-  public void testProjectIdRequired() {
+  public void testProjectIdNotRequiredAtInitialization() {
     FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials())
         .build();
     FirebaseApp app = FirebaseApp.initializeApp(options, "testProjectIdRequired");
-    try {
-      FirebaseAuth.getInstance(app);
-      fail("Expected exception.");
-    } catch (IllegalArgumentException expected) {
-      Assert.assertEquals(
-          "Project ID is required to access the auth service. Use a service account credential "
-              + "or set the project ID explicitly via FirebaseOptions. Alternatively you can "
-              + "also set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.",
-          expected.getMessage());
-    }
+    assertNotNull(FirebaseAuth.getInstance(app));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -85,10 +85,16 @@ public class FirebaseUserManagerTest {
     FirebaseApp.initializeApp(new FirebaseOptions.Builder()
             .setCredentials(credentials)
             .build());
+    FirebaseAuth auth = FirebaseAuth.getInstance();
     try {
-      FirebaseAuth.getInstance();
+      auth.getUserManager();
       fail("No error thrown for missing project ID");
     } catch (IllegalArgumentException expected) {
+      assertEquals(
+          "Project ID is required to access the auth service. Use a service account credential "
+              + "or set the project ID explicitly via FirebaseOptions. Alternatively you can "
+              + "also set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.",
+          expected.getMessage());
     }
   }
 


### PR DESCRIPTION
`FirebaseUserManager` requires a project ID. Currently we init the user manager when creating `FirebaseAuth`, which fails if a project ID is not specified. To be consistent with how other child-components are initialized in `FirebaseAuth`, I'm using the `Supplier` interface to defer the initialization of `FirebaseUserManager`.