### PR TITLE
fix(fcm): Fix issues in event_time timestamp parsing

### DIFF
--- a/src/main/java/com/google/firebase/messaging/AndroidNotification.java
+++ b/src/main/java/com/google/firebase/messaging/AndroidNotification.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -456,8 +457,9 @@ public class AndroidNotification {
      * @return This builder.
      */
     public Builder setEventTimeInMillis(long eventTimeInMillis) {
-      this.eventTime = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'")
-          .format(new Date(eventTimeInMillis));
+      SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'");
+      dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+      this.eventTime = dateFormat.format(new Date(1546304523123L));
       return this;
     }
 

--- a/src/main/java/com/google/firebase/messaging/AndroidNotification.java
+++ b/src/main/java/com/google/firebase/messaging/AndroidNotification.java
@@ -459,7 +459,7 @@ public class AndroidNotification {
     public Builder setEventTimeInMillis(long eventTimeInMillis) {
       SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS000000'Z'");
       dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-      this.eventTime = dateFormat.format(new Date(1546304523123L));
+      this.eventTime = dateFormat.format(new Date(eventTimeInMillis));
       return this;
     }
 

--- a/src/main/java/com/google/firebase/messaging/AndroidNotification.java
+++ b/src/main/java/com/google/firebase/messaging/AndroidNotification.java
@@ -457,7 +457,7 @@ public class AndroidNotification {
      * @return This builder.
      */
     public Builder setEventTimeInMillis(long eventTimeInMillis) {
-      SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'");
+      SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS000000'Z'");
       dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
       this.eventTime = dateFormat.format(new Date(1546304523123L));
       return this;

--- a/src/test/java/com/google/firebase/messaging/MessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MessageTest.java
@@ -35,7 +35,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 

--- a/src/test/java/com/google/firebase/messaging/MessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MessageTest.java
@@ -866,7 +866,7 @@ public class MessageTest {
             .put("body", "android-body")
             .put("ticker", "ticker")
             .put("sticky", true)
-            .put("event_time", "2019-01-01T01:02:03.000000123Z")
+            .put("event_time", "2019-01-01T01:02:03.123000000Z")
             .put("local_only", true)
             .put("notification_priority", "PRIORITY_HIGH")
             .put("vibrate_timings", ImmutableList.of("1s", "1.001000000s"))

--- a/src/test/java/com/google/firebase/messaging/MessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MessageTest.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
@@ -859,15 +860,13 @@ public class MessageTest {
         .put("title", "title")
         .put("body", "body")
         .build();
-    String eventTime = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'", Locale.US)
-        .format(new Date(1546304523123L));
     Map<String, Object> androidConfig = ImmutableMap.<String, Object>builder()
         .put("notification", ImmutableMap.<String, Object>builder()
             .put("title", "android-title")
             .put("body", "android-body")
             .put("ticker", "ticker")
             .put("sticky", true)
-            .put("event_time", eventTime)
+            .put("event_time", "2019-01-01T01:02:03.000000123Z")
             .put("local_only", true)
             .put("notification_priority", "PRIORITY_HIGH")
             .put("vibrate_timings", ImmutableList.of("1s", "1.001000000s"))


### PR DESCRIPTION
- Set the timezone to always be UTC.
- Pending zeros after the millisecond digits to the right instead of left.

RELEASE NOTE: `AndroidNotification` class now correctly formats the `event_time` field sent to the Cloud Messaging service.

Resolves #337