### PR TITLE
Upgrade Cloud Firestore dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -422,7 +422,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-firestore</artifactId>
-            <version>1.21.0</version>
+            <version>1.31.0</version>
         </dependency>
 
         <!-- Utilities -->


### PR DESCRIPTION
Will provide IN query features

RELEASE NOTE: fix(Cloud Firestore): Upgraded `google-cloud-firestore` dependency version to 1.31.0 which provides support for `IN` queries.