### PR TITLE
fix(fcm): Increase the multicast request count limit to 500.

### DIFF
--- a/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
@@ -149,7 +149,7 @@ public class FirebaseMessaging {
    * <p>The responses list obtained by calling {@link BatchResponse#getResponses()} on the return
    * value corresponds to the order of input messages.
    *
-   * @param messages A non-null, non-empty list containing up to 100 messages.
+   * @param messages A non-null, non-empty list containing up to 500 messages.
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
    *     delivery. An exception here indicates a total failure -- i.e. none of the messages in the
@@ -171,7 +171,7 @@ public class FirebaseMessaging {
    * <p>The responses list obtained by calling {@link BatchResponse#getResponses()} on the return
    * value corresponds to the order of input messages.
    *
-   * @param messages A non-null, non-empty list containing up to 100 messages.
+   * @param messages A non-null, non-empty list containing up to 500 messages.
    * @param dryRun A boolean indicating whether to perform a dry run (validation only) of the send.
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
@@ -186,7 +186,7 @@ public class FirebaseMessaging {
   /**
    * Similar to {@link #sendAll(List)} but performs the operation asynchronously.
    *
-   * @param messages A non-null, non-empty list containing up to 100 messages.
+   * @param messages A non-null, non-empty list containing up to 500 messages.
    * @return @return An {@code ApiFuture} that will complete with a {@link BatchResponse} when
    *     the messages have been sent.
    */
@@ -197,7 +197,7 @@ public class FirebaseMessaging {
   /**
    * Similar to {@link #sendAll(List, boolean)} but performs the operation asynchronously.
    *
-   * @param messages A non-null, non-empty list containing up to 100 messages.
+   * @param messages A non-null, non-empty list containing up to 500 messages.
    * @param dryRun A boolean indicating whether to perform a dry run (validation only) of the send.
    * @return @return An {@code ApiFuture} that will complete with a {@link BatchResponse} when
    *     the messages have been sent, or when the emulation has finished.
@@ -284,8 +284,8 @@ public class FirebaseMessaging {
 
     final List<Message> immutableMessages = ImmutableList.copyOf(messages);
     checkArgument(!immutableMessages.isEmpty(), "messages list must not be empty");
-    checkArgument(immutableMessages.size() <= 100,
-        "messages list must not contain more than 100 elements");
+    checkArgument(immutableMessages.size() <= 500,
+        "messages list must not contain more than 500 elements");
     final FirebaseMessagingClient messagingClient = getMessagingClient();
     return new CallableOperation<BatchResponse,FirebaseMessagingException>() {
       @Override

--- a/src/main/java/com/google/firebase/messaging/MulticastMessage.java
+++ b/src/main/java/com/google/firebase/messaging/MulticastMessage.java
@@ -31,7 +31,7 @@ import java.util.Map;
 /**
  * Represents a message that can be sent to multiple devices via Firebase Cloud Messaging (FCM).
  * Contains payload information as well as the list of device registration tokens to which the
- * message should be sent. A single {@code MulticastMessage} may contain up to 100 registration
+ * message should be sent. A single {@code MulticastMessage} may contain up to 500 registration
  * tokens.
  *
  * <p>Instances of this class are thread-safe and immutable. Use {@link MulticastMessage.Builder}
@@ -55,7 +55,7 @@ public class MulticastMessage {
   private MulticastMessage(Builder builder) {
     this.tokens = builder.tokens.build();
     checkArgument(!this.tokens.isEmpty(), "at least one token must be specified");
-    checkArgument(this.tokens.size() <= 100, "no more than 100 tokens can be specified");
+    checkArgument(this.tokens.size() <= 500, "no more than 500 tokens can be specified");
     for (String token : this.tokens) {
       checkArgument(!Strings.isNullOrEmpty(token), "none of the tokens can be null or empty");
     }
@@ -103,7 +103,7 @@ public class MulticastMessage {
     private Builder() {}
 
     /**
-     * Adds a token to which the message should be sent. Up to 100 tokens can be specified on
+     * Adds a token to which the message should be sent. Up to 500 tokens can be specified on
      * a single instance of {@link MulticastMessage}.
      *
      * @param token A non-null, non-empty Firebase device registration token.
@@ -115,7 +115,7 @@ public class MulticastMessage {
     }
 
     /**
-     * Adds a collection of tokens to which the message should be sent. Up to 100 tokens can be
+     * Adds a collection of tokens to which the message should be sent. Up to 500 tokens can be
      * specified on a single instance of {@link MulticastMessage}.
      *
      * @param tokens Collection of Firebase device registration tokens.

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingIT.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingIT.java
@@ -114,16 +114,16 @@ public class FirebaseMessagingIT {
   }
 
   @Test
-  public void testSendHundred() throws Exception {
+  public void testSendFiveHundred() throws Exception {
     List<Message> messages = new ArrayList<>();
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 500; i++) {
       messages.add(Message.builder().setTopic("foo-bar-" + (i % 10)).build());
     }
 
     BatchResponse response = FirebaseMessaging.getInstance().sendAll(messages, true);
 
-    assertEquals(100, response.getResponses().size());
-    assertEquals(100, response.getSuccessCount());
+    assertEquals(500, response.getResponses().size());
+    assertEquals(500, response.getSuccessCount());
     assertEquals(0, response.getFailureCount());
     for (SendResponse sendResponse : response.getResponses()) {
       if (!sendResponse.isSuccessful()) {

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingTest.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingTest.java
@@ -296,7 +296,7 @@ public class FirebaseMessagingTest {
     MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId(null);
     FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
     ImmutableList.Builder<Message> listBuilder = ImmutableList.builder();
-    for (int i = 0; i < 101; i++) {
+    for (int i = 0; i < 501; i++) {
       listBuilder.add(Message.builder().setTopic("topic").build());
     }
 

--- a/src/test/java/com/google/firebase/messaging/MulticastMessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MulticastMessageTest.java
@@ -70,12 +70,12 @@ public class MulticastMessageTest {
   @Test
   public void testTooManyTokens() {
     MulticastMessage.Builder builder = MulticastMessage.builder();
-    for (int i = 0; i < 101; i++) {
+    for (int i = 0; i < 501; i++) {
       builder.addToken("token" + i);
     }
     try {
       builder.build();
-      fail("No error thrown for more than 100 tokens");
+      fail("No error thrown for more than 500 tokens");
     } catch (IllegalArgumentException expected) {
       // expected
     }

--- a/src/test/java/com/google/firebase/snippets/FirebaseMessagingSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseMessagingSnippets.java
@@ -122,7 +122,7 @@ public class FirebaseMessagingSnippets {
     String registrationToken = "YOUR_REGISTRATION_TOKEN";
 
     // [START send_all]
-    // Create a list containing up to 100 messages.
+    // Create a list containing up to 500 messages.
     List<Message> messages = Arrays.asList(
         Message.builder()
             .setNotification(new Notification("Price drop", "5% off all electronics"))


### PR DESCRIPTION
Increase the multicast request count limit to 500.

### Testing

  * Updated the related tests.

RELEASE NOTE: Number of messages per batch increased to 500.