### PR TITLE
Add image in notification support.

### DIFF
--- a/src/main/java/com/google/firebase/messaging/AndroidNotification.java
+++ b/src/main/java/com/google/firebase/messaging/AndroidNotification.java
@@ -66,6 +66,9 @@ public class AndroidNotification {
   
   @Key("channel_id")
   private final String channelId;
+  
+  @Key("image")
+  private final String image;
 
   private AndroidNotification(Builder builder) {
     this.title = builder.title;
@@ -97,6 +100,7 @@ public class AndroidNotification {
       this.titleLocArgs = null;
     }
     this.channelId = builder.channelId;
+    this.image = builder.image;
   }
 
   /**
@@ -122,6 +126,7 @@ public class AndroidNotification {
     private String titleLocKey;
     private List<String> titleLocArgs = new ArrayList<>();
     private String channelId;
+    private String image;
 
     private Builder() {}
 
@@ -289,6 +294,18 @@ public class AndroidNotification {
      */
     public Builder setChannelId(String channelId) {
       this.channelId = channelId;
+      return this;
+    }
+
+    /**
+     * Sets the URL of the image that is going to be displayed in the notification. When provided, 
+     * overrides the image set via {@link Notification}.
+     *
+     * @param image URL of the image that is going to be displayed in the notification.
+     * @return This builder.
+     */
+    public Builder setImage(String image) {
+      this.image = image;
       return this;
     }
 

--- a/src/main/java/com/google/firebase/messaging/ApnsFcmOptions.java
+++ b/src/main/java/com/google/firebase/messaging/ApnsFcmOptions.java
@@ -24,10 +24,14 @@ public final class ApnsFcmOptions {
 
   @Key("analytics_label")
   private final String analyticsLabel;
+  
+  @Key("image")
+  private final String image;
 
   private ApnsFcmOptions(Builder builder) {
     FcmOptionsUtil.checkAnalyticsLabel(builder.analyticsLabel);
     this.analyticsLabel = builder.analyticsLabel;
+    this.image = builder.image;
   }
 
   /**
@@ -53,6 +57,8 @@ public final class ApnsFcmOptions {
 
     private String analyticsLabel;
 
+    private String image;
+
     private Builder() {}
 
     /**
@@ -61,6 +67,15 @@ public final class ApnsFcmOptions {
      */
     public Builder setAnalyticsLabel(String analyticsLabel) {
       this.analyticsLabel = analyticsLabel;
+      return this;
+    }
+
+    /**
+     * @param image URL of the image that is going to be displayed in the notification.
+     * @return This builder
+     */
+    public Builder setImage(String image) {
+      this.image = image;
       return this;
     }
 

--- a/src/main/java/com/google/firebase/messaging/Notification.java
+++ b/src/main/java/com/google/firebase/messaging/Notification.java
@@ -29,6 +29,9 @@ public class Notification {
 
   @Key("body")
   private final String body;
+  
+  @Key("image")
+  private final String image;
 
   /**
    * Creates a new {@code Notification} using the given title and body.
@@ -39,6 +42,20 @@ public class Notification {
   public Notification(String title, String body) {
     this.title = title;
     this.body = body;
+    this.image = null;
+  }
+  
+  /**
+   * Creates a new {@code Notification} using the given title, body, and image.
+   *
+   * @param title Title of the notification.
+   * @param body Body of the notification.
+   * @param image URL of the image that is going to be displayed in the notification.
+   */
+  public Notification(String title, String body, String image) {
+    this.title = title;
+    this.body = body;
+    this.image = image;
   }
 
 }

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingIT.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingIT.java
@@ -44,7 +44,7 @@ public class FirebaseMessagingIT {
   public void testSend() throws Exception {
     FirebaseMessaging messaging = FirebaseMessaging.getInstance();
     Message message = Message.builder()
-        .setNotification(new Notification("Title", "Body"))
+        .setNotification(new Notification("Title", "Body", "Image.png"))
         .setAndroidConfig(AndroidConfig.builder()
             .setRestrictedPackageName("com.google.firebase.testing")
             .build())

--- a/src/test/java/com/google/firebase/messaging/MessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MessageTest.java
@@ -678,6 +678,76 @@ public class MessageTest {
     }
   }
 
+  @Test
+  public void testImageInNotification() throws IOException {
+    Message message = Message.builder()
+        .setNotification(new Notification("title", "body", "image.png"))
+        .setTopic("test-topic")
+        .build();
+    Map<String, String> data = ImmutableMap.of(
+        "title", "title", "body", "body", "image", "image.png");
+    assertJsonEquals(ImmutableMap.of("topic", "test-topic", "notification", data), message);
+  }
+
+  @Test
+  public void testImageInAndroidNotification() throws IOException {
+    Message message = Message.builder()
+        .setNotification(new Notification("title", "body", "image.png"))
+        .setAndroidConfig(AndroidConfig.builder()
+        .setNotification(AndroidNotification.builder()
+            .setTitle("android-title")
+            .setBody("android-body")
+            .setImage("android-image.png")
+            .build())
+        .build())
+        .setTopic("test-topic")
+        .build();
+    Map<String, Object> notification = ImmutableMap.<String, Object>builder()
+        .put("title", "title")
+        .put("body", "body")
+        .put("image", "image.png")
+        .build();
+    Map<String, Object> androidConfig = ImmutableMap.<String, Object>builder()
+        .put("notification", ImmutableMap.<String, Object>builder()
+            .put("title", "android-title")
+            .put("body", "android-body")
+            .put("image", "android-image.png")
+            .build())
+        .build();
+    assertJsonEquals(ImmutableMap.of(
+        "topic", "test-topic", "notification", notification, "android", androidConfig), message);
+  }
+  
+  @Test
+  public void testImageInApnsNotification() throws IOException {
+    Message message = Message.builder()
+        .setTopic("test-topic")
+        .setNotification(new Notification("title", "body", "image.png"))
+        .setApnsConfig(
+            ApnsConfig.builder().setAps(Aps.builder().build())
+                .setFcmOptions(ApnsFcmOptions.builder().setImage("apns-image.png").build())
+                .build()).build();
+
+    ImmutableMap<String, Object> notification =
+        ImmutableMap.<String, Object>builder()
+            .put("title", "title")
+            .put("body", "body")
+            .put("image", "image.png")
+            .build();
+    ImmutableMap<String, Object> apnsConfig =
+        ImmutableMap.<String, Object>builder()
+            .put("fcm_options", ImmutableMap.of("image", "apns-image.png"))
+            .put("payload", ImmutableMap.of("aps", ImmutableMap.of()))
+            .build();
+    ImmutableMap<String, Object> expected =
+        ImmutableMap.<String, Object>builder()
+            .put("topic", "test-topic")
+            .put("notification", notification)
+            .put("apns", apnsConfig)
+            .build();
+    assertJsonEquals(expected, message);
+  }
+
   private static void assertJsonEquals(
       Map expected, Object actual) throws IOException {
     assertEquals(expected, toMap(actual));


### PR DESCRIPTION
Add image in notification support.

### Testing

  * Added unit tests and modified one existing integration test to reflect this change.

### API Changes

  * In Firebase Cloud Messaging, added "image" field in the general Notification class, the AndroidNotification class, and the ApnsFcmOptions class.