### PR TITLE
fix: Upgraded Firestore and GCS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,17 +412,17 @@
         <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
-            <version>0.16.1</version>
+            <version>0.17.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <version>1.79.0</version>
+            <version>1.91.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-firestore</artifactId>
-            <version>1.9.0</version>
+            <version>1.21.0</version>
         </dependency>
 
         <!-- Utilities -->


### PR DESCRIPTION
RELEASE NOTE: Upgraded Cloud Firestore dependency version to 1.21.0.
RELEASE NOTE: Upgraded Cloud Storage dependency version to 1.91.0.

Resolves #310 
