### PR TITLE
Add updateRequest method to Tenant class and add unit tests.

### DIFF
--- a/src/main/java/com/google/firebase/auth/Tenant.java
+++ b/src/main/java/com/google/firebase/auth/Tenant.java
@@ -55,6 +55,22 @@ public final class Tenant {
   }
 
   /**
+   * Returns a new {@link UpdateRequest}, which can be used to update the attributes
+   * of this tenant.
+   *
+   * @return a non-null Tenant.UpdateRequest instance.
+   */
+  public UpdateRequest updateRequest() {
+    return UpdateRequest
+      .newBuilder()
+      .setTenantId(getTenantId())
+      .setDisplayName(getDisplayName())
+      .setPasswordSignInAllowed(isPasswordSignInAllowed())
+      .setEmailLinkSignInEnabled(isEmailLinkSignInEnabled())
+      .build();
+  }
+
+  /**
    * Class used to hold the information needs to make a tenant create request.
    */
   @AutoValue
@@ -85,12 +101,16 @@ public final class Tenant {
      * Returns a builder for a tenant create request.
      */
     public static Builder newBuilder() {
+      // TOOD(micahstairs): Figure out if any of the CreateRequest fields should default to anything
+      // particular. If any fields do not have a reasonable default, then the
+      // fields should be made nullable, otherwise AutoValue will throw an
+      // exception if those fields are left unset.
       return new AutoValue_Tenant_CreateRequest.Builder();
     }
 
     /**
-    * Builder class used to construct a create request.
-    */
+     * Builder class used to construct a create request.
+     */
     @AutoValue.Builder
     abstract static class Builder {
       public abstract Builder setDisplayName(String displayName);
@@ -107,7 +127,14 @@ public final class Tenant {
    * Class used to hold the information needs to make a tenant update request. 
    */
   @AutoValue
-  public abstract static class UpdateRequest {
+  public abstract static class UpdateRequest { 
+
+    /**
+     * Returns the id of this tenant.
+     *
+     * @return a non-empty tenant id string.
+     */
+    public abstract String getTenantId();
 
     /**
      * Returns the display name of this tenant.
@@ -134,14 +161,20 @@ public final class Tenant {
      * Returns a builder for a tenant update request.
      */
     public static Builder newBuilder() {
+      // TOOD(micahstairs): Figure out if any of the UpdateRequest fields should default to anything
+      // particular. If any fields do not have a reasonable default, then the
+      // fields should be made nullable, otherwise AutoValue will throw an
+      // exception if those fields are left unset.
       return new AutoValue_Tenant_UpdateRequest.Builder();
     }
 
     /**
-    * Builder class used to construct a update request.
-    */
+     * Builder class used to construct a update request.
+     */
     @AutoValue.Builder
     abstract static class Builder {
+      public abstract Builder setTenantId(String tenantId);
+
       public abstract Builder setDisplayName(String displayName);
 
       public abstract Builder setPasswordSignInAllowed(boolean allowPasswordSignIn);

--- a/src/main/java/com/google/firebase/auth/Tenant.java
+++ b/src/main/java/com/google/firebase/auth/Tenant.java
@@ -110,7 +110,7 @@ public final class Tenant {
     }
 
     /**
-     * Sets whether to/Users/micahstairs/firebase-admin-java  enable email link user authentication.
+     * Sets whether to  enable email link user authentication.
      *
      * @param emailLinkSignInEnabled a boolean indicating whether users can be authenticated using
      *     an email link, and false otherwise.

--- a/src/main/java/com/google/firebase/auth/Tenant.java
+++ b/src/main/java/com/google/firebase/auth/Tenant.java
@@ -16,8 +16,13 @@
 
 package com.google.firebase.auth;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.api.client.util.Key;
-import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Contains metadata associated with a Firebase tenant.
@@ -61,127 +66,130 @@ public final class Tenant {
    * @return a non-null Tenant.UpdateRequest instance.
    */
   public UpdateRequest updateRequest() {
-    return UpdateRequest
-      .newBuilder()
-      .setTenantId(getTenantId())
-      .setDisplayName(getDisplayName())
-      .setPasswordSignInAllowed(isPasswordSignInAllowed())
-      .setEmailLinkSignInEnabled(isEmailLinkSignInEnabled())
-      .build();
+    return new UpdateRequest(getTenantId());
   }
 
   /**
-   * Class used to hold the information needs to make a tenant create request.
+   * A specification class for creating new user accounts.
+   *
+   * <p>Set the initial attributes of the new tenant by calling various setter methods available in
+   * this class. None of the attributes are required.
    */
-  @AutoValue
-  public abstract static class CreateRequest {
+  public static class CreateRequest {
+
+    private final Map<String,Object> properties = new HashMap<>();
 
     /**
-     * Returns the display name of this tenant.
+     * Creates a new {@link CreateRequest}, which can be used to create a new tenant.
      *
-     * @return a non-empty display name string.
+     * <p>The returned object should be passed to {@link TenantManager#createTenant(CreateRequest)}
+     * to register the tenant information persistently.
      */
-    public abstract String getDisplayName();
+    public CreateRequest() { }
 
     /**
-     * Returns whether to allow email/password user authentication.
+     * Sets the display name for the new tenant.
      *
-     * @return true if a user can be authenticated using an email and password, and false otherwise.
+     * @param displayName a non-null, non-empty display name string.
      */
-    public abstract boolean isPasswordSignInAllowed();
-
-    /**
-     * Returns whether to enable email link user authentication.
-     *
-     * @return true if a user can be authenticated using an email link, and false otherwise.
-     */
-    public abstract boolean isEmailLinkSignInEnabled();
-
-    /**
-     * Returns a builder for a tenant create request.
-     */
-    public static Builder newBuilder() {
-      // TOOD(micahstairs): Figure out if any of the CreateRequest fields should default to anything
-      // particular. If any fields do not have a reasonable default, then the
-      // fields should be made nullable, otherwise AutoValue will throw an
-      // exception if those fields are left unset.
-      return new AutoValue_Tenant_CreateRequest.Builder();
+    public CreateRequest setDisplayName(String displayName) {
+      checkArgument(!Strings.isNullOrEmpty(displayName), "display name must not be null or empty");
+      properties.put("dislayName", displayName);
+      return this;
     }
 
     /**
-     * Builder class used to construct a create request.
+     * Sets whether to allow email/password user authentication.
+     *
+     * @param passwordSignInAllowed a boolean indicating whether users can be authenticated using
+     *     an email and password, and false otherwise.
      */
-    @AutoValue.Builder
-    abstract static class Builder {
-      public abstract Builder setDisplayName(String displayName);
+    public CreateRequest setPasswordSignInAllowed(boolean passwordSignInAllowed) {
+      properties.put("allowPasswordSignup", passwordSignInAllowed);
+      return this;
+    }
 
-      public abstract Builder setPasswordSignInAllowed(boolean allowPasswordSignIn);
+    /**
+     * Sets whether to enable email link user authentication.
+     *
+     * @param emailLinkSignInEnabled a boolean indicating whether users can be authenticated using
+     *     an email link, and false otherwise.
+     */
+    public CreateRequest setEmailLinkSignInEnabled(boolean emailLinkSignInEnabled) {
+      properties.put("enableEmailLinkSignin", emailLinkSignInEnabled);
+      return this;
+    }
 
-      public abstract Builder setEmailLinkSignInEnabled(boolean enableEmailLinkSignIn);
-
-      public abstract CreateRequest build();
+    Map<String, Object> getProperties() {
+      return ImmutableMap.copyOf(properties);
     }
   }
 
   /**
-   * Class used to hold the information needs to make a tenant update request. 
+   * A class for updating the attributes of an existing tenant.
+   *
+   * <p>An instance of this class can be obtained via a {@link Tenant} object, or from a tenant ID
+   * string. Specify the changes to be made to the tenant by calling the various setter methods
+   * available in this class.
    */
-  @AutoValue
-  public abstract static class UpdateRequest { 
+  public static class UpdateRequest {
+
+    private final Map<String,Object> properties = new HashMap<>();
 
     /**
-     * Returns the id of this tenant.
+     * Creates a new {@link UpdateRequest}, which can be used to update the attributes of the
+     * of the tenant identified by the specified tenant ID.
      *
-     * @return a non-empty tenant id string.
-     */
-    public abstract String getTenantId();
-
-    /**
-     * Returns the display name of this tenant.
+     * <p>This method allows updating attributes of a tenant account, without first having to call
+     * {@link TenantManager#getTenant(String)}.
      *
-     * @return a non-empty display name string.
+     * @param tenantId a non-null, non-empty tenant ID string.
+     * @throws IllegalArgumentException If the tenant ID is null or empty.
      */
-    public abstract String getDisplayName();
+    public UpdateRequest(String tenantId) {
+      checkArgument(!Strings.isNullOrEmpty(tenantId), "tenant ID must not be null or empty");
+      properties.put("tenantId", tenantId);
+    }
 
-    /**
-     * Returns whether to allow email/password user authentication.
-     *
-     * @return true if a user can be authenticated using an email and password, and false otherwise.
-     */
-    public abstract boolean isPasswordSignInAllowed();
-
-    /**
-     * Returns whether to enable email link user authentication.
-     *
-     * @return true if a user can be authenticated using an email link, and false otherwise.
-     */
-    public abstract boolean isEmailLinkSignInEnabled();
-
-    /**
-     * Returns a builder for a tenant update request.
-     */
-    public static Builder newBuilder() {
-      // TOOD(micahstairs): Figure out if any of the UpdateRequest fields should default to anything
-      // particular. If any fields do not have a reasonable default, then the
-      // fields should be made nullable, otherwise AutoValue will throw an
-      // exception if those fields are left unset.
-      return new AutoValue_Tenant_UpdateRequest.Builder();
+    String getTenantId() {
+      return (String) properties.get("tenantId");
     }
 
     /**
-     * Builder class used to construct a update request.
+     * Sets the display name of the existingtenant.
+     *
+     * @param displayName a non-null, non-empty display name string.
      */
-    @AutoValue.Builder
-    abstract static class Builder {
-      public abstract Builder setTenantId(String tenantId);
+    public UpdateRequest setDisplayName(String displayName) {
+      checkArgument(!Strings.isNullOrEmpty(displayName), "display name must not be null or empty");
+      properties.put("displayName", displayName);
+      return this;
+    }
 
-      public abstract Builder setDisplayName(String displayName);
+    /**
+     * Sets whether to allow email/password user authentication.
+     *
+     * @param passwordSignInAllowed a boolean indicating whether users can be authenticated using
+     *     an email and password, and false otherwise.
+     */
+    public UpdateRequest setPasswordSignInAllowed(boolean passwordSignInAllowed) {
+      properties.put("allowPasswordSignup", passwordSignInAllowed);
+      return this;
+    }
 
-      public abstract Builder setPasswordSignInAllowed(boolean allowPasswordSignIn);
+    /**
+     * Sets whether to enable email link user authentication.
+     *
+     * @param emailLinkSignInEnabled a boolean indicating whether users can be authenticated using
+     *     an email link, and false otherwise.
+     */
+    public UpdateRequest setEmailLinkSignInEnabled(boolean emailLinkSignInEnabled) {
+      properties.put("enableEmailLinkSignin", emailLinkSignInEnabled);
+      return this;
+    }
 
-      public abstract Builder setEmailLinkSignInEnabled(boolean enableEmailLinkSignIn);
-
-      public abstract UpdateRequest build();
+    Map<String, Object> getProperties() {
+      return ImmutableMap.copyOf(properties);
     }
   }
 }

--- a/src/main/java/com/google/firebase/auth/Tenant.java
+++ b/src/main/java/com/google/firebase/auth/Tenant.java
@@ -75,7 +75,7 @@ public final class Tenant {
    * <p>Set the initial attributes of the new tenant by calling various setter methods available in
    * this class. None of the attributes are required.
    */
-  public static class CreateRequest {
+  public static final class CreateRequest {
 
     private final Map<String,Object> properties = new HashMap<>();
 
@@ -110,7 +110,7 @@ public final class Tenant {
     }
 
     /**
-     * Sets whether to enable email link user authentication.
+     * Sets whether to/Users/micahstairs/firebase-admin-java  enable email link user authentication.
      *
      * @param emailLinkSignInEnabled a boolean indicating whether users can be authenticated using
      *     an email link, and false otherwise.
@@ -132,7 +132,7 @@ public final class Tenant {
    * string. Specify the changes to be made to the tenant by calling the various setter methods
    * available in this class.
    */
-  public static class UpdateRequest {
+  public static final class UpdateRequest {
 
     private final Map<String,Object> properties = new HashMap<>();
 

--- a/src/main/java/com/google/firebase/auth/Tenant.java
+++ b/src/main/java/com/google/firebase/auth/Tenant.java
@@ -31,7 +31,7 @@ import java.util.Map;
  */
 public final class Tenant {
 
-  @Key("tenantId")
+  @Key("name")
   private String tenantId;
 
   @Key("displayName")
@@ -148,11 +148,11 @@ public final class Tenant {
      */
     public UpdateRequest(String tenantId) {
       checkArgument(!Strings.isNullOrEmpty(tenantId), "tenant ID must not be null or empty");
-      properties.put("tenantId", tenantId);
+      properties.put("name", tenantId);
     }
 
     String getTenantId() {
-      return (String) properties.get("tenantId");
+      return (String) properties.get("name");
     }
 
     /**

--- a/src/main/java/com/google/firebase/auth/Tenant.java
+++ b/src/main/java/com/google/firebase/auth/Tenant.java
@@ -94,7 +94,7 @@ public final class Tenant {
      */
     public CreateRequest setDisplayName(String displayName) {
       checkArgument(!Strings.isNullOrEmpty(displayName), "display name must not be null or empty");
-      properties.put("dislayName", displayName);
+      properties.put("displayName", displayName);
       return this;
     }
 

--- a/src/main/java/com/google/firebase/auth/UserRecord.java
+++ b/src/main/java/com/google/firebase/auth/UserRecord.java
@@ -357,10 +357,10 @@ public class UserRecord implements UserInfo {
     /**
      * Sets the display name for the new user.
      *
-     * @param displayName a non-null, non-empty display name string.
+     * @param displayName a non-null display name string.
      */
     public CreateRequest setDisplayName(String displayName) {
-      checkNotNull(displayName, "displayName cannot be null or empty");
+      checkNotNull(displayName, "displayName cannot be null");
       properties.put("displayName", displayName);
       return this;
     }

--- a/src/test/java/com/google/firebase/auth/ListTenantsPageTest.java
+++ b/src/test/java/com/google/firebase/auth/ListTenantsPageTest.java
@@ -321,7 +321,7 @@ public class ListTenantsPageTest {
 
   private static Tenant newTenant(String tenantId) throws IOException {
     return Utils.getDefaultJsonFactory().fromString(
-        String.format("{\"tenantId\":\"%s\"}", tenantId), Tenant.class);
+        String.format("{\"name\":\"%s\"}", tenantId), Tenant.class);
   }
 
   private static class TestTenantSource implements ListTenantsPage.TenantSource {

--- a/src/test/java/com/google/firebase/auth/TenantTest.java
+++ b/src/test/java/com/google/firebase/auth/TenantTest.java
@@ -19,11 +19,13 @@ package com.google.firebase.auth;
 import static com.google.firebase.auth.Tenant.UpdateRequest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.json.JsonFactory;
 import java.io.IOException;
+import java.util.Map;
 import org.junit.Test;
 
 public class TenantTest {
@@ -47,7 +49,7 @@ public class TenantTest {
   }
 
   @Test
-  public void testUpdateRequest() throws IOException {
+  public void testCreateUpdateRequestFromTenant() throws IOException {
     Tenant tenant = jsonFactory.fromString(
         "{"
           + "\"tenantId\":\"TENANT_ID\","
@@ -58,10 +60,30 @@ public class TenantTest {
 
     Tenant.UpdateRequest updateRequest = tenant.updateRequest();
 
-    assertEquals(updateRequest.getTenantId(), "TENANT_ID");
-    assertEquals(updateRequest.getDisplayName(), "DISPLAY_NAME");
-    assertTrue(updateRequest.isPasswordSignInAllowed());
-    assertFalse(updateRequest.isEmailLinkSignInEnabled());
+    assertEquals("TENANT_ID", updateRequest.getTenantId());
+    Map<String,Object> properties = updateRequest.getProperties();
+    assertEquals(properties.size(), 1);
+    assertEquals("TENANT_ID", (String) properties.get("tenantId"));
+    assertNull(properties.get("displayName"));
+    assertNull(properties.get("allowPasswordSignup"));
+    assertNull(properties.get("enableEmailLinkSignin"));
+  }
+
+  @Test
+  public void testCreateUpdateRequestFromTenantId() throws IOException {
+    Tenant.UpdateRequest updateRequest = new Tenant.UpdateRequest("TENANT_ID");
+    updateRequest
+      .setDisplayName("DISPLAY_NAME")
+      .setPasswordSignInAllowed(false)
+      .setEmailLinkSignInEnabled(true);
+
+    assertEquals("TENANT_ID", updateRequest.getTenantId());
+    Map<String,Object> properties = updateRequest.getProperties();
+    assertEquals(properties.size(), 4);
+    assertEquals("TENANT_ID", (String) properties.get("tenantId"));
+    assertEquals("DISPLAY_NAME", (String) properties.get("displayName"));
+    assertFalse((boolean) properties.get("allowPasswordSignup"));
+    assertTrue((boolean) properties.get("enableEmailLinkSignin"));
   }
 }
 

--- a/src/test/java/com/google/firebase/auth/TenantTest.java
+++ b/src/test/java/com/google/firebase/auth/TenantTest.java
@@ -32,15 +32,17 @@ public class TenantTest {
 
   private static final JsonFactory jsonFactory = Utils.getDefaultJsonFactory();
 
+  private static final String TENANT_JSON_STRING = 
+      "{"
+        + "\"tenantId\":\"TENANT_ID\","
+        + "\"displayName\":\"DISPLAY_NAME\","
+        + "\"allowPasswordSignup\":true,"
+        + "\"enableEmailLinkSignin\":false"
+        + "}";
+
   @Test
   public void testJsonSerialization() throws IOException {
-    Tenant tenant = jsonFactory.fromString(
-        "{"
-          + "\"tenantId\":\"TENANT_ID\","
-          + "\"displayName\":\"DISPLAY_NAME\","
-          + "\"allowPasswordSignup\":true,"
-          + "\"enableEmailLinkSignin\":false"
-          + "}", Tenant.class);
+    Tenant tenant = jsonFactory.fromString(TENANT_JSON_STRING, Tenant.class);
 
     assertEquals(tenant.getTenantId(), "TENANT_ID");
     assertEquals(tenant.getDisplayName(), "DISPLAY_NAME");
@@ -50,13 +52,7 @@ public class TenantTest {
 
   @Test
   public void testCreateUpdateRequestFromTenant() throws IOException {
-    Tenant tenant = jsonFactory.fromString(
-        "{"
-          + "\"tenantId\":\"TENANT_ID\","
-          + "\"displayName\":\"DISPLAY_NAME\","
-          + "\"allowPasswordSignup\":true,"
-          + "\"enableEmailLinkSignin\":false"
-          + "}", Tenant.class);
+    Tenant tenant = jsonFactory.fromString(TENANT_JSON_STRING, Tenant.class);
 
     Tenant.UpdateRequest updateRequest = tenant.updateRequest();
 
@@ -64,9 +60,6 @@ public class TenantTest {
     Map<String,Object> properties = updateRequest.getProperties();
     assertEquals(properties.size(), 1);
     assertEquals("TENANT_ID", (String) properties.get("tenantId"));
-    assertNull(properties.get("displayName"));
-    assertNull(properties.get("allowPasswordSignup"));
-    assertNull(properties.get("enableEmailLinkSignin"));
   }
 
   @Test

--- a/src/test/java/com/google/firebase/auth/TenantTest.java
+++ b/src/test/java/com/google/firebase/auth/TenantTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.auth;
+
+import static com.google.firebase.auth.Tenant.UpdateRequest;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.api.client.googleapis.util.Utils;
+import com.google.api.client.json.JsonFactory;
+import java.io.IOException;
+import org.junit.Test;
+
+public class TenantTest {
+
+  private static final JsonFactory jsonFactory = Utils.getDefaultJsonFactory();
+
+  @Test
+  public void testJsonSerialization() throws IOException {
+    Tenant tenant = jsonFactory.fromString(
+        "{"
+          + "\"tenantId\":\"TENANT_ID\","
+          + "\"displayName\":\"DISPLAY_NAME\","
+          + "\"allowPasswordSignup\":true,"
+          + "\"enableEmailLinkSignin\":false"
+          + "}", Tenant.class);
+
+    assertEquals(tenant.getTenantId(), "TENANT_ID");
+    assertEquals(tenant.getDisplayName(), "DISPLAY_NAME");
+    assertTrue(tenant.isPasswordSignInAllowed());
+    assertFalse(tenant.isEmailLinkSignInEnabled());
+  }
+
+  @Test
+  public void testUpdateRequest() throws IOException {
+    Tenant tenant = jsonFactory.fromString(
+        "{"
+          + "\"tenantId\":\"TENANT_ID\","
+          + "\"displayName\":\"DISPLAY_NAME\","
+          + "\"allowPasswordSignup\":true,"
+          + "\"enableEmailLinkSignin\":false"
+          + "}", Tenant.class);
+
+    Tenant.UpdateRequest updateRequest = tenant.updateRequest();
+
+    assertEquals(updateRequest.getTenantId(), "TENANT_ID");
+    assertEquals(updateRequest.getDisplayName(), "DISPLAY_NAME");
+    assertTrue(updateRequest.isPasswordSignInAllowed());
+    assertFalse(updateRequest.isEmailLinkSignInEnabled());
+  }
+}
+

--- a/src/test/java/com/google/firebase/auth/TenantTest.java
+++ b/src/test/java/com/google/firebase/auth/TenantTest.java
@@ -34,7 +34,7 @@ public class TenantTest {
 
   private static final String TENANT_JSON_STRING = 
       "{"
-        + "\"tenantId\":\"TENANT_ID\","
+        + "\"name\":\"TENANT_ID\","
         + "\"displayName\":\"DISPLAY_NAME\","
         + "\"allowPasswordSignup\":true,"
         + "\"enableEmailLinkSignin\":false"
@@ -59,7 +59,7 @@ public class TenantTest {
     assertEquals("TENANT_ID", updateRequest.getTenantId());
     Map<String,Object> properties = updateRequest.getProperties();
     assertEquals(properties.size(), 1);
-    assertEquals("TENANT_ID", (String) properties.get("tenantId"));
+    assertEquals("TENANT_ID", (String) properties.get("name"));
   }
 
   @Test
@@ -73,7 +73,7 @@ public class TenantTest {
     assertEquals("TENANT_ID", updateRequest.getTenantId());
     Map<String,Object> properties = updateRequest.getProperties();
     assertEquals(properties.size(), 4);
-    assertEquals("TENANT_ID", (String) properties.get("tenantId"));
+    assertEquals("TENANT_ID", (String) properties.get("name"));
     assertEquals("DISPLAY_NAME", (String) properties.get("displayName"));
     assertFalse((boolean) properties.get("allowPasswordSignup"));
     assertTrue((boolean) properties.get("enableEmailLinkSignin"));

--- a/src/test/java/com/google/firebase/auth/TenantTest.java
+++ b/src/test/java/com/google/firebase/auth/TenantTest.java
@@ -51,7 +51,7 @@ public class TenantTest {
   }
 
   @Test
-  public void testCreateUpdateRequestFromTenant() throws IOException {
+  public void testUpdateRequestFromTenant() throws IOException {
     Tenant tenant = jsonFactory.fromString(TENANT_JSON_STRING, Tenant.class);
 
     Tenant.UpdateRequest updateRequest = tenant.updateRequest();
@@ -63,7 +63,7 @@ public class TenantTest {
   }
 
   @Test
-  public void testCreateUpdateRequestFromTenantId() throws IOException {
+  public void testUpdateRequestFromTenantId() throws IOException {
     Tenant.UpdateRequest updateRequest = new Tenant.UpdateRequest("TENANT_ID");
     updateRequest
       .setDisplayName("DISPLAY_NAME")
@@ -74,6 +74,21 @@ public class TenantTest {
     Map<String,Object> properties = updateRequest.getProperties();
     assertEquals(properties.size(), 4);
     assertEquals("TENANT_ID", (String) properties.get("tenantId"));
+    assertEquals("DISPLAY_NAME", (String) properties.get("displayName"));
+    assertFalse((boolean) properties.get("allowPasswordSignup"));
+    assertTrue((boolean) properties.get("enableEmailLinkSignin"));
+  }
+
+  @Test
+  public void testCreateRequest() throws IOException {
+    Tenant.CreateRequest createRequest = new Tenant.CreateRequest();
+    createRequest
+      .setDisplayName("DISPLAY_NAME")
+      .setPasswordSignInAllowed(false)
+      .setEmailLinkSignInEnabled(true);
+
+    Map<String,Object> properties = createRequest.getProperties();
+    assertEquals(properties.size(), 3);
     assertEquals("DISPLAY_NAME", (String) properties.get("displayName"));
     assertFalse((boolean) properties.get("allowPasswordSignup"));
     assertTrue((boolean) properties.get("enableEmailLinkSignin"));


### PR DESCRIPTION
This pull request adds some things to the Tenant class and adds a few unit tests. This is part of the initiative to adding multi-tenancy support (see issue #332).

It's worth noting that these changes deviate from the API design doc. I realized that the updateTenant method in my design doc doesn’t match the design of the existing updateUser method. To fix this, I'm adding the tenantId to Tenant.UpdateRequest.

This PR also removes the usage of AutoValue since using it was going to deviate too much from the design of the request classes in UserRecord. This change will also make it easier to do JSON serialization when we sending the requests.