### PR TITLE
Remove (base64) 'REDACTED' passwords from user records.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,9 +136,13 @@ Create a new project in the [Firebase console](https://console.firebase.google.c
 not already have one. Use a separate, dedicated project for integration tests since the test suite
 makes a large number of writes to the Firebase realtime database. Download the service account
 private key from the "Settings > Service Accounts" page of the project, and save it as
-`integration_cert.json` at the root of the codebase. Also obtain the web API key of the project
-from the "Settings > General" page, and save it as `integration_apikey.txt` at the root of the
-codebase. Now run the following command to invoke the integration test suite:
+`integration_cert.json` at the root of the codebase. Grant your service account the `Firebase
+Authentication Admin` role at
+[Google Cloud Platform Console / IAM & admin](https://console.cloud.google.com/iam-admin). This is
+required to ensure that exported user records contain the password hashes of the user accounts.
+Also obtain the web API key of the project from the "Settings > General" page, and save it as
+`integration_apikey.txt` at the root of the codebase. Now run the following command to invoke the
+integration test suite:
 
 ```
 mvn verify

--- a/src/main/java/com/google/firebase/auth/ExportedUserRecord.java
+++ b/src/main/java/com/google/firebase/auth/ExportedUserRecord.java
@@ -17,6 +17,7 @@
 package com.google.firebase.auth;
 
 import com.google.api.client.json.JsonFactory;
+import com.google.common.io.BaseEncoding;
 import com.google.firebase.auth.internal.DownloadAccountResponse.User;
 import com.google.firebase.internal.Nullable;
 
@@ -28,10 +29,17 @@ public class ExportedUserRecord extends UserRecord {
 
   private final String passwordHash;
   private final String passwordSalt;
+  private static final String REDACTED_BASE64 = BaseEncoding.base64Url().encode(
+      "REDACTED".getBytes());
 
   ExportedUserRecord(User response, JsonFactory jsonFactory) {
     super(response, jsonFactory);
-    this.passwordHash = response.getPasswordHash();
+    String passwordHash = response.getPasswordHash();
+    if (passwordHash != null && !passwordHash.equals(REDACTED_BASE64)) {
+      this.passwordHash = passwordHash;
+    } else {
+      this.passwordHash = null;
+    }
     this.passwordSalt = response.getPasswordSalt();
   }
 

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -264,7 +264,9 @@ public class FirebaseAuthIT {
         for (ExportedUserRecord user : page.getValues()) {
           if (uids.contains(user.getUid())) {
             collected.incrementAndGet();
-            assertNotNull(user.getPasswordHash());
+            assertNotNull("Missing passwordHash field. A common cause would be "
+                + "forgetting to add the \"Firebase Authentication Admin\" permission. See "
+                + "instructions in CONTRIBUTING.md", user.getPasswordHash());
             assertNotNull(user.getPasswordSalt());
           }
         }


### PR DESCRIPTION
Base64 'REDACTED' passwords look like passwords hashes, but aren't, leading to
potential confusion.

Additionally, added docs to CONTRIBUTING.md detailing how to add the
permission that causes password hashes to be properly returned as well
as adjusting the test failure message should the developer not add that
permission.

b/141189502