### PR TITLE
Fix Date test in another Locale

### DIFF
--- a/src/main/java/com/google/firebase/internal/DateUtils.java
+++ b/src/main/java/com/google/firebase/internal/DateUtils.java
@@ -20,6 +20,7 @@ import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 /**
@@ -57,9 +58,9 @@ final class DateUtils {
   static final String PATTERN_ASCTIME = "EEE MMM d HH:mm:ss yyyy";
 
   private static final SimpleDateFormat[] DEFAULT_PATTERNS = new SimpleDateFormat[] {
-      new SimpleDateFormat(PATTERN_RFC1123),
-      new SimpleDateFormat(PATTERN_RFC1036),
-      new SimpleDateFormat(PATTERN_ASCTIME)
+      new SimpleDateFormat(PATTERN_RFC1123, Locale.ROOT),
+      new SimpleDateFormat(PATTERN_RFC1036, Locale.ROOT),
+      new SimpleDateFormat(PATTERN_ASCTIME, Locale.ROOT)
   };
 
   static final TimeZone GMT = TimeZone.getTimeZone("GMT");

--- a/src/main/java/com/google/firebase/internal/DateUtils.java
+++ b/src/main/java/com/google/firebase/internal/DateUtils.java
@@ -58,9 +58,9 @@ final class DateUtils {
   static final String PATTERN_ASCTIME = "EEE MMM d HH:mm:ss yyyy";
 
   private static final SimpleDateFormat[] DEFAULT_PATTERNS = new SimpleDateFormat[] {
-      new SimpleDateFormat(PATTERN_RFC1123, Locale.UK),
-      new SimpleDateFormat(PATTERN_RFC1036, Locale.UK),
-      new SimpleDateFormat(PATTERN_ASCTIME, Locale.UK)
+      new SimpleDateFormat(PATTERN_RFC1123, Locale.US),
+      new SimpleDateFormat(PATTERN_RFC1036, Locale.US),
+      new SimpleDateFormat(PATTERN_ASCTIME, Locale.US)
   };
 
   static final TimeZone GMT = TimeZone.getTimeZone("GMT");

--- a/src/main/java/com/google/firebase/internal/DateUtils.java
+++ b/src/main/java/com/google/firebase/internal/DateUtils.java
@@ -58,9 +58,9 @@ final class DateUtils {
   static final String PATTERN_ASCTIME = "EEE MMM d HH:mm:ss yyyy";
 
   private static final SimpleDateFormat[] DEFAULT_PATTERNS = new SimpleDateFormat[] {
-      new SimpleDateFormat(PATTERN_RFC1123, Locale.ROOT),
-      new SimpleDateFormat(PATTERN_RFC1036, Locale.ROOT),
-      new SimpleDateFormat(PATTERN_ASCTIME, Locale.ROOT)
+      new SimpleDateFormat(PATTERN_RFC1123, Locale.UK),
+      new SimpleDateFormat(PATTERN_RFC1036, Locale.UK),
+      new SimpleDateFormat(PATTERN_ASCTIME, Locale.UK)
   };
 
   static final TimeZone GMT = TimeZone.getTimeZone("GMT");

--- a/src/test/java/com/google/firebase/internal/RetryUnsuccessfulResponseHandlerTest.java
+++ b/src/test/java/com/google/firebase/internal/RetryUnsuccessfulResponseHandlerTest.java
@@ -140,7 +140,7 @@ public class RetryUnsuccessfulResponseHandlerTest {
   @Test
   public void testRetryAfterGivenAsDate() throws IOException {
     SimpleDateFormat dateFormat =
-            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.UK);
+            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
     dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
     Date date = new Date(1000);
     Clock clock = new FixedClock(date.getTime());

--- a/src/test/java/com/google/firebase/internal/RetryUnsuccessfulResponseHandlerTest.java
+++ b/src/test/java/com/google/firebase/internal/RetryUnsuccessfulResponseHandlerTest.java
@@ -35,7 +35,9 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
+
 import org.junit.Test;
 
 public class RetryUnsuccessfulResponseHandlerTest {
@@ -137,7 +139,8 @@ public class RetryUnsuccessfulResponseHandlerTest {
 
   @Test
   public void testRetryAfterGivenAsDate() throws IOException {
-    SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
+    SimpleDateFormat dateFormat =
+            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ROOT);
     dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
     Date date = new Date(1000);
     Clock clock = new FixedClock(date.getTime());

--- a/src/test/java/com/google/firebase/internal/RetryUnsuccessfulResponseHandlerTest.java
+++ b/src/test/java/com/google/firebase/internal/RetryUnsuccessfulResponseHandlerTest.java
@@ -140,7 +140,7 @@ public class RetryUnsuccessfulResponseHandlerTest {
   @Test
   public void testRetryAfterGivenAsDate() throws IOException {
     SimpleDateFormat dateFormat =
-            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ROOT);
+            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.UK);
     dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
     Date date = new Date(1000);
     Clock clock = new FixedClock(date.getTime());

--- a/src/test/java/com/google/firebase/messaging/MessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MessageTest.java
@@ -849,7 +849,7 @@ public class MessageTest {
         .put("title", "title")
         .put("body", "body")
         .build();
-    String eventTime = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'", Locale.ROOT)
+    String eventTime = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'", Locale.US)
         .format(new Date(1546304523123L));
     Map<String, Object> androidConfig = ImmutableMap.<String, Object>builder()
         .put("notification", ImmutableMap.<String, Object>builder()

--- a/src/test/java/com/google/firebase/messaging/MessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MessageTest.java
@@ -33,6 +33,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
@@ -769,7 +770,7 @@ public class MessageTest {
     assertJsonEquals(ImmutableMap.of(
         "topic", "test-topic", "notification", notification, "android", androidConfig), message);
   }
-  
+
   @Test
   public void testImageInApnsNotification() throws IOException {
     Message message = Message.builder()
@@ -799,7 +800,7 @@ public class MessageTest {
             .build();
     assertJsonEquals(expected, message);
   }
-  
+
   @Test
   public void testInvalidColorInAndroidNotificationLightSettings() throws IOException {
     try {
@@ -814,7 +815,7 @@ public class MessageTest {
       // expected
     }
   }
-  
+
   @Test
   public void testExtendedAndroidNotificationParameters() throws IOException {
     long[] vibrateTimings = {1000L, 1001L};
@@ -848,7 +849,7 @@ public class MessageTest {
         .put("title", "title")
         .put("body", "body")
         .build();
-    String eventTime = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'")
+    String eventTime = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'", Locale.ROOT)
         .format(new Date(1546304523123L));
     Map<String, Object> androidConfig = ImmutableMap.<String, Object>builder()
         .put("notification", ImmutableMap.<String, Object>builder()


### PR DESCRIPTION
### Discussion
No issue.

Current Date test is depend on Locale(GMT).

I ran the test on my local machine and it was not successful.
This is because the Japanese locale (JMT) is used.

I defined use Locale.US.

### Testing
Fixed test

### API Changes
None
