### PR TITLE
Fixing an intermittent test failure

### DIFF
--- a/src/test/java/com/google/firebase/FirebaseAppTest.java
+++ b/src/test/java/com/google/firebase/FirebaseAppTest.java
@@ -39,6 +39,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.firebase.FirebaseApp.TokenRefresher;
 import com.google.firebase.FirebaseOptions.Builder;
 import com.google.firebase.database.FirebaseDatabase;
@@ -60,6 +61,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -81,6 +83,11 @@ public class FirebaseAppTest {
   @BeforeClass
   public static void setupClass() throws IOException {
     TestUtils.getApplicationDefaultCredentials();
+  }
+
+  @AfterClass
+  public static void tearDownClass() {
+    TestUtils.unsetEnvironmentVariables(ImmutableSet.of(FirebaseApp.FIREBASE_CONFIG_ENV_VAR));
   }
 
   @Test(expected = NullPointerException.class)


### PR DESCRIPTION
Not sure how, but the recent changes to database tests is causing a test failure in some environments:

```
Running com.google.firebase.database.FirebaseDatabaseTest
Tests run: 10, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.052 sec <<< FAILURE! - in com.google.firebase.database.FirebaseDatabaseTest
testDbUrlIsEmulatorUrlForDbRefWithPath(com.google.firebase.database.FirebaseDatabaseTest)  Time elapsed: 0.004 sec  <<< ERROR!
java.lang.IllegalArgumentException: Failed to load settings from the system's environment variables
	at com.google.firebase.database.FirebaseDatabaseTest.testDbUrlIsEmulatorUrlForDbRefWithPath(FirebaseDatabaseTest.java:252)
Caused by: com.fasterxml.jackson.core.JsonParseException: 
Unexpected character (',' (code 44)): was expecting double-quote to start field name
 at [Source: (String)"{,,"; line: 1, column: 3]
	at com.google.firebase.database.FirebaseDatabaseTest.testDbUrlIsEmulatorUrlForDbRefWithPath(FirebaseDatabaseTest.java:252)

testDbUrlIsEmulatorUrlWhenSettingOptionsManually(com.google.firebase.database.FirebaseDatabaseTest)  Time elapsed: 0 sec  <<< ERROR!
java.lang.IllegalArgumentException: Failed to load settings from the system's environment variables
	at com.google.firebase.database.FirebaseDatabaseTest.testDbUrlIsEmulatorUrlWhenSettingOptionsManually(FirebaseDatabaseTest.java:215)
Caused by: com.fasterxml.jackson.core.JsonParseException: 
Unexpected character (',' (code 44)): was expecting double-quote to start field name
 at [Source: (String)"{,,"; line: 1, column: 3]
	at com.google.firebase.database.FirebaseDatabaseTest.testDbUrlIsEmulatorUrlWhenSettingOptionsManually(FirebaseDatabaseTest.java:215)
```

Seems to be related to the order of tests. `FirebaseAppTest` has some test cases where they set the `FIREBASE_CONFIG` env variable to malformed values like `{,,`. These values are not cleared and are picked up by later tests.