### PR TITLE
feat(rtdb): Connect to RTDB emulator when valid emulator URL is passed OR env vars are set correctly

### DIFF
--- a/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/src/main/java/com/google/firebase/FirebaseApp.java
@@ -34,7 +34,8 @@ import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.firebase.database.util.EmulatorHelper;
+import com.google.firebase.FirebaseOptions.DeferredApplicationCredentials;
+import com.google.firebase.FirebaseOptions.DeferredApplicationCredentials.CredentialsGenerator;
 import com.google.firebase.internal.FirebaseAppStore;
 import com.google.firebase.internal.FirebaseScheduledExecutor;
 import com.google.firebase.internal.FirebaseService;
@@ -46,7 +47,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -583,7 +583,8 @@ public class FirebaseApp {
   private static FirebaseOptions getOptionsFromEnvironment() throws IOException {
     String defaultConfig = System.getenv(FIREBASE_CONFIG_ENV_VAR);
     if (Strings.isNullOrEmpty(defaultConfig)) {
-      return new FirebaseOptions.Builder().setCredentials(getApplicationDefaultOrEmptyCredentials())
+      return new FirebaseOptions.Builder()
+          .setDeferredCredentials(DEFAULT_OR_EMPTY_CREDS)
           .build();
     }
     JsonFactory jsonFactory = Utils.getDefaultJsonFactory();
@@ -597,18 +598,22 @@ public class FirebaseApp {
       parser = jsonFactory.createJsonParser(reader);
     }
     parser.parseAndClose(builder);
-    builder.setCredentials(getApplicationDefaultOrEmptyCredentials());
+    builder.setDeferredCredentials(DEFAULT_OR_EMPTY_CREDS);
     return builder.build();
   }
 
-  private static GoogleCredentials getApplicationDefaultOrEmptyCredentials() {
-    try {
-      return GoogleCredentials.getApplicationDefault();
-    } catch (IOException e) {
-      logger.error(
-          "Failed to fetch default application credentials. Proceeding with blank credentials.",
-          e);
-      return GoogleCredentials.newBuilder().build();
-    }
-  }
+  private static final DeferredApplicationCredentials DEFAULT_OR_EMPTY_CREDS =
+      new DeferredApplicationCredentials(new CredentialsGenerator() {
+        @Override
+        public GoogleCredentials generate() {
+          try {
+            return GoogleCredentials.getApplicationDefault();
+          } catch (IOException e) {
+            logger
+                .error("Failed to fetch default application credentials, proceeding with null", e);
+            return null;
+          }
+        }
+      }
+      );
 }

--- a/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/src/main/java/com/google/firebase/FirebaseApp.java
@@ -19,6 +19,7 @@ package com.google.firebase;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.firebase.FirebaseOptions.APPLICATION_DEFAULT_CREDENTIALS;
 
 import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.json.JsonFactory;
@@ -34,7 +35,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.firebase.internal.FirebaseAppStore;
 import com.google.firebase.internal.FirebaseScheduledExecutor;
@@ -92,17 +92,6 @@ public class FirebaseApp {
    * accesses to instances map should be protected by this lock.
    */
   private static final Object appsLock = new Object();
-  private static final Supplier<GoogleCredentials> DEFAULT_CREDS_CALLABLE =
-      new Supplier<GoogleCredentials>() {
-        @Override
-        public GoogleCredentials get() {
-          try {
-            return GoogleCredentials.getApplicationDefault();
-          } catch (IOException e) {
-            throw new IllegalStateException(e);
-          }
-        }
-      };
 
   private final String name;
   private final FirebaseOptions options;
@@ -595,7 +584,7 @@ public class FirebaseApp {
     String defaultConfig = System.getenv(FIREBASE_CONFIG_ENV_VAR);
     if (Strings.isNullOrEmpty(defaultConfig)) {
       return new FirebaseOptions.Builder()
-          .setCredentials(DEFAULT_CREDS_CALLABLE)
+          .setCredentials(APPLICATION_DEFAULT_CREDENTIALS)
           .build();
     }
     JsonFactory jsonFactory = Utils.getDefaultJsonFactory();
@@ -609,7 +598,7 @@ public class FirebaseApp {
       parser = jsonFactory.createJsonParser(reader);
     }
     parser.parseAndClose(builder);
-    builder.setCredentials(DEFAULT_CREDS_CALLABLE);
+    builder.setCredentials(APPLICATION_DEFAULT_CREDENTIALS);
     return builder.build();
   }
 }

--- a/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/src/main/java/com/google/firebase/FirebaseApp.java
@@ -34,6 +34,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.firebase.database.util.EmulatorHelper;
 import com.google.firebase.internal.FirebaseAppStore;
 import com.google.firebase.internal.FirebaseScheduledExecutor;
 import com.google.firebase.internal.FirebaseService;
@@ -45,6 +46,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -581,11 +583,9 @@ public class FirebaseApp {
   private static FirebaseOptions getOptionsFromEnvironment() throws IOException {
     String defaultConfig = System.getenv(FIREBASE_CONFIG_ENV_VAR);
     if (Strings.isNullOrEmpty(defaultConfig)) {
-      return new FirebaseOptions.Builder()
-        .setCredentials(GoogleCredentials.getApplicationDefault())
-        .build();
+      return new FirebaseOptions.Builder().setCredentials(getApplicationDefaultOrEmptyCredentials())
+          .build();
     }
-
     JsonFactory jsonFactory = Utils.getDefaultJsonFactory();
     FirebaseOptions.Builder builder = new FirebaseOptions.Builder();
     JsonParser parser;
@@ -597,7 +597,18 @@ public class FirebaseApp {
       parser = jsonFactory.createJsonParser(reader);
     }
     parser.parseAndClose(builder);
-    builder.setCredentials(GoogleCredentials.getApplicationDefault());
+    builder.setCredentials(getApplicationDefaultOrEmptyCredentials());
     return builder.build();
+  }
+
+  private static GoogleCredentials getApplicationDefaultOrEmptyCredentials() {
+    try {
+      return GoogleCredentials.getApplicationDefault();
+    } catch (IOException e) {
+      logger.error(
+          "Failed to fetch default application credentials. Proceeding with blank credentials.",
+          e);
+      return GoogleCredentials.newBuilder().build();
+    }
   }
 }

--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -33,6 +33,7 @@ import com.google.firebase.internal.FirebaseThreadManagers;
 import com.google.firebase.internal.NonNull;
 import com.google.firebase.internal.Nullable;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +58,18 @@ public final class FirebaseOptions {
           // Enables access to Google Cloud Firestore
           "https://www.googleapis.com/auth/cloud-platform",
           "https://www.googleapis.com/auth/datastore");
+
+  static final Supplier<GoogleCredentials> APPLICATION_DEFAULT_CREDENTIALS =
+      new Supplier<GoogleCredentials>() {
+        @Override
+        public GoogleCredentials get() {
+          try {
+            return GoogleCredentials.getApplicationDefault();
+          } catch (IOException e) {
+            throw new IllegalStateException(e);
+          }
+        }
+      };
 
   private final String databaseUrl;
   private final String storageBucket;

--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -23,17 +23,21 @@ import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.util.Key;
+import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.firestore.FirestoreOptions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.firebase.database.util.EmulatorHelper;
 import com.google.firebase.internal.FirebaseThreadManagers;
 import com.google.firebase.internal.NonNull;
 import com.google.firebase.internal.Nullable;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /** Configurable Firebase options. */
 public final class FirebaseOptions {
@@ -70,10 +74,16 @@ public final class FirebaseOptions {
   private final FirestoreOptions firestoreOptions;
 
   private FirebaseOptions(@NonNull FirebaseOptions.Builder builder) {
-    this.credentials = checkNotNull(builder.credentials,
-        "FirebaseOptions must be initialized with setCredentials().")
-        .createScoped(FIREBASE_SCOPES);
-    this.databaseUrl = builder.databaseUrl;
+    String emulatorUrl = EmulatorHelper.getEmulatorUrl(builder.databaseUrl);
+    if (!Strings.isNullOrEmpty(emulatorUrl)) {
+      this.databaseUrl = emulatorUrl;
+      this.credentials = new EmulatorCredentials();
+    } else {
+      this.databaseUrl = builder.databaseUrl;
+      this.credentials = checkNotNull(builder.credentials,
+          "FirebaseOptions must be initialized with setCredentials().")
+          .createScoped(FIREBASE_SCOPES);
+    }
     this.databaseAuthVariableOverride = builder.databaseAuthVariableOverride;
     this.projectId = builder.projectId;
     if (!Strings.isNullOrEmpty(builder.storageBucket)) {
@@ -453,6 +463,23 @@ public final class FirebaseOptions {
      */
     public FirebaseOptions build() {
       return new FirebaseOptions(this);
+    }
+  }
+
+  private static class EmulatorCredentials extends GoogleCredentials {
+
+    private static AccessToken newToken() {
+      return new AccessToken("owner",
+          new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1)));
+    }
+
+    EmulatorCredentials() {
+      super(newToken());
+    }
+
+    @Override
+    public AccessToken refreshAccessToken() {
+      return newToken();
     }
   }
 }

--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -26,8 +26,9 @@ import com.google.api.client.util.Key;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.firestore.FirestoreOptions;
 import com.google.common.base.Strings;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
-import com.google.firebase.FirebaseOptions.DeferredApplicationCredentials.CredentialsGenerator;
 import com.google.firebase.internal.FirebaseThreadManagers;
 import com.google.firebase.internal.NonNull;
 import com.google.firebase.internal.Nullable;
@@ -59,7 +60,7 @@ public final class FirebaseOptions {
 
   private final String databaseUrl;
   private final String storageBucket;
-  private final DeferredApplicationCredentials deferredCredentials;
+  private final Supplier<GoogleCredentials> credentialsSupplier;
   private final Map<String, Object> databaseAuthVariableOverride;
   private final String projectId;
   private final String serviceAccountId;
@@ -72,17 +73,8 @@ public final class FirebaseOptions {
 
   private FirebaseOptions(@NonNull final FirebaseOptions.Builder builder) {
     this.databaseUrl = builder.databaseUrl;
-    if (builder.deferredCredentials != null) {
-      this.deferredCredentials = builder.deferredCredentials;
-    } else {
-      this.deferredCredentials = new DeferredApplicationCredentials(new CredentialsGenerator() {
-        @Override
-        public GoogleCredentials generate() {
-          return checkNotNull(builder.credentials,
-              "FirebaseOptions must be initialized with setCredentials().");
-        }
-      });
-    }
+    this.credentialsSupplier = checkNotNull(
+        builder.credentialsSupplier, "FirebaseOptions must be initialized with setCredentials().");
     this.databaseAuthVariableOverride = builder.databaseAuthVariableOverride;
     this.projectId = builder.projectId;
     if (!Strings.isNullOrEmpty(builder.storageBucket)) {
@@ -127,7 +119,7 @@ public final class FirebaseOptions {
   }
 
   GoogleCredentials getCredentials() {
-    return deferredCredentials.getCredentials();
+    return credentialsSupplier.get();
   }
 
   /**
@@ -236,8 +228,7 @@ public final class FirebaseOptions {
 
     @Key("serviceAccountId")
     private String serviceAccountId;
-    private GoogleCredentials credentials;
-    private DeferredApplicationCredentials deferredCredentials;
+    private Supplier<GoogleCredentials> credentialsSupplier;
     private FirestoreOptions firestoreOptions;
     private HttpTransport httpTransport = Utils.getDefaultTransport();
     private JsonFactory jsonFactory = Utils.getDefaultJsonFactory();
@@ -257,7 +248,7 @@ public final class FirebaseOptions {
     public Builder(FirebaseOptions options) {
       databaseUrl = options.databaseUrl;
       storageBucket = options.storageBucket;
-      deferredCredentials = options.deferredCredentials;
+      credentialsSupplier = options.credentialsSupplier;
       databaseAuthVariableOverride = options.databaseAuthVariableOverride;
       projectId = options.projectId;
       httpTransport = options.httpTransport;
@@ -317,19 +308,19 @@ public final class FirebaseOptions {
      * @return This <code>Builder</code> instance is returned so subsequent calls can be chained.
      */
     public Builder setCredentials(GoogleCredentials credentials) {
-      this.credentials = checkNotNull(credentials);
+      this.credentialsSupplier = Suppliers
+          .ofInstance(checkNotNull(credentials).createScoped(FIREBASE_SCOPES));
       return this;
     }
 
     /**
-     * Sets the <code>DeferredApplicationCredentials</code> to use to authenticate the SDK. This is
-     * NOT intended for public use outside the SDK.
+     * Sets the <code>Supplier</code> of <code>GoogleCredentials</code> to use to authenticate the SDK. This is NOT intended for public use outside the SDK.
      *
-     * @param credentials DeferredApplicationCredentials instance that wraps GoogleCredentials.
+     * @param credentialsSupplier Supplier instance that wraps GoogleCredentials.
      * @return This <code>Builder</code> instance is returned so subsequent calls can be chained.
      */
-    Builder setDeferredCredentials(DeferredApplicationCredentials credentials) {
-      this.deferredCredentials = checkNotNull(credentials);
+    Builder setCredentials(Supplier<GoogleCredentials> credentialsSupplier) {
+      this.credentialsSupplier = checkNotNull(credentialsSupplier);
       return this;
     }
     /**
@@ -473,29 +464,6 @@ public final class FirebaseOptions {
      */
     public FirebaseOptions build() {
       return new FirebaseOptions(this);
-    }
-  }
-
-  static class DeferredApplicationCredentials {
-
-    private final CredentialsGenerator credentialsGenerator;
-    private GoogleCredentials googleCredentials = null;
-
-    DeferredApplicationCredentials(
-        CredentialsGenerator credentialsGenerator) {
-      this.credentialsGenerator = credentialsGenerator;
-    }
-
-    public GoogleCredentials getCredentials() {
-      if (googleCredentials == null) {
-        googleCredentials = credentialsGenerator.generate().createScoped(FIREBASE_SCOPES);
-      }
-      return googleCredentials;
-    }
-
-    public interface CredentialsGenerator {
-
-      GoogleCredentials generate();
     }
   }
 }

--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -64,7 +64,7 @@ public final class FirebaseOptions {
         @Override
         public GoogleCredentials get() {
           try {
-            return GoogleCredentials.getApplicationDefault();
+            return GoogleCredentials.getApplicationDefault().createScoped(FIREBASE_SCOPES);
           } catch (IOException e) {
             throw new IllegalStateException(e);
           }

--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -314,7 +314,8 @@ public final class FirebaseOptions {
     }
 
     /**
-     * Sets the <code>Supplier</code> of <code>GoogleCredentials</code> to use to authenticate the SDK. This is NOT intended for public use outside the SDK.
+     * Sets the <code>Supplier</code> of <code>GoogleCredentials</code> to use to authenticate the
+     * SDK. This is NOT intended for public use outside the SDK.
      *
      * @param credentialsSupplier Supplier instance that wraps GoogleCredentials.
      * @return This <code>Builder</code> instance is returned so subsequent calls can be chained.
@@ -323,6 +324,7 @@ public final class FirebaseOptions {
       this.credentialsSupplier = checkNotNull(credentialsSupplier);
       return this;
     }
+
     /**
      * Sets the <code>auth</code> variable to be used by the Realtime Database rules.
      *

--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -23,21 +23,17 @@ import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.util.Key;
-import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.firestore.FirestoreOptions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import com.google.firebase.database.util.EmulatorHelper;
 import com.google.firebase.internal.FirebaseThreadManagers;
 import com.google.firebase.internal.NonNull;
 import com.google.firebase.internal.Nullable;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /** Configurable Firebase options. */
 public final class FirebaseOptions {
@@ -74,16 +70,10 @@ public final class FirebaseOptions {
   private final FirestoreOptions firestoreOptions;
 
   private FirebaseOptions(@NonNull FirebaseOptions.Builder builder) {
-    String emulatorUrl = EmulatorHelper.getEmulatorUrl(builder.databaseUrl);
-    if (!Strings.isNullOrEmpty(emulatorUrl)) {
-      this.databaseUrl = emulatorUrl;
-      this.credentials = new EmulatorCredentials();
-    } else {
-      this.databaseUrl = builder.databaseUrl;
-      this.credentials = checkNotNull(builder.credentials,
-          "FirebaseOptions must be initialized with setCredentials().")
-          .createScoped(FIREBASE_SCOPES);
-    }
+    this.databaseUrl = builder.databaseUrl;
+    this.credentials = checkNotNull(builder.credentials,
+        "FirebaseOptions must be initialized with setCredentials().")
+        .createScoped(FIREBASE_SCOPES);
     this.databaseAuthVariableOverride = builder.databaseAuthVariableOverride;
     this.projectId = builder.projectId;
     if (!Strings.isNullOrEmpty(builder.storageBucket)) {
@@ -463,23 +453,6 @@ public final class FirebaseOptions {
      */
     public FirebaseOptions build() {
       return new FirebaseOptions(this);
-    }
-  }
-
-  private static class EmulatorCredentials extends GoogleCredentials {
-
-    private static AccessToken newToken() {
-      return new AccessToken("owner",
-          new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1)));
-    }
-
-    EmulatorCredentials() {
-      super(newToken());
-    }
-
-    @Override
-    public AccessToken refreshAccessToken() {
-      return newToken();
     }
   }
 }

--- a/src/main/java/com/google/firebase/database/FirebaseDatabase.java
+++ b/src/main/java/com/google/firebase/database/FirebaseDatabase.java
@@ -46,8 +46,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class FirebaseDatabase {
 
-  private static final String FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR = "FIREBASE_RTDB_EMULATOR_HOST";
-  private static final String RTDB_EMULATOR_HOST = "localhost:9000";
+  static final String FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR = "FIREBASE_RTDB_EMULATOR_HOST";
+  static final String RTDB_EMULATOR_HOST = "localhost:9000";
   private final FirebaseApp app;
   private final RepoInfo repoInfo;
   private final DatabaseConfig config;

--- a/src/main/java/com/google/firebase/database/FirebaseDatabase.java
+++ b/src/main/java/com/google/firebase/database/FirebaseDatabase.java
@@ -129,7 +129,7 @@ public class FirebaseDatabase {
     ParsedUrl parsedUrl;
     boolean connectingToEmulator = false;
     String possibleEmulatorUrl = EmulatorHelper
-        .overwriteDatabaseUrlWithEmulatorHost(url, EmulatorHelper.getEmulatorHostFromEnv());
+        .getEmulatorUrl(url, EmulatorHelper.getEmulatorHostFromEnv());
     if (!Strings.isNullOrEmpty(possibleEmulatorUrl)) {
       parsedUrl = Utilities.parseUrl(possibleEmulatorUrl);
       connectingToEmulator = true;
@@ -164,7 +164,6 @@ public class FirebaseDatabase {
     }
     return database;
   }
-
 
   /** This exists so Repo can create FirebaseDatabase objects to keep legacy tests working. */
   static FirebaseDatabase createForTests(
@@ -226,7 +225,7 @@ public class FirebaseDatabase {
     checkNotNull(url,
         "Can't pass null for argument 'url' in FirebaseDatabase.getReferenceFromUrl()");
     String possibleEmulatorUrl = EmulatorHelper
-        .overwriteDatabaseUrlWithEmulatorHost(url, EmulatorHelper.getEmulatorHostFromEnv());
+        .getEmulatorUrl(url, EmulatorHelper.getEmulatorHostFromEnv());
     if (!Strings.isNullOrEmpty(possibleEmulatorUrl)) {
       url = possibleEmulatorUrl;
     }
@@ -406,13 +405,13 @@ public class FirebaseDatabase {
 
   private static class EmulatorCredentials extends GoogleCredentials {
 
+    EmulatorCredentials() {
+      super(newToken());
+    }
+
     private static AccessToken newToken() {
       return new AccessToken("owner",
           new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1)));
-    }
-
-    EmulatorCredentials() {
-      super(newToken());
     }
 
     @Override
@@ -423,11 +422,6 @@ public class FirebaseDatabase {
     @Override
     public Map<String, List<String>> getRequestMetadata() throws IOException {
       return ImmutableMap.of();
-    }
-
-    @Override
-    public void refresh() throws IOException {
-      super.refresh();
     }
   }
 }

--- a/src/main/java/com/google/firebase/database/FirebaseDatabase.java
+++ b/src/main/java/com/google/firebase/database/FirebaseDatabase.java
@@ -126,14 +126,16 @@ public class FirebaseDatabase {
           "Failed to get FirebaseDatabase instance: Specify DatabaseURL within "
               + "FirebaseApp or from your getInstance() call.");
     }
+    ParsedUrl parsedUrl;
     boolean connectingToEmulator = false;
     String possibleEmulatorUrl = EmulatorHelper
         .overwriteDatabaseUrlWithEmulatorHost(url, EmulatorHelper.getEmulatorHostFromEnv());
     if (!Strings.isNullOrEmpty(possibleEmulatorUrl)) {
-      url = possibleEmulatorUrl;
+      parsedUrl = Utilities.parseUrl(possibleEmulatorUrl);
       connectingToEmulator = true;
+    } else {
+      parsedUrl = Utilities.parseUrl(url);
     }
-    ParsedUrl parsedUrl = Utilities.parseUrl(url);
     if (!parsedUrl.path.isEmpty()) {
       throw new DatabaseException(
           "Specified Database URL '"

--- a/src/main/java/com/google/firebase/database/connection/NettyWebSocketClient.java
+++ b/src/main/java/com/google/firebase/database/connection/NettyWebSocketClient.java
@@ -90,15 +90,15 @@ class NettyWebSocketClient implements WebsocketConnection.WSClient {
             .trustManager(trustFactory).build();
       }
       final int port = uri.getPort() != -1 ? uri.getPort() : DEFAULT_WSS_PORT;
-      final SslContext[] sslContexts = new SslContext[]{sslContext};
+      final SslContext finalSslContext = sslContext;
       bootstrap.group(group)
           .channel(NioSocketChannel.class)
           .handler(new ChannelInitializer<SocketChannel>() {
             @Override
             protected void initChannel(SocketChannel ch) {
               ChannelPipeline p = ch.pipeline();
-              if (sslContexts[0] != null) {
-                p.addLast(sslContexts[0].newHandler(ch.alloc(), uri.getHost(), port));
+              if (finalSslContext != null) {
+                p.addLast(finalSslContext.newHandler(ch.alloc(), uri.getHost(), port));
               }
               p.addLast(
                   new HttpClientCodec(),

--- a/src/main/java/com/google/firebase/database/connection/NettyWebSocketClient.java
+++ b/src/main/java/com/google/firebase/database/connection/NettyWebSocketClient.java
@@ -83,8 +83,7 @@ class NettyWebSocketClient implements WebsocketConnection.WSClient {
       Bootstrap bootstrap = new Bootstrap();
       SslContext sslContext = null;
       if (this.isSecure) {
-        TrustManagerFactory trustFactory = null;
-        trustFactory = TrustManagerFactory.getInstance(
+        TrustManagerFactory trustFactory = TrustManagerFactory.getInstance(
             TrustManagerFactory.getDefaultAlgorithm());
         trustFactory.init((KeyStore) null);
         sslContext = SslContextBuilder.forClient()

--- a/src/main/java/com/google/firebase/database/connection/WebsocketConnection.java
+++ b/src/main/java/com/google/firebase/database/connection/WebsocketConnection.java
@@ -413,8 +413,8 @@ class WebsocketConnection {
       String host = (optCachedHost != null) ? optCachedHost : hostInfo.getHost();
       URI uri = HostInfo.getConnectionUrl(
           host, hostInfo.isSecure(), hostInfo.getNamespace(), optLastSessionId);
-      return new NettyWebSocketClient(
-          uri, context.getUserAgent(), context.getThreadFactory(), delegate, hostInfo.isSecure());
+      return new NettyWebSocketClient(uri, hostInfo.isSecure(), context.getUserAgent(),
+          context.getThreadFactory(), delegate);
     }
   }
 

--- a/src/main/java/com/google/firebase/database/connection/WebsocketConnection.java
+++ b/src/main/java/com/google/firebase/database/connection/WebsocketConnection.java
@@ -414,7 +414,7 @@ class WebsocketConnection {
       URI uri = HostInfo.getConnectionUrl(
           host, hostInfo.isSecure(), hostInfo.getNamespace(), optLastSessionId);
       return new NettyWebSocketClient(
-          uri, context.getUserAgent(), context.getThreadFactory(), delegate);
+          uri, context.getUserAgent(), context.getThreadFactory(), delegate, hostInfo.isSecure());
     }
   }
 

--- a/src/main/java/com/google/firebase/database/core/Context.java
+++ b/src/main/java/com/google/firebase/database/core/Context.java
@@ -16,6 +16,7 @@
 
 package com.google.firebase.database.core;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.ImplFirebaseTrampolines;
 import com.google.firebase.database.DatabaseException;
@@ -232,5 +233,14 @@ public class Context {
             .append("/")
             .append(platformAgent);
     return sb.toString();
+  }
+
+  public void setCustomCredentials(GoogleCredentials customCredentials, boolean autoRefresh) {
+    // ensure that platform exists
+    getPlatform();
+    // ensure that runloop exists else we might get a NPE
+    this.ensureRunLoop();
+    this.authTokenProvider = new JvmAuthTokenProvider(firebaseApp, this.getExecutorService(),
+        autoRefresh, customCredentials);
   }
 }

--- a/src/main/java/com/google/firebase/database/core/DatabaseConfig.java
+++ b/src/main/java/com/google/firebase/database/core/DatabaseConfig.java
@@ -16,8 +16,11 @@
 
 package com.google.firebase.database.core;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.database.DatabaseException;
+import com.google.firebase.database.utilities.DefaultRunLoop;
+import java.util.concurrent.ExecutorService;
 
 /**
  * TODO: Since this is no longer public, we should merge it with Context and clean all
@@ -114,4 +117,6 @@ public class DatabaseConfig extends Context {
   public synchronized void setFirebaseApp(FirebaseApp app) {
     this.firebaseApp = app;
   }
+
+
 }

--- a/src/main/java/com/google/firebase/database/core/DatabaseConfig.java
+++ b/src/main/java/com/google/firebase/database/core/DatabaseConfig.java
@@ -16,11 +16,8 @@
 
 package com.google.firebase.database.core;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.database.DatabaseException;
-import com.google.firebase.database.utilities.DefaultRunLoop;
-import java.util.concurrent.ExecutorService;
 
 /**
  * TODO: Since this is no longer public, we should merge it with Context and clean all
@@ -117,6 +114,4 @@ public class DatabaseConfig extends Context {
   public synchronized void setFirebaseApp(FirebaseApp app) {
     this.firebaseApp = app;
   }
-
-
 }

--- a/src/main/java/com/google/firebase/database/core/JvmAuthTokenProvider.java
+++ b/src/main/java/com/google/firebase/database/core/JvmAuthTokenProvider.java
@@ -40,8 +40,14 @@ public class JvmAuthTokenProvider implements AuthTokenProvider {
     this(firebaseApp, executor, true);
   }
 
+
   JvmAuthTokenProvider(FirebaseApp firebaseApp, Executor executor, boolean autoRefresh) {
-    this.credentials = ImplFirebaseTrampolines.getCredentials(firebaseApp);
+    this(firebaseApp, executor, autoRefresh, ImplFirebaseTrampolines.getCredentials(firebaseApp));
+  }
+
+  JvmAuthTokenProvider(FirebaseApp firebaseApp, Executor executor, boolean autoRefresh,
+      GoogleCredentials customCredentials) {
+    this.credentials = customCredentials;
     this.authVariable = firebaseApp.getOptions().getDatabaseAuthVariableOverride();
     this.executor = executor;
     if (autoRefresh) {

--- a/src/main/java/com/google/firebase/database/core/JvmAuthTokenProvider.java
+++ b/src/main/java/com/google/firebase/database/core/JvmAuthTokenProvider.java
@@ -40,7 +40,6 @@ public class JvmAuthTokenProvider implements AuthTokenProvider {
     this(firebaseApp, executor, true);
   }
 
-
   JvmAuthTokenProvider(FirebaseApp firebaseApp, Executor executor, boolean autoRefresh) {
     this(firebaseApp, executor, autoRefresh, ImplFirebaseTrampolines.getCredentials(firebaseApp));
   }

--- a/src/main/java/com/google/firebase/database/util/EmulatorHelper.java
+++ b/src/main/java/com/google/firebase/database/util/EmulatorHelper.java
@@ -1,0 +1,71 @@
+package com.google.firebase.database.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.firebase.database.core.Path;
+import com.google.firebase.database.core.RepoInfo;
+import com.google.firebase.database.utilities.ParsedUrl;
+import com.google.firebase.database.utilities.Utilities;
+
+public final class EmulatorHelper {
+
+  private EmulatorHelper() {
+  }
+
+  @VisibleForTesting
+  public static final String FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR = "FIREBASE_RTDB_EMULATOR_HOST";
+
+  private static String getEmulatorHostFromEnv() {
+    return System.getenv(FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR);
+  }
+
+  public static ParsedUrl parsedUrlForEmulator(String dbName, String emulatorUrl) {
+    RepoInfo repoInfo = new RepoInfo();
+    repoInfo.host = emulatorUrl;
+    repoInfo.namespace = dbName;
+    repoInfo.secure = false;
+    ParsedUrl parsedUrl = new ParsedUrl();
+    parsedUrl.repoInfo = repoInfo;
+    parsedUrl.path = new Path("");
+    return parsedUrl;
+  }
+
+  @VisibleForTesting
+  static String extractEmulatorUrlFromDbUrl(String suppliedDatabaseUrl) {
+    if (Strings.isNullOrEmpty(suppliedDatabaseUrl)) {
+      return null;
+    }
+    ParsedUrl parsedUrl = Utilities.parseUrl(suppliedDatabaseUrl);
+    RepoInfo repoInfo = parsedUrl.repoInfo;
+    if (repoInfo.isSecure() || repoInfo.host.endsWith(".firebaseio.com") || !suppliedDatabaseUrl
+        .contains("ns=")) {
+      return null;
+    }
+    String pathString = parsedUrl.path.isEmpty() ? "/" : parsedUrl.path.toString() + "/";
+    return String.format("http://%s%s?ns=%s", repoInfo.host, pathString, repoInfo.namespace);
+  }
+
+  public static String getEmulatorUrl(String suppliedDatabaseUrl) {
+    String extractedEmulatorUrl = extractEmulatorUrlFromDbUrl(suppliedDatabaseUrl);
+    if (!Strings.isNullOrEmpty(extractedEmulatorUrl)) {
+      return extractedEmulatorUrl;
+    }
+    String emulatorHostFromEnv = getEmulatorHostFromEnv();
+    if (Strings.isNullOrEmpty(emulatorHostFromEnv)) {
+      return null;
+    }
+    if (emulatorHostFromEnv.contains("http:") || emulatorHostFromEnv.contains("?ns=")) {
+      throw new IllegalArgumentException(
+          "emulator host declared in environment variable must be of the format \"host:port\"");
+    }
+    String namespaceName = "default";
+    String path = "/";
+    if (!Strings.isNullOrEmpty(suppliedDatabaseUrl)) {
+      ParsedUrl parsedUrl = Utilities.parseUrl(suppliedDatabaseUrl);
+      namespaceName = parsedUrl.repoInfo.namespace;
+      path = parsedUrl.path.isEmpty() ? "/" : parsedUrl.path.toString() + "/";
+    }
+    // Must format correctly
+    return String.format("http://%s%s?ns=%s", emulatorHostFromEnv, path, namespaceName);
+  }
+}

--- a/src/main/java/com/google/firebase/database/util/EmulatorHelper.java
+++ b/src/main/java/com/google/firebase/database/util/EmulatorHelper.java
@@ -43,12 +43,13 @@ public final class EmulatorHelper {
     }
     ParsedUrl parsedUrl = Utilities.parseUrl(suppliedDatabaseUrl);
     RepoInfo repoInfo = parsedUrl.repoInfo;
-    if (repoInfo.isSecure() || repoInfo.host.endsWith(".firebaseio.com") || !suppliedDatabaseUrl
+    if (repoInfo.host.endsWith(".firebaseio.com") || !suppliedDatabaseUrl
         .contains("ns=")) {
       return null;
     }
     String pathString = parsedUrl.path.isEmpty() ? "/" : parsedUrl.path.toString() + "/";
-    return String.format("http://%s%s?ns=%s", repoInfo.host, pathString, repoInfo.namespace);
+    String scheme = repoInfo.isSecure() ? "https" : "http";
+    return String.format("%s://%s%s?ns=%s", scheme, repoInfo.host, pathString, repoInfo.namespace);
   }
 
   public static String overwriteDatabaseUrlWithEmulatorHost(String suppliedDatabaseUrl,

--- a/src/main/java/com/google/firebase/database/util/EmulatorHelper.java
+++ b/src/main/java/com/google/firebase/database/util/EmulatorHelper.java
@@ -37,26 +37,18 @@ public final class EmulatorHelper {
 
   @VisibleForTesting
   @Nullable
-  static String tryToExtractEmulatorUrlFromDbUrl(String suppliedDatabaseUrl) {
-    if (Strings.isNullOrEmpty(suppliedDatabaseUrl)) {
-      return null;
+  static boolean isEmulatorUrl(String databaseUrl) {
+    if (Strings.isNullOrEmpty(databaseUrl)) {
+      return false;
     }
-    ParsedUrl parsedUrl = Utilities.parseUrl(suppliedDatabaseUrl);
-    RepoInfo repoInfo = parsedUrl.repoInfo;
-    if (repoInfo.host.endsWith(".firebaseio.com") || !suppliedDatabaseUrl
-        .contains("ns=")) {
-      return null;
-    }
-    String pathString = parsedUrl.path.isEmpty() ? "/" : parsedUrl.path.toString() + "/";
-    String scheme = repoInfo.isSecure() ? "https" : "http";
-    return String.format("%s://%s%s?ns=%s", scheme, repoInfo.host, pathString, repoInfo.namespace);
+    RepoInfo repoInfo = Utilities.parseUrl(databaseUrl).repoInfo;
+    return !repoInfo.host.endsWith(".firebaseio.com") && databaseUrl.contains("ns=");
   }
 
-  public static String overwriteDatabaseUrlWithEmulatorHost(String suppliedDatabaseUrl,
-      String emulatorHost) {
-    String extractedEmulatorUrl = tryToExtractEmulatorUrlFromDbUrl(suppliedDatabaseUrl);
-    if (!Strings.isNullOrEmpty(extractedEmulatorUrl)) {
-      return extractedEmulatorUrl;
+  @Nullable
+  public static String getEmulatorUrl(String suppliedDatabaseUrl, String emulatorHost) {
+    if (isEmulatorUrl(suppliedDatabaseUrl)) {
+      return suppliedDatabaseUrl;
     }
     if (Strings.isNullOrEmpty(emulatorHost)) {
       return null;
@@ -68,9 +60,9 @@ public final class EmulatorHelper {
     String namespaceName = "default";
     String path = "/";
     if (!Strings.isNullOrEmpty(suppliedDatabaseUrl)) {
-      ParsedUrl parsedUrl = Utilities.parseUrl(suppliedDatabaseUrl);
-      namespaceName = parsedUrl.repoInfo.namespace;
-      path = parsedUrl.path.isEmpty() ? "/" : parsedUrl.path.toString() + "/";
+      ParsedUrl parsedDbUrl = Utilities.parseUrl(suppliedDatabaseUrl);
+      namespaceName = parsedDbUrl.repoInfo.namespace;
+      path = parsedDbUrl.path.isEmpty() ? "/" : parsedDbUrl.path.toString() + "/";
     }
     // Must format correctly
     return String.format("http://%s%s?ns=%s", emulatorHost, path, namespaceName);

--- a/src/main/java/com/google/firebase/database/utilities/Utilities.java
+++ b/src/main/java/com/google/firebase/database/utilities/Utilities.java
@@ -18,78 +18,117 @@ package com.google.firebase.database.utilities;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.SettableApiFuture;
+import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseException;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.core.Path;
 import com.google.firebase.database.core.RepoInfo;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 
 public class Utilities {
-
   private static final char[] HEX_CHARACTERS = "0123456789abcdef".toCharArray();
 
   public static ParsedUrl parseUrl(String url) throws DatabaseException {
-    String original = url;
     try {
-      int schemeOffset = original.indexOf("//");
-      if (schemeOffset == -1) {
-        throw new URISyntaxException(original, "Invalid scheme specified");
-      }
-      int pathOffset = original.substring(schemeOffset + 2).indexOf("/");
-      if (pathOffset != -1) {
-        pathOffset += schemeOffset + 2;
-        String[] pathSegments = original.substring(pathOffset).split("/");
-        StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < pathSegments.length; ++i) {
-          if (!pathSegments[i].equals("")) {
-            builder.append("/");
-            builder.append(URLEncoder.encode(pathSegments[i], "UTF-8"));
-          }
-        }
-        original = original.substring(0, pathOffset) + builder.toString();
+      URI uri = URI.create(url);
+
+      String scheme = uri.getScheme();
+      if (scheme == null) {
+        throw new IllegalArgumentException("Database URL does not specify a URL scheme");
       }
 
-      URI uri = new URI(original);
-      // URLEncoding a space turns it into a '+', which is different
-      // from our expected behavior. Do a manual replace to fix it.
-      final String pathString = uri.getPath().replace("+", " ");
-      Validation.validateRootPathString(pathString);
-      String scheme = uri.getScheme();
+      String host = uri.getHost();
+      if (host == null) {
+        throw new IllegalArgumentException("Database URL does not specify a valid host");
+      }
 
       RepoInfo repoInfo = new RepoInfo();
-      repoInfo.host = uri.getHost().toLowerCase();
+      repoInfo.host = host.toLowerCase();
 
       int port = uri.getPort();
       if (port != -1) {
-        repoInfo.secure = scheme.equals("https");
+        repoInfo.secure = scheme.equals("https") || scheme.equals("wss");
         repoInfo.host += ":" + port;
       } else {
         repoInfo.secure = true;
       }
-      String[] parts = repoInfo.host.split("\\.");
 
-      repoInfo.namespace = parts[0].toLowerCase();
+      Map<String, String> params = getQueryParamsMap(uri.getQuery());
+      String namespaceParam = params.get("ns");
+      if (!Strings.isNullOrEmpty(namespaceParam)) {
+        repoInfo.namespace = namespaceParam;
+      } else {
+        String[] parts = host.split("\\.", -1);
+        repoInfo.namespace = parts[0].toLowerCase();
+      }
+
       repoInfo.internalHost = repoInfo.host;
-      ParsedUrl parsedUrl = new ParsedUrl();
-      parsedUrl.path = new Path(pathString);
-      parsedUrl.repoInfo = repoInfo;
-      return parsedUrl;
 
-    } catch (URISyntaxException e) {
-      throw new DatabaseException("Invalid Firebase Database url specified", e);
-    } catch (UnsupportedEncodingException e) {
-      throw new DatabaseException("Failed to URLEncode the path", e);
+      String originalPathString = extractPathString(url);
+      // URLEncoding a space turns it into a '+', which is different
+      // from our expected behavior. Do a manual replace to fix it.
+      originalPathString = originalPathString.replace("+", " ");
+      Validation.validateRootPathString(originalPathString);
+
+      ParsedUrl parsedUrl = new ParsedUrl();
+      parsedUrl.path = new Path(originalPathString);
+      parsedUrl.repoInfo = repoInfo;
+
+      return parsedUrl;
+    } catch (Exception e) {
+      throw new DatabaseException("Invalid Firebase Database url specified: " + url, e);
     }
+  }
+
+  /**
+   * Extracts the path string from the original URL without changing the encoding (unlike
+   * Uri.getPath()).
+   */
+  private static String extractPathString(String originalUrl) {
+    int schemeOffset = originalUrl.indexOf("//");
+    if (schemeOffset == -1) {
+      throw new DatabaseException("Firebase Database URL is missing URL scheme");
+    }
+
+    String urlWithoutScheme = originalUrl.substring(schemeOffset + 2);
+    int pathOffset = urlWithoutScheme.indexOf("/");
+    if (pathOffset != -1) {
+      int queryOffset = urlWithoutScheme.indexOf("?");
+      if (queryOffset != -1) {
+        return urlWithoutScheme.substring(pathOffset + 1, queryOffset);
+      } else {
+        return urlWithoutScheme.substring(pathOffset + 1);
+      }
+    } else {
+      return "";
+    }
+  }
+
+  static Map<String, String> getQueryParamsMap(String queryString) {
+    Map<String, String> paramsMap = new HashMap<>();
+    if (Strings.isNullOrEmpty(queryString)) {
+      return paramsMap;
+    }
+    String[] paramPairs = queryString.split("&");
+    for (String paramPair : paramPairs) {
+      String[] pairParts = paramPair.split("=");
+      String value = paramsMap.get(pairParts[0]);
+      if (Strings.isNullOrEmpty(value)) {
+        value = pairParts[1];
+      } else {
+        value += "," + pairParts[1];
+      }
+      paramsMap.put(pairParts[0], value);
+    }
+    return paramsMap;
   }
 
   public static String[] splitIntoFrames(String src, int maxFrameSize) {

--- a/src/main/java/com/google/firebase/database/utilities/Utilities.java
+++ b/src/main/java/com/google/firebase/database/utilities/Utilities.java
@@ -58,13 +58,11 @@ public class Utilities {
 
       RepoInfo repoInfo = new RepoInfo();
       repoInfo.host = host.toLowerCase();
+      repoInfo.secure = scheme.equals("https") || scheme.equals("wss");
 
       int port = uri.getPort();
       if (port != -1) {
-        repoInfo.secure = scheme.equals("https") || scheme.equals("wss");
         repoInfo.host += ":" + port;
-      } else {
-        repoInfo.secure = true;
       }
 
       Map<String, String> params = getQueryParamsMap(uri.getRawQuery());

--- a/src/main/java/com/google/firebase/database/utilities/Utilities.java
+++ b/src/main/java/com/google/firebase/database/utilities/Utilities.java
@@ -90,10 +90,10 @@ public class Utilities {
   }
 
   /**
-   * Extracts a map of query parameters from a non-encoded query string. Repeated parameters have
+   * Extracts a map of query parameters from an encoded query string. Repeated parameters have
    * values concatenated with commas.
    *
-   * @param queryString to parse params from. Must be non-encoded.
+   * @param queryString to parse params from. Must be encoded.
    * @return map of query parameters and their values.
    */
   @VisibleForTesting

--- a/src/main/java/com/google/firebase/database/utilities/Utilities.java
+++ b/src/main/java/com/google/firebase/database/utilities/Utilities.java
@@ -76,11 +76,12 @@ public class Utilities {
 
       repoInfo.internalHost = repoInfo.host;
       // use raw (encoded) path for backwards compatibility.
-      String originalPathString = uri.getRawPath();
-      Validation.validateRootPathString(originalPathString);
+      String pathString = uri.getRawPath();
+      pathString = pathString.replace("+", " ");
+      Validation.validateRootPathString(pathString);
 
       ParsedUrl parsedUrl = new ParsedUrl();
-      parsedUrl.path = new Path(originalPathString);
+      parsedUrl.path = new Path(pathString);
       parsedUrl.repoInfo = repoInfo;
 
       return parsedUrl;

--- a/src/main/java/com/google/firebase/database/utilities/Utilities.java
+++ b/src/main/java/com/google/firebase/database/utilities/Utilities.java
@@ -18,6 +18,7 @@ package com.google.firebase.database.utilities;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.SettableApiFuture;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
 import com.google.firebase.database.DatabaseError;
@@ -27,6 +28,7 @@ import com.google.firebase.database.core.Path;
 import com.google.firebase.database.core.RepoInfo;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -72,10 +74,7 @@ public class Utilities {
 
       repoInfo.internalHost = repoInfo.host;
 
-      String originalPathString = extractPathString(url);
-      // URLEncoding a space turns it into a '+', which is different
-      // from our expected behavior. Do a manual replace to fix it.
-      originalPathString = originalPathString.replace("+", " ");
+      String originalPathString = uri.getPath();
       Validation.validateRootPathString(originalPathString);
 
       ParsedUrl parsedUrl = new ParsedUrl();
@@ -112,6 +111,14 @@ public class Utilities {
     }
   }
 
+  /**
+   * Extracts a map of query parameters from a non-encoded query string. Repeated parameters have
+   * values concatenated with commas.
+   *
+   * @param queryString to parse params from. Must be non-encoded.
+   * @return map of query parameters and their values.
+   */
+  @VisibleForTesting
   static Map<String, String> getQueryParamsMap(String queryString) {
     Map<String, String> paramsMap = new HashMap<>();
     if (Strings.isNullOrEmpty(queryString)) {

--- a/src/test/java/com/google/firebase/FirebaseAppTest.java
+++ b/src/test/java/com/google/firebase/FirebaseAppTest.java
@@ -35,6 +35,8 @@ import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.auth.oauth2.OAuth2Credentials.CredentialsChangedListener;
 import com.google.common.base.Defaults;
 import com.google.common.base.Strings;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.FirebaseApp.TokenRefresher;
@@ -580,6 +582,14 @@ public class FirebaseAppTest {
     new FirebaseException("");
   }
 
+
+  @Test
+  public void testFirebaseAppCreationWithEmptySupplier() {
+    FirebaseApp.initializeApp(FirebaseOptions.builder()
+        .setDatabaseUrl("https://test-ns.firebaseio.com")
+        .setCredentials(Suppliers.<GoogleCredentials>ofInstance(null)).build());
+
+  }
   private static void setFirebaseConfigEnvironmentVariable(String configJSON) {
     String configValue;
     if (configJSON.isEmpty() || configJSON.startsWith("{")) {

--- a/src/test/java/com/google/firebase/FirebaseAppTest.java
+++ b/src/test/java/com/google/firebase/FirebaseAppTest.java
@@ -37,9 +37,11 @@ import com.google.common.base.Defaults;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.firebase.FirebaseApp.TokenRefresher;
 import com.google.firebase.FirebaseOptions.Builder;
 import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.util.EmulatorHelper;
 import com.google.firebase.testing.FirebaseAppRule;
 import com.google.firebase.testing.ServiceAccount;
 import com.google.firebase.testing.TestUtils;
@@ -578,6 +580,105 @@ public class FirebaseAppTest {
   @Test(expected = IllegalArgumentException.class)
   public void testFirebaseExceptionEmptyDetail() {
     new FirebaseException("");
+  }
+
+
+  @Test
+  public void testDbUrlIsEmulatorUrlWhenSettingOptionsManually() {
+    class CustomTestCase {
+
+      private String suppliedDbUrl;
+      private String envVariableUrl;
+      private String expectedEmulatorUrl;
+
+      private CustomTestCase(String suppliedDbUrl, String envVariableUrl,
+          String expectedEmulatorUrl) {
+        this.suppliedDbUrl = suppliedDbUrl;
+        this.envVariableUrl = envVariableUrl;
+        this.expectedEmulatorUrl = expectedEmulatorUrl;
+      }
+    }
+
+    List<CustomTestCase> testCases; // separated decl and assignment coz of checkstyle
+    testCases = ImmutableList
+        .of(
+            // cases where the env var is ignored as the supplied DB URL is a valid emulator URL
+            new CustomTestCase("http://my-custom-hosted-emulator.com:80?ns=dummy-ns", "",
+                "http://my-custom-hosted-emulator.com:80/?ns=dummy-ns"),
+            new CustomTestCase("http://localhost:9000?ns=test-ns", null,
+                "http://localhost:9000/?ns=test-ns"),
+
+            // cases where the supplied DB URL is not an emulator URL, so we extract ns from it
+            // and append it to the emulator URL from env var(if it is valid)
+            new CustomTestCase("https://valid-namespace.firebaseio.com", "localhost:8080",
+                "http://localhost:8080/?ns=valid-namespace"),
+            new CustomTestCase("https://firebaseio.com?ns=valid-namespace", "localhost:90",
+                "http://localhost:90/?ns=valid-namespace")
+        );
+    int i = 0;
+    for (CustomTestCase tc : testCases) {
+      TestUtils.setEnvironmentVariables(
+          ImmutableMap.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR,
+              Strings.nullToEmpty(tc.envVariableUrl)));
+      FirebaseOptions firebaseOptions = FirebaseOptions.builder().setDatabaseUrl(tc.suppliedDbUrl)
+          .build();
+      assertEquals(tc.expectedEmulatorUrl, firebaseOptions.getDatabaseUrl());
+      FirebaseApp app = FirebaseApp
+          .initializeApp(firebaseOptions, "testEmulatorConnectApp_" + (i++));
+      assertEquals(tc.expectedEmulatorUrl, app.getOptions().getDatabaseUrl());
+      // clean up after
+      app.delete();
+      TestUtils.unsetEnvironmentVariables(
+          ImmutableSet.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR));
+    }
+  }
+
+  @Test
+  public void testDatabaseUrlIsEmulatorUrlWithEnvVarAndDefaultSettings() {
+    List<String> envVars = ImmutableList
+        .of("localhost:8000", "custom-emulator-url:90", "192.123.212.145:90", "[::1]:90");
+
+    for (String envVar : envVars) {
+      TestUtils.setEnvironmentVariables(
+          ImmutableMap.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR, envVar));
+      // Hack to remove the default app left over from previous tests.
+      try {
+        FirebaseApp.getInstance(FirebaseApp.DEFAULT_APP_NAME).delete();
+      } catch (Exception ignored) {
+        // proceed if no leftover default app found.
+      }
+      FirebaseApp app = FirebaseApp.initializeApp();
+      assertEquals(String.format("http://%s/?ns=default", envVar),
+          app.getOptions().getDatabaseUrl());
+      // clean up after
+      app.delete();
+      TestUtils.unsetEnvironmentVariables(
+          ImmutableSet.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR));
+    }
+  }
+
+  @Test
+  public void testDbUrlIsEmulatorUrlWithDefaultAppNameWhenSettingAnyAppName() {
+    List<String> envVars = ImmutableList
+        .of("localhost:8000", "custom-emulator-url:90", "192.123.212.145:90", "[::1]:90");
+    int i = 0;
+    for (String envVar : envVars) {
+      TestUtils.setEnvironmentVariables(
+          ImmutableMap.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR, envVar));
+      // Hack to remove the default app left over from previous tests.
+      try {
+        FirebaseApp.getInstance(FirebaseApp.DEFAULT_APP_NAME).delete();
+      } catch (Exception ignored) {
+        // proceed if no leftover default app found.
+      }
+      FirebaseApp app = FirebaseApp.initializeApp("testAppName#" + (i++));
+      assertEquals(String.format("http://%s/?ns=default", envVar),
+          app.getOptions().getDatabaseUrl());
+      // clean up after
+      app.delete();
+      TestUtils.unsetEnvironmentVariables(
+          ImmutableSet.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR));
+    }
   }
 
   private static void setFirebaseConfigEnvironmentVariable(String configJSON) {

--- a/src/test/java/com/google/firebase/FirebaseAppTest.java
+++ b/src/test/java/com/google/firebase/FirebaseAppTest.java
@@ -582,14 +582,13 @@ public class FirebaseAppTest {
     new FirebaseException("");
   }
 
-
   @Test
   public void testFirebaseAppCreationWithEmptySupplier() {
     FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setDatabaseUrl("https://test-ns.firebaseio.com")
         .setCredentials(Suppliers.<GoogleCredentials>ofInstance(null)).build());
-
   }
+
   private static void setFirebaseConfigEnvironmentVariable(String configJSON) {
     String configValue;
     if (configJSON.isEmpty() || configJSON.startsWith("{")) {

--- a/src/test/java/com/google/firebase/FirebaseOptionsTest.java
+++ b/src/test/java/com/google/firebase/FirebaseOptionsTest.java
@@ -161,7 +161,7 @@ public class FirebaseOptionsTest {
 
   @Test(expected = NullPointerException.class)
   public void createOptionsWithNullCredentials() {
-    new FirebaseOptions.Builder().setCredentials(null).build();
+    new FirebaseOptions.Builder().setCredentials((GoogleCredentials) null).build();
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/google/firebase/FirebaseOptionsTest.java
+++ b/src/test/java/com/google/firebase/FirebaseOptionsTest.java
@@ -156,7 +156,7 @@ public class FirebaseOptionsTest {
 
   @Test(expected = NullPointerException.class)
   public void createOptionsWithCredentialMissing() {
-    new FirebaseOptions.Builder().build();
+    new FirebaseOptions.Builder().build().getCredentials();
   }
 
   @Test(expected = NullPointerException.class)

--- a/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
+++ b/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
@@ -49,12 +49,12 @@ public class FirebaseDatabaseTest {
           .build();
 
   @Before
-  public  void setupClass() {
+  public void setupTestMethod() {
     FirebaseApp.initializeApp(firebaseOptions);
   }
 
   @After
-  public  void tearDownClass() {
+  public void tearDownTestMethod() {
     TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
   }
 

--- a/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
+++ b/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
@@ -205,7 +205,7 @@ public class FirebaseDatabaseTest {
         // and append it to the emulator URL from env var(if it is valid)
         new CustomTestCase("https://valid-namespace.firebaseio.com", "localhost:8080",
             "http://localhost:8080", "valid-namespace"),
-        new CustomTestCase("https://firebaseio.com?ns=valid-namespace", "localhost:90",
+        new CustomTestCase("https://test.firebaseio.com?ns=valid-namespace", "localhost:90",
             "http://localhost:90", "valid-namespace")
     );
     boolean earlierDefaultAppFound = false;
@@ -216,17 +216,20 @@ public class FirebaseDatabaseTest {
       // proceed if no leftover default app found.
     }
     for (CustomTestCase tc : testCases) {
-      FirebaseApp app = FirebaseApp.initializeApp();
-      TestUtils.setEnvironmentVariables(
-          ImmutableMap.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR,
-              Strings.nullToEmpty(tc.envVariableUrl)));
-      FirebaseDatabase instance = FirebaseDatabase.getInstance(app, tc.suppliedDbUrl);
-      assertEquals(tc.expectedEmulatorUrl, instance.getReference().repo.getRepoInfo().toString());
-      assertEquals(tc.namespace, instance.getReference().repo.getRepoInfo().namespace);
-      // clean up after
-      app.delete();
-      TestUtils.unsetEnvironmentVariables(
-          ImmutableSet.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR));
+      try {
+        FirebaseApp app = FirebaseApp.initializeApp();
+        TestUtils.setEnvironmentVariables(
+            ImmutableMap.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR,
+                Strings.nullToEmpty(tc.envVariableUrl)));
+        FirebaseDatabase instance = FirebaseDatabase.getInstance(app, tc.suppliedDbUrl);
+        assertEquals(tc.expectedEmulatorUrl, instance.getReference().repo.getRepoInfo().toString());
+        assertEquals(tc.namespace, instance.getReference().repo.getRepoInfo().namespace);
+        // clean up after
+        app.delete();
+      } finally {
+        TestUtils.unsetEnvironmentVariables(
+            ImmutableSet.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR));
+      }
     }
     if (earlierDefaultAppFound) {
       FirebaseApp.initializeApp();
@@ -278,20 +281,25 @@ public class FirebaseDatabaseTest {
     } catch (Exception ignored) {
       // proceed if no leftover default app found.
     }
+
     for (CustomTestCase tc : testCases) {
-      FirebaseApp app = FirebaseApp.initializeApp();
-      TestUtils.setEnvironmentVariables(
-          ImmutableMap.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR,
-              Strings.nullToEmpty(tc.envVariableUrl)));
-      FirebaseDatabase instance = FirebaseDatabase.getInstance(app, tc.rootDbUrl);
-      DatabaseReference dbRef = instance.getReferenceFromUrl(tc.pathUrl);
-      assertEquals(tc.expectedEmulatorRootUrl, dbRef.repo.getRepoInfo().toString());
-      assertEquals(tc.namespace, dbRef.repo.getRepoInfo().namespace);
-      assertEquals(tc.path, dbRef.path.toString());
-      // clean up after
-      app.delete();
-      TestUtils.unsetEnvironmentVariables(
-          ImmutableSet.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR));
+      try {
+        FirebaseApp app = FirebaseApp.initializeApp();
+        TestUtils.setEnvironmentVariables(
+            ImmutableMap.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR,
+                Strings.nullToEmpty(tc.envVariableUrl)));
+        FirebaseDatabase instance = FirebaseDatabase.getInstance(app, tc.rootDbUrl);
+        DatabaseReference dbRef = instance.getReferenceFromUrl(tc.pathUrl);
+        assertEquals(tc.expectedEmulatorRootUrl, dbRef.repo.getRepoInfo().toString());
+        assertEquals(tc.namespace, dbRef.repo.getRepoInfo().namespace);
+        assertEquals(tc.path, dbRef.path.toString());
+        // clean up after
+        app.delete();
+
+      } finally {
+        TestUtils.unsetEnvironmentVariables(
+            ImmutableSet.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR));
+      }
     }
     if (earlierDefaultAppFound) {
       FirebaseApp.initializeApp();

--- a/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
+++ b/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
@@ -196,8 +196,7 @@ public class FirebaseDatabaseTest {
   @Test
   public void testDbUrlIsEmulatorUrlWhenSettingOptionsManually() {
 
-    List<CustomTestCase> testCases;
-    testCases = ImmutableList.of(
+    List<CustomTestCase> testCases = ImmutableList.of(
         // cases where the env var is ignored because the supplied DB URL is a valid emulator URL
         new CustomTestCase("http://my-custom-hosted-emulator.com:80?ns=dummy-ns", "",
             "http://my-custom-hosted-emulator.com:80", "dummy-ns"),
@@ -233,8 +232,7 @@ public class FirebaseDatabaseTest {
   @Test
   public void testDbUrlIsEmulatorUrlForDbRefWithPath() {
 
-    List<CustomTestCase> testCases;
-    testCases = ImmutableList.of(
+    List<CustomTestCase> testCases = ImmutableList.of(
         new CustomTestCase("http://my-custom-hosted-emulator.com:80?ns=dummy-ns",
             "http://my-custom-hosted-emulator.com:80?ns=dummy-ns", "",
             "http://my-custom-hosted-emulator.com:80", "dummy-ns", "/"),

--- a/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
+++ b/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
@@ -23,15 +23,14 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.testing.ServiceAccount;
-
 import com.google.firebase.testing.TestUtils;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -120,7 +119,6 @@ public class FirebaseDatabaseTest {
     assertNotNull(reference);
     assertEquals("bar", reference.getKey());
     assertEquals("foo", reference.getParent().getKey());
-
     try {
       defaultDatabase.getReferenceFromUrl(null);
       fail("No error thrown for null URL");
@@ -170,5 +168,16 @@ public class FirebaseDatabaseTest {
     FirebaseDatabase db2 = FirebaseDatabase.getInstance(app);
     assertNotNull(db2);
     assertNotSame(db1, db2);
+  }
+
+  @Test
+  public void testTalksToEmulatorWithEnvVars() {
+    TestUtils.setEnvironmentVariables(
+        ImmutableMap.of(FirebaseDatabase.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR, "true"));
+    FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "testTalksToEmulator");
+    FirebaseDatabase db = FirebaseDatabase.getInstance(app);
+    assertNotNull(db);
+    assertSame(FirebaseDatabase.RTDB_EMULATOR_HOST, db.getReference().repo.getRepoInfo().host);
+    assertSame(false, db.getReference().repo.getRepoInfo().isSecure());
   }
 }

--- a/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
+++ b/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
@@ -34,10 +34,6 @@ import com.google.firebase.database.util.EmulatorHelper;
 import com.google.firebase.testing.ServiceAccount;
 import com.google.firebase.testing.TestUtils;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class FirebaseDatabaseTest {
@@ -48,99 +44,118 @@ public class FirebaseDatabaseTest {
           .setDatabaseUrl("https://firebase-db-test.firebaseio.com")
           .build();
 
-  @Before
-  public void setupTestMethod() {
+  @Test
+  public void testGetInstance() {
     FirebaseApp.initializeApp(firebaseOptions);
-  }
-
-  @After
-  public void tearDownTestMethod() {
-    TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
-  }
-
-  @Test
-  public void testGetInstance() throws ExecutionException, InterruptedException {
-    FirebaseDatabase defaultDatabase = FirebaseDatabase.getInstance();
-    assertNotNull(defaultDatabase);
-    assertSame(defaultDatabase, FirebaseDatabase.getInstance());
-    assertSame(FirebaseApp.getInstance(), defaultDatabase.getApp());
-  }
-
-  @Test
-  public void testGetInstanceForUrl() throws ExecutionException, InterruptedException {
-    String url = "https://firebase-db-test2.firebaseio.com";
-    FirebaseDatabase otherDatabase = FirebaseDatabase.getInstance(url);
-    assertNotNull(otherDatabase);
-    assertNotSame(otherDatabase, FirebaseDatabase.getInstance());
-  }
-
-  @Test
-  public void testInvalidUrl() throws ExecutionException, InterruptedException {
-    String[] urls = new String[]{
-        null, "", "https://firebase-db-test.firebaseio.com/foo"
-    };
-    for (String url : urls) {
-      try {
-        FirebaseDatabase.getInstance(url);
-        fail("No error thrown for URL: " + url);
-      } catch (DatabaseException expected) {
-        // expected
-      }
+    try {
+      FirebaseDatabase defaultDatabase = FirebaseDatabase.getInstance();
+      assertNotNull(defaultDatabase);
+      assertSame(defaultDatabase, FirebaseDatabase.getInstance());
+      assertSame(FirebaseApp.getInstance(), defaultDatabase.getApp());
+    } finally {
+      TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
     }
   }
 
   @Test
-  public void testGetInstanceForApp() throws ExecutionException, InterruptedException {
+  public void testGetInstanceForUrl() {
+    FirebaseApp.initializeApp(firebaseOptions);
+    try {
+      String url = "https://firebase-db-test2.firebaseio.com";
+      FirebaseDatabase otherDatabase = FirebaseDatabase.getInstance(url);
+      assertNotNull(otherDatabase);
+      assertNotSame(otherDatabase, FirebaseDatabase.getInstance());
+    } finally {
+      TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
+    }
+  }
+
+  @Test
+  public void testInvalidUrl() {
+    FirebaseApp.initializeApp(firebaseOptions);
+    try {
+      String[] urls = new String[]{
+          null, "", "https://firebase-db-test.firebaseio.com/foo"
+      };
+      for (String url : urls) {
+        try {
+          FirebaseDatabase.getInstance(url);
+          fail("No error thrown for URL: " + url);
+        } catch (DatabaseException expected) {
+          // expected
+        }
+      }
+    } finally {
+      TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
+    }
+  }
+
+  @Test
+  public void testGetInstanceForApp() {
     FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "testGetInstanceForApp");
-    FirebaseDatabase db = FirebaseDatabase.getInstance(app);
-    assertNotNull(db);
-    assertSame(db, FirebaseDatabase.getInstance(app));
+    try {
+      FirebaseDatabase db = FirebaseDatabase.getInstance(app);
+      assertNotNull(db);
+      assertSame(db, FirebaseDatabase.getInstance(app));
+    } finally {
+      TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
+    }
   }
 
   @Test
   public void testReference() {
-    FirebaseDatabase defaultDatabase = FirebaseDatabase.getInstance();
-    DatabaseReference reference = defaultDatabase.getReference();
-    assertNotNull(reference);
-    assertNull(reference.getKey());
-    assertNull(reference.getParent());
+    FirebaseApp.initializeApp(firebaseOptions);
+    try {
+      FirebaseDatabase defaultDatabase = FirebaseDatabase.getInstance();
+      DatabaseReference reference = defaultDatabase.getReference();
+      assertNotNull(reference);
+      assertNull(reference.getKey());
+      assertNull(reference.getParent());
 
-    reference = defaultDatabase.getReference("foo");
-    assertNotNull(reference);
-    assertEquals("foo", reference.getKey());
-    assertNull(reference.getParent().getKey());
+      reference = defaultDatabase.getReference("foo");
+      assertNotNull(reference);
+      assertEquals("foo", reference.getKey());
+      assertNull(reference.getParent().getKey());
 
-    reference = defaultDatabase.getReference("foo/bar");
-    assertNotNull(reference);
-    assertEquals("bar", reference.getKey());
-    assertEquals("foo", reference.getParent().getKey());
+      reference = defaultDatabase.getReference("foo/bar");
+      assertNotNull(reference);
+      assertEquals("bar", reference.getKey());
+      assertEquals("foo", reference.getParent().getKey());
+    } finally {
+      TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
+    }
   }
 
   @Test
   public void testReferenceFromUrl() {
-    FirebaseDatabase defaultDatabase = FirebaseDatabase.getInstance();
-    DatabaseReference reference = defaultDatabase.getReferenceFromUrl(
-        "https://firebase-db-test.firebaseio.com/foo/bar");
-    assertNotNull(reference);
-    assertEquals("bar", reference.getKey());
-    assertEquals("foo", reference.getParent().getKey());
+    FirebaseApp.initializeApp(firebaseOptions);
     try {
-      defaultDatabase.getReferenceFromUrl(null);
-      fail("No error thrown for null URL");
-    } catch (NullPointerException expected) {
-      // expected
-    }
+      FirebaseDatabase defaultDatabase = FirebaseDatabase.getInstance();
+      DatabaseReference reference = defaultDatabase.getReferenceFromUrl(
+          "https://firebase-db-test.firebaseio.com/foo/bar");
+      assertNotNull(reference);
+      assertEquals("bar", reference.getKey());
+      assertEquals("foo", reference.getParent().getKey());
+      try {
+        defaultDatabase.getReferenceFromUrl(null);
+        fail("No error thrown for null URL");
+      } catch (NullPointerException expected) {
+        // expected
+      }
 
-    try {
-      defaultDatabase.getReferenceFromUrl("https://other-db-test.firebaseio.com/foo/bar");
-      fail("No error thrown for invalid URL");
-    } catch (DatabaseException expected) {
-      // expected
+      try {
+        defaultDatabase.getReferenceFromUrl("https://other-db-test.firebaseio.com/foo/bar");
+        fail("No error thrown for invalid URL");
+      } catch (DatabaseException expected) {
+        // expected
+      }
+    } finally {
+      TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
     }
   }
 
   @Test
-  public void testAppDelete() throws ExecutionException, InterruptedException {
+  public void testAppDelete() {
     FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "testAppDelete");
     FirebaseDatabase db = FirebaseDatabase.getInstance(app);
     assertNotNull(db);
@@ -162,36 +177,24 @@ public class FirebaseDatabaseTest {
   }
 
   @Test
-  public void testInitAfterAppDelete() throws ExecutionException, InterruptedException,
-      TimeoutException {
-    FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "testInitAfterAppDelete");
-    FirebaseDatabase db1 = FirebaseDatabase.getInstance(app);
-    assertNotNull(db1);
-    app.delete();
+  public void testInitAfterAppDelete() {
+    try {
+      FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "testInitAfterAppDelete");
+      FirebaseDatabase db1 = FirebaseDatabase.getInstance(app);
+      assertNotNull(db1);
+      app.delete();
 
-    app = FirebaseApp.initializeApp(firebaseOptions, "testInitAfterAppDelete");
-    FirebaseDatabase db2 = FirebaseDatabase.getInstance(app);
-    assertNotNull(db2);
-    assertNotSame(db1, db2);
+      app = FirebaseApp.initializeApp(firebaseOptions, "testInitAfterAppDelete");
+      FirebaseDatabase db2 = FirebaseDatabase.getInstance(app);
+      assertNotNull(db2);
+      assertNotSame(db1, db2);
+    } finally {
+      TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
+    }
   }
 
   @Test
   public void testDbUrlIsEmulatorUrlWhenSettingOptionsManually() {
-    class CustomTestCase {
-
-      private String suppliedDbUrl;
-      private String envVariableUrl;
-      private String expectedEmulatorUrl;
-      private String namespace;
-
-      private CustomTestCase(String suppliedDbUrl, String envVariableUrl,
-          String expectedEmulatorUrl, String namespace) {
-        this.suppliedDbUrl = suppliedDbUrl;
-        this.envVariableUrl = envVariableUrl;
-        this.expectedEmulatorUrl = expectedEmulatorUrl;
-        this.namespace = namespace;
-      }
-    }
 
     List<CustomTestCase> testCases;
     testCases = ImmutableList.of(
@@ -208,21 +211,15 @@ public class FirebaseDatabaseTest {
         new CustomTestCase("https://test.firebaseio.com?ns=valid-namespace", "localhost:90",
             "http://localhost:90", "valid-namespace")
     );
-    boolean earlierDefaultAppFound = false;
-    try {
-      FirebaseApp.getInstance(FirebaseApp.DEFAULT_APP_NAME).delete();
-      earlierDefaultAppFound = true;
-    } catch (Exception ignored) {
-      // proceed if no leftover default app found.
-    }
     for (CustomTestCase tc : testCases) {
       try {
         FirebaseApp app = FirebaseApp.initializeApp();
         TestUtils.setEnvironmentVariables(
             ImmutableMap.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR,
                 Strings.nullToEmpty(tc.envVariableUrl)));
-        FirebaseDatabase instance = FirebaseDatabase.getInstance(app, tc.suppliedDbUrl);
-        assertEquals(tc.expectedEmulatorUrl, instance.getReference().repo.getRepoInfo().toString());
+        FirebaseDatabase instance = FirebaseDatabase.getInstance(app, tc.rootDbUrl);
+        assertEquals(tc.expectedEmulatorRootUrl,
+            instance.getReference().repo.getRepoInfo().toString());
         assertEquals(tc.namespace, instance.getReference().repo.getRepoInfo().namespace);
         // clean up after
         app.delete();
@@ -231,33 +228,10 @@ public class FirebaseDatabaseTest {
             ImmutableSet.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR));
       }
     }
-    if (earlierDefaultAppFound) {
-      FirebaseApp.initializeApp();
-    }
   }
-
 
   @Test
   public void testDbUrlIsEmulatorUrlForDbRefWithPath() {
-    class CustomTestCase {
-
-      private String rootDbUrl;
-      private String pathUrl;
-      private String envVariableUrl;
-      private String expectedEmulatorRootUrl;
-      private String namespace;
-      private String path;
-
-      private CustomTestCase(String rootDbUrl, String pathUrl, String envVariableUrl,
-          String expectedEmulatorRootUrl, String namespace, String path) {
-        this.rootDbUrl = rootDbUrl;
-        this.pathUrl = pathUrl;
-        this.envVariableUrl = envVariableUrl;
-        this.expectedEmulatorRootUrl = expectedEmulatorRootUrl;
-        this.namespace = namespace;
-        this.path = path;
-      }
-    }
 
     List<CustomTestCase> testCases;
     testCases = ImmutableList.of(
@@ -274,13 +248,6 @@ public class FirebaseDatabaseTest {
             "http://valid-namespace.firebaseio.com/a/b/c/d", "localhost:8080",
             "http://localhost:8080", "valid-namespace", "/a/b/c/d")
     );
-    boolean earlierDefaultAppFound = false;
-    try {
-      FirebaseApp.getInstance(FirebaseApp.DEFAULT_APP_NAME).delete();
-      earlierDefaultAppFound = true;
-    } catch (Exception ignored) {
-      // proceed if no leftover default app found.
-    }
 
     for (CustomTestCase tc : testCases) {
       try {
@@ -301,8 +268,30 @@ public class FirebaseDatabaseTest {
             ImmutableSet.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR));
       }
     }
-    if (earlierDefaultAppFound) {
-      FirebaseApp.initializeApp();
+  }
+
+  private static class CustomTestCase {
+
+    private String rootDbUrl;
+    private String pathUrl;
+    private String envVariableUrl;
+    private String expectedEmulatorRootUrl;
+    private String namespace;
+    private String path;
+
+    private CustomTestCase(String rootDbUrl, String envVariableUrl,
+        String expectedEmulatorRootUrl, String namespace) {
+      this(rootDbUrl, null, envVariableUrl, expectedEmulatorRootUrl, namespace, null);
+    }
+
+    private CustomTestCase(String rootDbUrl, String pathUrl, String envVariableUrl,
+        String expectedEmulatorRootUrl, String namespace, String path) {
+      this.rootDbUrl = rootDbUrl;
+      this.pathUrl = pathUrl;
+      this.envVariableUrl = envVariableUrl;
+      this.expectedEmulatorRootUrl = expectedEmulatorRootUrl;
+      this.namespace = namespace;
+      this.path = path;
     }
   }
 }

--- a/src/test/java/com/google/firebase/database/util/EmulatorHelperTest.java
+++ b/src/test/java/com/google/firebase/database/util/EmulatorHelperTest.java
@@ -1,0 +1,144 @@
+package com.google.firebase.database.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.firebase.database.DatabaseException;
+import com.google.firebase.testing.TestUtils;
+import java.util.List;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class EmulatorHelperTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testExtractingEmulatorUrlFromSuppliedUrlSucceeds() {
+    Map<String, String> suppliedToExpectedUrlsMap = ImmutableMap.of(
+        "http://localhost:9000?ns=test-ns", "http://localhost:9000/?ns=test-ns",
+        "http://my-custom-hosted-emulator.com:80?ns=dummy-ns",
+        "http://my-custom-hosted-emulator.com:80/?ns=dummy-ns",
+        "http://my-custom-hosted-emulator.com:80/path/to/document?ns=dummy-ns",
+        "http://my-custom-hosted-emulator.com:80/path/to/document/?ns=dummy-ns"
+    );
+    for (Map.Entry<String, String> e : suppliedToExpectedUrlsMap.entrySet()) {
+      assertEquals(e.getValue(), EmulatorHelper.extractEmulatorUrlFromDbUrl(e.getKey()));
+    }
+  }
+
+  @Test
+  public void testExtractingEmulatorUrlsFromSuppliedUrlFails() {
+    List<String> nonEmulatorUrls = ImmutableList.of(
+        "https://localhost:9000?ns=test-ns",// https scheme
+        "http://localhost?ns=test-ns", // missing port
+        "http://localhost:9000",// missing ns param
+        "http://my-custom-hosted-emulator.com?ns=dummy-ns", // missing port
+        "http://my-custom-hosted-emulator.com:80", // missing ns param
+        "http://test-namespace.firebaseio.com" // firebaseio.com not supported
+    );
+    for (String url : nonEmulatorUrls) {
+      assertNull(EmulatorHelper.extractEmulatorUrlFromDbUrl(url));
+    }
+  }
+
+  @Test
+  public void testExtractingEmulatorUrlsThrowsException() {
+    List<String> invalidFormedUrls = ImmutableList.of(
+        "localhost",
+        "localhost:9000"
+    );
+    for (String invalidFormedUrl : invalidFormedUrls) {
+      thrown.expect(DatabaseException.class);
+      EmulatorHelper.extractEmulatorUrlFromDbUrl(invalidFormedUrl);
+    }
+  }
+
+  @Test
+  public void testEmulatorUrlCorrectlyPickedUp() {
+    class CustomTestCase {
+
+      private String suppliedDbUrl;
+      private String envVariableUrl;
+      private String expectedEmulatorUrl;
+
+      private CustomTestCase(String suppliedDbUrl, String envVariableUrl,
+          String expectedEmulatorUrl) {
+        this.suppliedDbUrl = suppliedDbUrl;
+        this.envVariableUrl = envVariableUrl;
+        this.expectedEmulatorUrl = expectedEmulatorUrl;
+      }
+    }
+
+    List<CustomTestCase> testCases; // separated declaration and assignment coz of checkstyle
+    testCases = ImmutableList.of(
+        // cases where the env var is ignored because the supplied DB URL is a valid emulator URL
+        new CustomTestCase("http://my-custom-hosted-emulator.com:80?ns=dummy-ns", "",
+            "http://my-custom-hosted-emulator.com:80/?ns=dummy-ns"),
+        new CustomTestCase("http://localhost:9000?ns=test-ns", null,
+            "http://localhost:9000/?ns=test-ns"),
+        new CustomTestCase("http://my-custom-hosted-emulator.com:80?ns=dummy-ns",
+            "http://localhost:8080/ns=ns-2",
+            "http://my-custom-hosted-emulator.com:80/?ns=dummy-ns"),
+        new CustomTestCase("http://localhost:9000?ns=ns-1", "localhost:8080",
+            "http://localhost:9000/?ns=ns-1"),
+        new CustomTestCase("http://localhost:9000?ns=ns-1", "http://localhost:8080/ns=ns-2",
+            "http://localhost:9000/?ns=ns-1"),
+        new CustomTestCase("http://localhost:9000/a/b/c?ns=ns-1", "http://localhost:8080/ns=ns-2",
+            "http://localhost:9000/a/b/c/?ns=ns-1"),
+
+        // cases where the supplied DB URL is not an emulator URL, so we extract ns from it
+        // and append it to the emulator URL from env var(if it is valid)
+        new CustomTestCase("https://valid-namespace.firebaseio.com", "localhost:8080",
+            "http://localhost:8080/?ns=valid-namespace"),
+        new CustomTestCase("https://valid-namespace.firebaseio.com", "custom-emulator-url:90",
+            "http://custom-emulator-url:90/?ns=valid-namespace"),
+        new CustomTestCase("https://valid-namespace.firebaseio.com/a/b/c", "custom-emulator-url:90",
+            "http://custom-emulator-url:90/a/b/c/?ns=valid-namespace"),
+        new CustomTestCase("https://valid-namespace.firebaseio.com", "192.123.212.145:90",
+            "http://192.123.212.145:90/?ns=valid-namespace"),
+        new CustomTestCase("https://valid-namespace.firebaseio.com", "[::1]:90",
+            "http://[::1]:90/?ns=valid-namespace"),
+        new CustomTestCase("https://firebaseio.com?ns=valid-namespace", "localhost:90",
+            "http://localhost:90/?ns=valid-namespace"),
+        new CustomTestCase(null, "localhost:90", "http://localhost:90/?ns=default"),
+        new CustomTestCase("", "localhost:90", "http://localhost:90/?ns=default")
+    );
+
+    for (CustomTestCase tc : testCases) {
+      TestUtils.setEnvironmentVariables(
+          ImmutableMap.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR,
+              Strings.nullToEmpty(tc.envVariableUrl)));
+      assertEquals(tc.expectedEmulatorUrl, EmulatorHelper.getEmulatorUrl(tc.suppliedDbUrl));
+      TestUtils.unsetEnvironmentVariables(
+          ImmutableSet.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR));
+    }
+  }
+
+  @Test
+  public void testInvalidEmulatorUrlFromEnvVarThrows() {
+    List<String> invalidEnvVars = ImmutableList.of(
+        "http://localhost:8080",
+        "http://localhost:8080?ns=test-ns",
+        "localhost"
+    );
+    for (String invalidEnvVar : invalidEnvVars) {
+      TestUtils.setEnvironmentVariables(
+          ImmutableMap.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR,
+              Strings.nullToEmpty(invalidEnvVar)));
+      thrown.expect(IllegalArgumentException.class);
+      EmulatorHelper.getEmulatorUrl("https://valid-namespace.firebaseio.com");
+      TestUtils.unsetEnvironmentVariables(
+          ImmutableSet.of(EmulatorHelper.FIREBASE_RTDB_EMULATOR_HOST_ENV_VAR));
+    }
+  }
+}
+
+

--- a/src/test/java/com/google/firebase/database/util/EmulatorHelperTest.java
+++ b/src/test/java/com/google/firebase/database/util/EmulatorHelperTest.java
@@ -24,7 +24,10 @@ public class EmulatorHelperTest {
         "http://my-custom-hosted-emulator.com:80?ns=dummy-ns",
         "http://my-custom-hosted-emulator.com:80/?ns=dummy-ns",
         "http://my-custom-hosted-emulator.com:80/path/to/document?ns=dummy-ns",
-        "http://my-custom-hosted-emulator.com:80/path/to/document/?ns=dummy-ns"
+        "http://my-custom-hosted-emulator.com:80/path/to/document/?ns=dummy-ns",
+        "https://localhost:9000?ns=test-ns", "https://localhost:9000/?ns=test-ns",
+        "http://my-custom-hosted-emulator.com?ns=dummy-ns",
+        "http://my-custom-hosted-emulator.com/?ns=dummy-ns"
     );
     for (Map.Entry<String, String> e : suppliedToExpectedUrlsMap.entrySet()) {
       assertEquals(e.getValue(), EmulatorHelper.tryToExtractEmulatorUrlFromDbUrl(e.getKey()));
@@ -34,10 +37,7 @@ public class EmulatorHelperTest {
   @Test
   public void testExtractingEmulatorUrlsFromSuppliedUrlFails() {
     List<String> nonEmulatorUrls = ImmutableList.of(
-        "https://localhost:9000?ns=test-ns",// https scheme
-        "http://localhost?ns=test-ns", // missing port
         "http://localhost:9000",// missing ns param
-        "http://my-custom-hosted-emulator.com?ns=dummy-ns", // missing port
         "http://my-custom-hosted-emulator.com:80", // missing ns param
         "http://test-namespace.firebaseio.com" // firebaseio.com not supported
     );
@@ -90,6 +90,8 @@ public class EmulatorHelperTest {
             "http://localhost:9000/?ns=ns-1"),
         new CustomTestCase("http://localhost:9000/a/b/c?ns=ns-1", "http://localhost:8080/ns=ns-2",
             "http://localhost:9000/a/b/c/?ns=ns-1"),
+        new CustomTestCase("https://firebaseio.com?ns=valid-namespace", "localhost:90",
+            "https://firebaseio.com/?ns=valid-namespace"),
 
         // cases where the supplied DB URL is not an emulator URL, so we extract ns from it
         // and append it to the emulator URL from env var(if it is valid)
@@ -103,8 +105,6 @@ public class EmulatorHelperTest {
             "http://192.123.212.145:90/?ns=valid-namespace"),
         new CustomTestCase("https://valid-namespace.firebaseio.com", "[::1]:90",
             "http://[::1]:90/?ns=valid-namespace"),
-        new CustomTestCase("https://firebaseio.com?ns=valid-namespace", "localhost:90",
-            "http://localhost:90/?ns=valid-namespace"),
         new CustomTestCase(null, "localhost:90", "http://localhost:90/?ns=default"),
         new CustomTestCase("", "localhost:90", "http://localhost:90/?ns=default")
     );

--- a/src/test/java/com/google/firebase/database/util/EmulatorHelperTest.java
+++ b/src/test/java/com/google/firebase/database/util/EmulatorHelperTest.java
@@ -2,16 +2,13 @@ package com.google.firebase.database.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.database.DatabaseException;
-import com.google.firebase.database.utilities.Utilities;
 import java.util.List;
 import java.util.Map;
-import javax.rmi.CORBA.Util;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/src/test/java/com/google/firebase/database/utilities/UtilitiesTest.java
+++ b/src/test/java/com/google/firebase/database/utilities/UtilitiesTest.java
@@ -32,6 +32,7 @@ import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseException;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.DatabaseReference.CompletionListener;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import org.junit.Test;
 
@@ -185,4 +186,11 @@ public class UtilitiesTest {
     assertSame(listener, result.getSecond());
   }
 
+  @Test
+  public void testExtractParamsFromUrl() {
+    Map<String, String> params = Utilities.getQueryParamsMap("abc=213&qpf=2312&xyz=true&qpf=hi");
+    assertEquals("213", params.get("abc"));
+    assertEquals("2312,hi", params.get("qpf"));
+    assertEquals("true", params.get("xyz"));
+  }
 }

--- a/src/test/java/com/google/firebase/database/utilities/UtilitiesTest.java
+++ b/src/test/java/com/google/firebase/database/utilities/UtilitiesTest.java
@@ -32,6 +32,8 @@ import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseException;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.DatabaseReference.CompletionListener;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import org.junit.Test;
@@ -80,7 +82,7 @@ public class UtilitiesTest {
         .parseUrl("https://firebaseio.com/path%20with%20spaces/?ns=random%20valid%20namespace");
     assertTrue(url.repoInfo.isSecure());
     assertEquals("random valid namespace", url.repoInfo.namespace);
-    assertEquals("/path with spaces", url.path.toString());
+    assertEquals("/path%20with%20spaces", url.path.toString());
   }
 
   @Test
@@ -193,19 +195,20 @@ public class UtilitiesTest {
   }
 
   @Test
-  public void testExtractParamsFromUrl() {
+  public void testExtractParamsFromUrl() throws UnsupportedEncodingException {
     Map<String, String> params = Utilities.getQueryParamsMap("abc=213&qpf=2312&xyz=true&qpf=hi");
     assertEquals("213", params.get("abc"));
     assertEquals("2312,hi", params.get("qpf"));
     assertEquals("true", params.get("xyz"));
-  }
 
+    params = Utilities.getQueryParamsMap(
+        "q=a%3D2%26b%3D3&oq=a%3D2%26b%3D3&aqs=chrome..69i57j0l5.4023j0j7&sourceid=chrome&ie=UTF-8");
+    assertEquals("a=2&b=3", params.get("q"));
+    assertEquals("a=2&b=3", params.get("oq"));
+    assertEquals("chrome", params.get("sourceid"));
 
-  @Test
-  public void testExtractParamsFromEncodedUrl() {
-    Map<String, String> params = Utilities.getQueryParamsMap("abc=213&qpf=2312&xyz=true&qpf=hi");
-    assertEquals("213", params.get("abc"));
-    assertEquals("2312,hi", params.get("qpf"));
-    assertEquals("true", params.get("xyz"));
+    params = Utilities.getQueryParamsMap("a=%3F%3F%3F&b=%3D%26%3D");
+    assertEquals("???", params.get("a"));
+    assertEquals("=&=", params.get("b"));
   }
 }

--- a/src/test/java/com/google/firebase/database/utilities/UtilitiesTest.java
+++ b/src/test/java/com/google/firebase/database/utilities/UtilitiesTest.java
@@ -75,6 +75,12 @@ public class UtilitiesTest {
     assertTrue(url.repoInfo.isSecure());
     assertEquals("test", url.repoInfo.namespace);
     assertEquals(ImmutableList.of("foo", "bar"), url.path.asList());
+
+    url = Utilities
+        .parseUrl("https://firebaseio.com/path%20with%20spaces/?ns=random%20valid%20namespace");
+    assertTrue(url.repoInfo.isSecure());
+    assertEquals("random valid namespace", url.repoInfo.namespace);
+    assertEquals("/path with spaces", url.path.toString());
   }
 
   @Test

--- a/src/test/java/com/google/firebase/database/utilities/UtilitiesTest.java
+++ b/src/test/java/com/google/firebase/database/utilities/UtilitiesTest.java
@@ -193,4 +193,13 @@ public class UtilitiesTest {
     assertEquals("2312,hi", params.get("qpf"));
     assertEquals("true", params.get("xyz"));
   }
+
+
+  @Test
+  public void testExtractParamsFromEncodedUrl() {
+    Map<String, String> params = Utilities.getQueryParamsMap("abc=213&qpf=2312&xyz=true&qpf=hi");
+    assertEquals("213", params.get("abc"));
+    assertEquals("2312,hi", params.get("qpf"));
+    assertEquals("true", params.get("xyz"));
+  }
 }

--- a/src/test/java/com/google/firebase/database/utilities/UtilitiesTest.java
+++ b/src/test/java/com/google/firebase/database/utilities/UtilitiesTest.java
@@ -83,6 +83,9 @@ public class UtilitiesTest {
     assertTrue(url.repoInfo.isSecure());
     assertEquals("random valid namespace", url.repoInfo.namespace);
     assertEquals("/path%20with%20spaces", url.path.toString());
+
+    url = Utilities.parseUrl("http://test.firebaseio.com/+");
+    assertEquals("/ ", url.path.toString());
   }
 
   @Test

--- a/src/test/java/com/google/firebase/testing/TestUtils.java
+++ b/src/test/java/com/google/firebase/testing/TestUtils.java
@@ -11,7 +11,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License.F
+ * limitations under the License.
  */
 
 package com.google.firebase.testing;


### PR DESCRIPTION
This PR makes it possible for the Java admin SDK to talk to the RTDB emulator instead of the actual database instance.
This can happen in the following fashion:-
1. If the user passes in a valid emulator URL (http scheme only, host can't contain `firebaseio.com`, has the `ns` query parameter)
2. Else, if the environment variable `FIREBASE_RTDB_EMULATOR_HOST` is set to a value of the form `host:port`.

If either 1. or 2. is true, we decide to talk to the RTDB emulator. In such cases, we 
- provide a valid emulator URL (either by replacing the supplied URL or making a new one)
- replace existing credentials with `EmulatorCredentials`, which use `owner` as the access token.

URL replacement happens in three places:- 
1. while constructing `FirebaseOptions` instances in `FirebaseApp`
2. when a specific `databaseUrl` is passed in `FirebaseDatabase.getInstance(String url)`
3. when a specific URL with path is passed in `FirebaseDatabase.getReferenceFromUrl(String url)`


Tests have been added with different combinations of passed-in URLs and environment variable values for classes `FirebaseApp`, `FirebaseDatabase`, and also for  `EmulatorHelper`: the helper class that actually does URL replacement if necessary.

**Notes for reviewers**
I have made changes to existing behavior to `Utilities.parseUrl(String url)`: these changes were necessary to recognize the `ns` query parameter, and also to suppost valid `<net_loc>` URL semantics where a URL like `http://localhost:8080/` is deemed valid.
These changes are nearly identical to changes to the same file in [this Android SDK PR](https://github.com/firebase/firebase-android-sdk/pull/680/files).
