### PR TITLE
Add missing WebpushFcmOptions entity (as per documentation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
--
+- [added] Added `WebpushFcmOptions` to the `FirebaseMessaging` API, which 
+  provides `setLink()` method.
 
 # v6.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
-- [added] Added `WebpushFcmOptions` to the `FirebaseMessaging` API, which 
-  provides `setLink()` method.
+- [added] Added `WebpushFcmOptions` to the `FirebaseMessaging` API, providing 
+  the `setLink()` method.
 
 # v6.9.0
 

--- a/src/main/java/com/google/firebase/messaging/WebpushConfig.java
+++ b/src/main/java/com/google/firebase/messaging/WebpushConfig.java
@@ -19,6 +19,7 @@ package com.google.firebase.messaging;
 import com.google.api.client.util.Key;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.internal.NonNull;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,10 +38,14 @@ public class WebpushConfig {
   @Key("notification")
   private final Map<String, Object> notification;
 
+  @Key("fcm_options")
+  private final WebpushFcmOptions fcmOptions;
+
   private WebpushConfig(Builder builder) {
     this.headers = builder.headers.isEmpty() ? null : ImmutableMap.copyOf(builder.headers);
     this.data = builder.data.isEmpty() ? null : ImmutableMap.copyOf(builder.data);
     this.notification = builder.notification != null ? builder.notification.getFields() : null;
+    this.fcmOptions = builder.fcmOptions;
   }
 
   /**
@@ -57,6 +62,8 @@ public class WebpushConfig {
     private final Map<String, String> headers = new HashMap<>();
     private final Map<String, String> data = new HashMap<>();
     private WebpushNotification notification;
+    private WebpushFcmOptions fcmOptions;
+
 
     private Builder() {}
 
@@ -122,6 +129,17 @@ public class WebpushConfig {
      */
     public Builder setNotification(WebpushNotification notification) {
       this.notification = notification;
+      return this;
+    }
+
+    /**
+     * Sets the Webpush FCM options to be included in the Webpush config.
+     *
+     * @param fcmOptions A {@link WebpushFcmOptions} instance.
+     * @return This builder.
+     */
+    public Builder setFcmOptions(WebpushFcmOptions fcmOptions) {
+      this.fcmOptions = fcmOptions;
       return this;
     }
 

--- a/src/main/java/com/google/firebase/messaging/WebpushFcmOptions.java
+++ b/src/main/java/com/google/firebase/messaging/WebpushFcmOptions.java
@@ -1,0 +1,23 @@
+package com.google.firebase.messaging;
+
+import com.google.api.client.util.Key;
+
+/**
+ * Represents options for features provided by the FCM SDK for Web.
+ * Can be included in {@link WebpushConfig}. Instances of this class are thread-safe and immutable.
+ */
+public class WebpushFcmOptions {
+
+  @Key("link")
+  private final String link;
+
+  /**
+   * Creates a new {@code WebpushFcmOptions} using given link.
+   *
+   * @param link The link to open when the user clicks on the notification.
+   *             For all URL values, HTTPS is required.
+   */
+  public WebpushFcmOptions(String link) {
+    this.link = link;
+  }
+}

--- a/src/main/java/com/google/firebase/messaging/WebpushFcmOptions.java
+++ b/src/main/java/com/google/firebase/messaging/WebpushFcmOptions.java
@@ -6,10 +6,14 @@ import com.google.api.client.util.Key;
  * Represents options for features provided by the FCM SDK for Web.
  * Can be included in {@link WebpushConfig}. Instances of this class are thread-safe and immutable.
  */
-public class WebpushFcmOptions {
+public final class WebpushFcmOptions {
 
   @Key("link")
   private final String link;
+
+  private WebpushFcmOptions(Builder builder) {
+    this.link = builder.link;
+  }
 
   /**
    * Creates a new {@code WebpushFcmOptions} using given link.
@@ -17,7 +21,42 @@ public class WebpushFcmOptions {
    * @param link The link to open when the user clicks on the notification.
    *             For all URL values, HTTPS is required.
    */
-  public WebpushFcmOptions(String link) {
-    this.link = link;
+  public static WebpushFcmOptions withLink(String link) {
+    return new Builder().setLink(link).build();
+  }
+
+  /**
+   * Creates a new {@link WebpushFcmOptions.Builder}.
+   *
+   * @return An {@link WebpushFcmOptions.Builder} instance.
+   */
+  public static WebpushFcmOptions.Builder builder() {
+    return new WebpushFcmOptions.Builder();
+  }
+
+  public static class Builder {
+
+    private String link;
+
+    private Builder() {}
+
+    /**
+     * @param link The link to open when the user clicks on the notification.
+     *             For all URL values, HTTPS is required.
+     * @return This builder
+     */
+    public WebpushFcmOptions.Builder setLink(String link) {
+      this.link = link;
+      return this;
+    }
+
+    /**
+     * Creates a new {@link WebpushFcmOptions} instance from the parameters set on this builder.
+     *
+     * @return A new {@link WebpushFcmOptions} instance.
+     */
+    public WebpushFcmOptions build() {
+      return new WebpushFcmOptions(this);
+    }
   }
 }

--- a/src/main/java/com/google/firebase/messaging/WebpushFcmOptions.java
+++ b/src/main/java/com/google/firebase/messaging/WebpushFcmOptions.java
@@ -30,7 +30,7 @@ public final class WebpushFcmOptions {
    *
    * @return An {@link WebpushFcmOptions.Builder} instance.
    */
-  public static WebpushFcmOptions.Builder builder() {
+  public static Builder builder() {
     return new WebpushFcmOptions.Builder();
   }
 
@@ -45,7 +45,7 @@ public final class WebpushFcmOptions {
      *             For all URL values, HTTPS is required.
      * @return This builder
      */
-    public WebpushFcmOptions.Builder setLink(String link) {
+    public Builder setLink(String link) {
       this.link = link;
       return this;
     }

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
@@ -781,6 +781,7 @@ public class FirebaseMessagingClientImplTest {
                     .putCustomData("k4", "v4")
                     .putAllCustomData(ImmutableMap.<String, Object>of("k5", "v5", "k6", "v6"))
                     .build())
+                .setFcmOptions(new WebpushFcmOptions("https://firebase.google.com"))
                 .build())
             .setTopic("test-topic")
             .build(),
@@ -811,7 +812,8 @@ public class FirebaseMessagingClientImplTest {
                     .put("k4", "v4")
                     .put("k5", "v5")
                     .put("k6", "v6")
-                    .build())
+                    .build(),
+                "fcm_options", ImmutableMap.of("link", "https://firebase.google.com"))
         ));
 
     return builder.build();

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
@@ -781,7 +781,7 @@ public class FirebaseMessagingClientImplTest {
                     .putCustomData("k4", "v4")
                     .putAllCustomData(ImmutableMap.<String, Object>of("k5", "v5", "k6", "v6"))
                     .build())
-                .setFcmOptions(new WebpushFcmOptions("https://firebase.google.com"))
+                .setFcmOptions(WebpushFcmOptions.withLink("https://firebase.google.com"))
                 .build())
             .setTopic("test-topic")
             .build(),

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingIT.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingIT.java
@@ -59,6 +59,7 @@ public class FirebaseMessagingIT {
         .setWebpushConfig(WebpushConfig.builder()
             .putHeader("X-Custom-Val", "Foo")
             .setNotification(new WebpushNotification("Title", "Body"))
+            .setFcmOptions(new WebpushFcmOptions("https://firebase.google.com"))
             .build())
         .setTopic("foo-bar")
         .build();

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingIT.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingIT.java
@@ -59,7 +59,7 @@ public class FirebaseMessagingIT {
         .setWebpushConfig(WebpushConfig.builder()
             .putHeader("X-Custom-Val", "Foo")
             .setNotification(new WebpushNotification("Title", "Body"))
-            .setFcmOptions(new WebpushFcmOptions("https://firebase.google.com"))
+            .setFcmOptions(WebpushFcmOptions.withLink("https://firebase.google.com"))
             .build())
         .setTopic("foo-bar")
         .build();

--- a/src/test/java/com/google/firebase/messaging/MessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MessageTest.java
@@ -279,7 +279,7 @@ public class MessageTest {
             .putAllHeaders(ImmutableMap.of("k2", "v2", "k3", "v3"))
             .putData("k1", "v1")
             .putAllData(ImmutableMap.of("k2", "v2", "k3", "v3"))
-            .setFcmOptions(new WebpushFcmOptions("https://my-server/page"))
+            .setFcmOptions(WebpushFcmOptions.withLink("https://my-server/page"))
             .build())
         .setTopic("test-topic")
         .build();

--- a/src/test/java/com/google/firebase/messaging/MessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MessageTest.java
@@ -272,6 +272,26 @@ public class MessageTest {
   }
 
   @Test
+  public void testWebpushMessageWithWebpushOptions() throws IOException {
+    Message message = Message.builder()
+        .setWebpushConfig(WebpushConfig.builder()
+            .putHeader("k1", "v1")
+            .putAllHeaders(ImmutableMap.of("k2", "v2", "k3", "v3"))
+            .putData("k1", "v1")
+            .putAllData(ImmutableMap.of("k2", "v2", "k3", "v3"))
+            .setFcmOptions(new WebpushFcmOptions("https://my-server/page"))
+            .build())
+        .setTopic("test-topic")
+        .build();
+    Map<String, Object> data = ImmutableMap.<String, Object>of(
+        "headers", ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3"),
+        "data", ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3"),
+        "fcm_options", ImmutableMap.of("link", "https://my-server/page")
+    );
+    assertJsonEquals(ImmutableMap.of("topic", "test-topic", "webpush", data), message);
+  }
+
+  @Test
   public void testWebpushMessageWithNotification() throws IOException {
     Message message = Message.builder()
         .setWebpushConfig(WebpushConfig.builder()

--- a/src/test/java/com/google/firebase/snippets/FirebaseMessagingSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseMessagingSnippets.java
@@ -240,7 +240,7 @@ public class FirebaseMessagingSnippets {
                 "$GOOG up 1.43% on the day",
                 "$GOOG gained 11.80 points to close at 835.67, up 1.43% on the day.",
                 "https://my-server/icon.png"))
-            .setFcmOptions(new WebpushFcmOptions("https://my-server/page-to-open-on-click"))
+            .setFcmOptions(WebpushFcmOptions.withLink("https://my-server/page-to-open-on-click"))
             .build())
         .setTopic("industry-tech")
         .build();

--- a/src/test/java/com/google/firebase/snippets/FirebaseMessagingSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseMessagingSnippets.java
@@ -30,6 +30,7 @@ import com.google.firebase.messaging.Notification;
 import com.google.firebase.messaging.SendResponse;
 import com.google.firebase.messaging.TopicManagementResponse;
 import com.google.firebase.messaging.WebpushConfig;
+import com.google.firebase.messaging.WebpushFcmOptions;
 import com.google.firebase.messaging.WebpushNotification;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -239,6 +240,7 @@ public class FirebaseMessagingSnippets {
                 "$GOOG up 1.43% on the day",
                 "$GOOG gained 11.80 points to close at 835.67, up 1.43% on the day.",
                 "https://my-server/icon.png"))
+            .setFcmOptions(new WebpushFcmOptions("https://my-server/page-to-open-on-click"))
             .build())
         .setTopic("industry-tech")
         .build();


### PR DESCRIPTION
WebpushFcmOptions is described in [documentation](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#webpushfcmoptions) but is not included in Java client.

Corresponding issue - #294
