### PR TITLE
fix: Enabled automatic HTTP retries for FirebaseProjectManagement

### DIFF
--- a/src/main/java/com/google/firebase/internal/ApiClientUtils.java
+++ b/src/main/java/com/google/firebase/internal/ApiClientUtils.java
@@ -19,7 +19,6 @@ package com.google.firebase.internal;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpTransport;
-import com.google.api.client.testing.util.MockSleeper;
 import com.google.common.collect.ImmutableList;
 import com.google.firebase.FirebaseApp;
 
@@ -30,17 +29,10 @@ import java.io.IOException;
  */
 public class ApiClientUtils {
 
-  private static final RetryConfig DEFAULT_RETRY_CONFIG = RetryConfig.builder()
+  static final RetryConfig DEFAULT_RETRY_CONFIG = RetryConfig.builder()
       .setMaxRetries(4)
       .setRetryStatusCodes(ImmutableList.of(500, 503))
       .setMaxIntervalMillis(60 * 1000)
-      .build();
-
-  private static final RetryConfig TEST_RETRY_CONFIG = RetryConfig.builder()
-      .setMaxRetries(4)
-      .setRetryStatusCodes(ImmutableList.of(500, 503))
-      .setMaxIntervalMillis(60 * 1000)
-      .setSleeper(new MockSleeper())
       .build();
 
   /**
@@ -71,18 +63,6 @@ public class ApiClientUtils {
   public static HttpRequestFactory newUnauthorizedRequestFactory(FirebaseApp app) {
     HttpTransport transport = app.getOptions().getHttpTransport();
     return transport.createRequestFactory();
-  }
-
-  /**
-   * Creates a new {@code HttpRequestFactory} which provides authorization (OAuth2), timeouts and
-   * automatic retries. Bypasses exponential backoff between consecutive retries for faster
-   * execution during tests.
-   *
-   * @param app {@link FirebaseApp} from which to obtain authorization credentials.
-   * @return A new {@code HttpRequestFactory} instance.
-   */
-  public static HttpRequestFactory newAuthorizedRequestFactoryForTests(FirebaseApp app) {
-    return newAuthorizedRequestFactory(app, TEST_RETRY_CONFIG);
   }
 
   public static void disconnectQuietly(HttpResponse response) {

--- a/src/main/java/com/google/firebase/internal/ApiClientUtils.java
+++ b/src/main/java/com/google/firebase/internal/ApiClientUtils.java
@@ -43,9 +43,21 @@ public class ApiClientUtils {
    * @return A new {@code HttpRequestFactory} instance.
    */
   public static HttpRequestFactory newAuthorizedRequestFactory(FirebaseApp app) {
+    return newAuthorizedRequestFactory(app, DEFAULT_RETRY_CONFIG);
+  }
+
+  /**
+   * Creates a new {@code HttpRequestFactory} which provides authorization (OAuth2), timeouts and
+   * automatic retries.
+   *
+   * @param app {@link FirebaseApp} from which to obtain authorization credentials.
+   * @param retryConfig {@link RetryConfig} instance or null to disable retries.
+   * @return A new {@code HttpRequestFactory} instance.
+   */
+  public static HttpRequestFactory newAuthorizedRequestFactory(
+      FirebaseApp app, @Nullable RetryConfig retryConfig) {
     HttpTransport transport = app.getOptions().getHttpTransport();
-    return transport.createRequestFactory(
-        new FirebaseRequestInitializer(app, DEFAULT_RETRY_CONFIG));
+    return transport.createRequestFactory(new FirebaseRequestInitializer(app, retryConfig));
   }
 
   public static HttpRequestFactory newUnauthorizedRequestFactory(FirebaseApp app) {

--- a/src/main/java/com/google/firebase/internal/ApiClientUtils.java
+++ b/src/main/java/com/google/firebase/internal/ApiClientUtils.java
@@ -19,6 +19,7 @@ package com.google.firebase.internal;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpTransport;
+import com.google.api.client.testing.util.MockSleeper;
 import com.google.common.collect.ImmutableList;
 import com.google.firebase.FirebaseApp;
 
@@ -33,6 +34,13 @@ public class ApiClientUtils {
       .setMaxRetries(4)
       .setRetryStatusCodes(ImmutableList.of(500, 503))
       .setMaxIntervalMillis(60 * 1000)
+      .build();
+
+  private static final RetryConfig TEST_RETRY_CONFIG = RetryConfig.builder()
+      .setMaxRetries(4)
+      .setRetryStatusCodes(ImmutableList.of(500, 503))
+      .setMaxIntervalMillis(60 * 1000)
+      .setSleeper(new MockSleeper())
       .build();
 
   /**
@@ -63,6 +71,18 @@ public class ApiClientUtils {
   public static HttpRequestFactory newUnauthorizedRequestFactory(FirebaseApp app) {
     HttpTransport transport = app.getOptions().getHttpTransport();
     return transport.createRequestFactory();
+  }
+
+  /**
+   * Creates a new {@code HttpRequestFactory} which provides authorization (OAuth2), timeouts and
+   * automatic retries. Bypasses exponential backoff between consecutive retries for faster
+   * execution during tests.
+   *
+   * @param app {@link FirebaseApp} from which to obtain authorization credentials.
+   * @return A new {@code HttpRequestFactory} instance.
+   */
+  public static HttpRequestFactory newAuthorizedRequestFactoryForTests(FirebaseApp app) {
+    return newAuthorizedRequestFactory(app, TEST_RETRY_CONFIG);
   }
 
   public static void disconnectQuietly(HttpResponse response) {

--- a/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImpl.java
+++ b/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImpl.java
@@ -56,6 +56,7 @@ class FirebaseProjectManagementServiceImpl implements AndroidAppService, IosAppS
   private final FirebaseApp app;
   private final Sleeper sleeper;
   private final Scheduler scheduler;
+  private final HttpRequestFactory requestFactory;
   private final HttpHelper httpHelper;
 
   private final CreateAndroidAppFromAppIdFunction createAndroidAppFromAppIdFunction =
@@ -77,8 +78,13 @@ class FirebaseProjectManagementServiceImpl implements AndroidAppService, IosAppS
     this.app = checkNotNull(app);
     this.sleeper = checkNotNull(sleeper);
     this.scheduler = checkNotNull(scheduler);
-    this.httpHelper = new HttpHelper(
-        app.getOptions().getJsonFactory(), checkNotNull(requestFactory));
+    this.requestFactory = checkNotNull(requestFactory);
+    this.httpHelper = new HttpHelper(app.getOptions().getJsonFactory(), requestFactory);
+  }
+
+  @VisibleForTesting
+  HttpRequestFactory getRequestFactory() {
+    return requestFactory;
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImpl.java
+++ b/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImpl.java
@@ -18,6 +18,7 @@ package com.google.firebase.projectmanagement;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponseInterceptor;
 import com.google.api.client.util.Base64;
 import com.google.api.client.util.Key;
@@ -32,8 +33,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.ImplFirebaseTrampolines;
+import com.google.firebase.internal.ApiClientUtils;
 import com.google.firebase.internal.CallableOperation;
-import com.google.firebase.internal.FirebaseRequestInitializer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -63,17 +64,21 @@ class FirebaseProjectManagementServiceImpl implements AndroidAppService, IosAppS
       new CreateIosAppFromAppIdFunction();
 
   FirebaseProjectManagementServiceImpl(FirebaseApp app) {
-    this(app, Sleeper.DEFAULT, new FirebaseAppScheduler(app));
+    this(
+        app,
+        Sleeper.DEFAULT,
+        new FirebaseAppScheduler(app),
+        ApiClientUtils.newAuthorizedRequestFactory(app));
   }
 
-  FirebaseProjectManagementServiceImpl(FirebaseApp app, Sleeper sleeper, Scheduler scheduler) {
+  @VisibleForTesting
+  FirebaseProjectManagementServiceImpl(
+      FirebaseApp app, Sleeper sleeper, Scheduler scheduler, HttpRequestFactory requestFactory) {
     this.app = checkNotNull(app);
     this.sleeper = checkNotNull(sleeper);
     this.scheduler = checkNotNull(scheduler);
     this.httpHelper = new HttpHelper(
-        app.getOptions().getJsonFactory(),
-        app.getOptions().getHttpTransport().createRequestFactory(
-            new FirebaseRequestInitializer(app)));
+        app.getOptions().getJsonFactory(), checkNotNull(requestFactory));
   }
 
   @VisibleForTesting

--- a/src/test/java/com/google/firebase/internal/ApiClientUtilsTest.java
+++ b/src/test/java/com/google/firebase/internal/ApiClientUtilsTest.java
@@ -70,6 +70,19 @@ public class ApiClientUtilsTest {
   }
 
   @Test
+  public void testAuthorizedHttpClientWithoutRetry() throws IOException {
+    FirebaseApp app = FirebaseApp.initializeApp(TEST_OPTIONS);
+
+    HttpRequestFactory requestFactory = ApiClientUtils.newAuthorizedRequestFactory(app, null);
+
+    assertTrue(requestFactory.getInitializer() instanceof FirebaseRequestInitializer);
+    HttpRequest request = requestFactory.buildGetRequest(TEST_URL);
+    assertEquals("Bearer test-token", request.getHeaders().getAuthorization());
+    HttpUnsuccessfulResponseHandler retryHandler = request.getUnsuccessfulResponseHandler();
+    assertFalse(retryHandler instanceof RetryHandlerDecorator);
+  }
+
+  @Test
   public void testUnauthorizedHttpClient() throws IOException {
     FirebaseApp app = FirebaseApp.initializeApp(TEST_OPTIONS);
 

--- a/src/test/java/com/google/firebase/internal/TestApiClientUtils.java
+++ b/src/test/java/com/google/firebase/internal/TestApiClientUtils.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.internal;
+
+import static com.google.firebase.internal.ApiClientUtils.DEFAULT_RETRY_CONFIG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpUnsuccessfulResponseHandler;
+import com.google.api.client.testing.util.MockSleeper;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.internal.RetryInitializer.RetryHandlerDecorator;
+import java.io.IOException;
+
+public class TestApiClientUtils {
+
+  private static final RetryConfig TEST_RETRY_CONFIG = RetryConfig.builder()
+      .setMaxRetries(DEFAULT_RETRY_CONFIG.getMaxRetries())
+      .setRetryStatusCodes(DEFAULT_RETRY_CONFIG.getRetryStatusCodes())
+      .setMaxIntervalMillis(DEFAULT_RETRY_CONFIG.getMaxIntervalMillis())
+      .setSleeper(new MockSleeper())
+      .build();
+
+  private static final GenericUrl TEST_URL = new GenericUrl("https://firebase.google.com");
+
+  /**
+   * Creates a new {@code HttpRequestFactory} which provides authorization (OAuth2), timeouts and
+   * automatic retries. Bypasses exponential backoff between consecutive retries for faster
+   * execution during tests.
+   *
+   * @param app {@link FirebaseApp} from which to obtain authorization credentials.
+   * @return A new {@code HttpRequestFactory} instance.
+   */
+  public static HttpRequestFactory delayBypassedRequestFactory(FirebaseApp app) {
+    return ApiClientUtils.newAuthorizedRequestFactory(app, TEST_RETRY_CONFIG);
+  }
+
+  /**
+   * Creates a new {@code HttpRequestFactory} which provides authorization (OAuth2), timeouts but
+   * no retries.
+   *
+   * @param app {@link FirebaseApp} from which to obtain authorization credentials.
+   * @return A new {@code HttpRequestFactory} instance.
+   */
+  public static HttpRequestFactory retryDisabledRequestFactory(FirebaseApp app) {
+    return ApiClientUtils.newAuthorizedRequestFactory(app, null);
+  }
+
+  /**
+   * Checks whther the given HttpRequestFactory has been configured for authorization and
+   * automatic retries.
+   *
+   * @param requestFactory The HttpRequestFactory to check.
+   */
+  public static void assertAuthAndRetrySupport(HttpRequestFactory requestFactory) {
+    assertTrue(requestFactory.getInitializer() instanceof FirebaseRequestInitializer);
+    HttpRequest request;
+    try {
+      request = requestFactory.buildGetRequest(TEST_URL);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to initialize request", e);
+    }
+
+    // Verify authorization
+    assertTrue(request.getHeaders().getAuthorization().startsWith("Bearer "));
+
+    // Verify retry support
+    HttpUnsuccessfulResponseHandler retryHandler = request.getUnsuccessfulResponseHandler();
+    assertTrue(retryHandler instanceof RetryHandlerDecorator);
+    RetryConfig retryConfig = ((RetryHandlerDecorator) retryHandler).getRetryHandler()
+        .getRetryConfig();
+    assertEquals(DEFAULT_RETRY_CONFIG.getMaxRetries(), retryConfig.getMaxRetries());
+    assertEquals(DEFAULT_RETRY_CONFIG.getMaxIntervalMillis(), retryConfig.getMaxIntervalMillis());
+    assertFalse(retryConfig.isRetryOnIOExceptions());
+    assertEquals(DEFAULT_RETRY_CONFIG.getRetryStatusCodes(), retryConfig.getRetryStatusCodes());
+  }
+}

--- a/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
+++ b/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.fail;
 
 import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpResponseInterceptor;
 import com.google.api.client.json.JsonParser;
@@ -43,6 +44,7 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.auth.MockGoogleCredentials;
+import com.google.firebase.internal.ApiClientUtils;
 import com.google.firebase.testing.MultiRequestMockHttpTransport;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -370,7 +372,7 @@ public class FirebaseProjectManagementServiceImplTest {
     MockLowLevelHttpResponse secondRpcResponse = new MockLowLevelHttpResponse();
     secondRpcResponse.setContent(LIST_IOS_APPS_PAGE_2_RESPONSE);
     serviceImpl = initServiceImpl(
-        ImmutableList.<MockLowLevelHttpResponse>of(firstRpcResponse, secondRpcResponse),
+        ImmutableList.of(firstRpcResponse, secondRpcResponse),
         interceptor);
 
     List<IosApp> iosAppList = serviceImpl.listIosAppsAsync(PROJECT_ID).get();
@@ -400,7 +402,7 @@ public class FirebaseProjectManagementServiceImplTest {
     MockLowLevelHttpResponse thirdRpcResponse = new MockLowLevelHttpResponse();
     thirdRpcResponse.setContent(CREATE_IOS_GET_OPERATION_ATTEMPT_2_RESPONSE);
     serviceImpl = initServiceImpl(
-        ImmutableList.<MockLowLevelHttpResponse>of(
+        ImmutableList.of(
             firstRpcResponse, secondRpcResponse, thirdRpcResponse),
         interceptor);
 
@@ -624,7 +626,7 @@ public class FirebaseProjectManagementServiceImplTest {
     MockLowLevelHttpResponse secondRpcResponse = new MockLowLevelHttpResponse();
     secondRpcResponse.setContent(LIST_ANDROID_APPS_PAGE_2_RESPONSE);
     serviceImpl = initServiceImpl(
-        ImmutableList.<MockLowLevelHttpResponse>of(firstRpcResponse, secondRpcResponse),
+        ImmutableList.of(firstRpcResponse, secondRpcResponse),
         interceptor);
 
     List<AndroidApp> androidAppList = serviceImpl.listAndroidApps(PROJECT_ID);
@@ -652,7 +654,7 @@ public class FirebaseProjectManagementServiceImplTest {
     MockLowLevelHttpResponse secondRpcResponse = new MockLowLevelHttpResponse();
     secondRpcResponse.setContent(LIST_ANDROID_APPS_PAGE_2_RESPONSE);
     serviceImpl = initServiceImpl(
-        ImmutableList.<MockLowLevelHttpResponse>of(firstRpcResponse, secondRpcResponse),
+        ImmutableList.of(firstRpcResponse, secondRpcResponse),
         interceptor);
 
     List<AndroidApp> androidAppList = serviceImpl.listAndroidAppsAsync(PROJECT_ID).get();
@@ -682,7 +684,7 @@ public class FirebaseProjectManagementServiceImplTest {
     MockLowLevelHttpResponse thirdRpcResponse = new MockLowLevelHttpResponse();
     thirdRpcResponse.setContent(CREATE_ANDROID_GET_OPERATION_ATTEMPT_2_RESPONSE);
     serviceImpl = initServiceImpl(
-        ImmutableList.<MockLowLevelHttpResponse>of(
+        ImmutableList.of(
             firstRpcResponse, secondRpcResponse, thirdRpcResponse),
         interceptor);
 
@@ -714,7 +716,7 @@ public class FirebaseProjectManagementServiceImplTest {
     MockLowLevelHttpResponse thirdRpcResponse = new MockLowLevelHttpResponse();
     thirdRpcResponse.setContent(CREATE_ANDROID_GET_OPERATION_ATTEMPT_2_RESPONSE);
     serviceImpl = initServiceImpl(
-        ImmutableList.<MockLowLevelHttpResponse>of(
+        ImmutableList.of(
             firstRpcResponse, secondRpcResponse, thirdRpcResponse),
         interceptor);
 
@@ -918,7 +920,7 @@ public class FirebaseProjectManagementServiceImplTest {
   private static FirebaseProjectManagementServiceImpl initServiceImpl(
       MockLowLevelHttpResponse mockResponse,
       MultiRequestTestResponseInterceptor interceptor) {
-    return initServiceImpl(ImmutableList.<MockLowLevelHttpResponse>of(mockResponse), interceptor);
+    return initServiceImpl(ImmutableList.of(mockResponse), interceptor);
   }
 
   private static FirebaseProjectManagementServiceImpl initServiceImpl(
@@ -931,8 +933,9 @@ public class FirebaseProjectManagementServiceImplTest {
         .setHttpTransport(transport)
         .build();
     FirebaseApp app = FirebaseApp.initializeApp(options);
-    FirebaseProjectManagementServiceImpl serviceImpl =
-        new FirebaseProjectManagementServiceImpl(app, new MockSleeper(), new MockScheduler());
+    HttpRequestFactory requestFactory = ApiClientUtils.newAuthorizedRequestFactory(app, null);
+    FirebaseProjectManagementServiceImpl serviceImpl = new FirebaseProjectManagementServiceImpl(
+        app, new MockSleeper(), new MockScheduler(), requestFactory);
     serviceImpl.setInterceptor(interceptor);
     return serviceImpl;
   }

--- a/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
+++ b/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
@@ -978,15 +978,6 @@ public class FirebaseProjectManagementServiceImplTest {
     return serviceImpl;
   }
 
-  private static List<MockLowLevelHttpResponse> errorResponseSequence(int status, String content) {
-    ImmutableList.Builder<MockLowLevelHttpResponse> responses = ImmutableList.builder();
-    for (int i = 0; i < 5; i++) {
-      responses.add(new MockLowLevelHttpResponse().setStatusCode(status).setContent(content));
-    }
-
-    return responses.build();
-  }
-
   private void checkRequestHeader(String expectedUrl, HttpMethod httpMethod) {
     assertEquals(
         "The number of HttpResponses is not equal to 1.", 1, interceptor.getNumberOfResponses());


### PR DESCRIPTION
Enables automatic HTTP retries for the `FirebaseProjectManagement` API. We disable retries for unit tests for faster execution of tests.

RELEASE NOTE: Project management APIs in the `FirebaseProjectManagement` class now automatically retries operations that fail due to retry-eligible HTTP errors.