### PR TITLE
MessagingServiceResponse object isn't serializing

### DIFF
--- a/src/main/java/com/google/firebase/messaging/internal/MessagingServiceResponse.java
+++ b/src/main/java/com/google/firebase/messaging/internal/MessagingServiceResponse.java
@@ -5,7 +5,7 @@ import com.google.api.client.util.Key;
 /**
  * The DTO for parsing success responses from the FCM service.
  */
-public class MessagingServiceResponse {
+public class MessagingServiceResponse extends GenericJson {
 
   @Key("name")
   private String messageId;


### PR DESCRIPTION
Without extending GenericJson in MessagingServiceResponse class, Json to MessagingServiceResponse object conversion isn't happening using Gson library.

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
