### PR TITLE
fix(fcm): Correctly handling FCM THIRD_PARTY_AUTH_ERROR error code

### DIFF
--- a/src/main/java/com/google/firebase/messaging/FirebaseMessagingClientImpl.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessagingClientImpl.java
@@ -67,14 +67,15 @@ final class FirebaseMessagingClientImpl implements FirebaseMessagingClient {
           .put("NOT_FOUND", "registration-token-not-registered")
           .put("PERMISSION_DENIED", "mismatched-credential")
           .put("RESOURCE_EXHAUSTED", "message-rate-exceeded")
-          .put("UNAUTHENTICATED", "invalid-apns-credentials")
+          .put("UNAUTHENTICATED", "third-party-auth-error")
 
           // FCM v1 new error codes
-          .put("APNS_AUTH_ERROR", "invalid-apns-credentials")
+          .put("APNS_AUTH_ERROR", "third-party-auth-error")
           .put("INTERNAL", FirebaseMessaging.INTERNAL_ERROR)
           .put("INVALID_ARGUMENT", "invalid-argument")
           .put("QUOTA_EXCEEDED", "message-rate-exceeded")
           .put("SENDER_ID_MISMATCH", "mismatched-credential")
+          .put("THIRD_PARTY_AUTH_ERROR", "third-party-auth-error")
           .put("UNAVAILABLE", "server-unavailable")
           .put("UNREGISTERED", "registration-token-not-registered")
           .build();

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
@@ -250,6 +250,24 @@ public class FirebaseMessagingClientImplTest {
   }
 
   @Test
+  public void testSendErrorWithThirdPartyError() {
+    for (int code : HTTP_ERRORS) {
+      response.setStatusCode(code).setContent(
+          "{\"error\": {\"status\": \"INVALID_ARGUMENT\", \"message\": \"test error\", "
+              + "\"details\":[{\"@type\": \"type.googleapis.com/google.firebase.fcm"
+              + ".v1.FcmError\", \"errorCode\": \"THIRD_PARTY_AUTH_ERROR\"}]}}");
+
+      try {
+        client.send(EMPTY_MESSAGE, DRY_RUN_DISABLED);
+        fail("No error thrown for HTTP error");
+      } catch (FirebaseMessagingException error) {
+        checkExceptionFromHttpResponse(error, "third-party-auth-error");
+      }
+      checkRequestHeader(interceptor.getLastRequest());
+    }
+  }
+
+  @Test
   public void testSendAll() throws Exception {
     final TestResponseInterceptor interceptor = new TestResponseInterceptor();
     FirebaseMessagingClient client = initMessagingClientForBatchRequests(


### PR DESCRIPTION
RELEASE NOTE: SDK now correctly handles the `THIRD_PARTY_AUTH_ERROR` error code returned by the backend service when sending notifications to iOS and web targets.