### PR TITLE
Error handling revamp for token verification APIs

### DIFF
--- a/src/main/java/com/google/firebase/auth/AuthErrorCode.java
+++ b/src/main/java/com/google/firebase/auth/AuthErrorCode.java
@@ -21,20 +21,34 @@ package com.google.firebase.auth;
  */
 public enum AuthErrorCode {
 
+  CERTIFICATE_FETCH_FAILED,
+
   /**
    * A user already exists with the provided email.
    */
   EMAIL_ALREADY_EXISTS,
+
+  EXPIRED_ID_TOKEN,
+
+  EXPIRED_SESSION_COOKIE,
 
   /**
    * The provided dynamic link domain is not configured or authorized for the current project.
    */
   INVALID_DYNAMIC_LINK_DOMAIN,
 
+  INVALID_ID_TOKEN,
+
+  INVALID_SESSION_COOKIE,
+
   /**
    * A user already exists with the provided phone number.
    */
   PHONE_NUMBER_ALREADY_EXISTS,
+
+  REVOKED_ID_TOKEN,
+
+  REVOKED_SESSION_COOKIE,
 
   /**
    * A user already exists with the provided UID.

--- a/src/main/java/com/google/firebase/auth/AuthErrorCode.java
+++ b/src/main/java/com/google/firebase/auth/AuthErrorCode.java
@@ -21,6 +21,9 @@ package com.google.firebase.auth;
  */
 public enum AuthErrorCode {
 
+  /**
+   * Failed to retrieve public key certificates required to verify JWTs.
+   */
   CERTIFICATE_FETCH_FAILED,
 
   /**
@@ -28,8 +31,14 @@ public enum AuthErrorCode {
    */
   EMAIL_ALREADY_EXISTS,
 
+  /**
+   * The specified ID token is expired.
+   */
   EXPIRED_ID_TOKEN,
 
+  /**
+   * The specified session cookie is expired.
+   */
   EXPIRED_SESSION_COOKIE,
 
   /**
@@ -37,8 +46,14 @@ public enum AuthErrorCode {
    */
   INVALID_DYNAMIC_LINK_DOMAIN,
 
+  /**
+   * The specified ID token is invalid.
+   */
   INVALID_ID_TOKEN,
 
+  /**
+   * The specified session cookie is invalid.
+   */
   INVALID_SESSION_COOKIE,
 
   /**
@@ -46,8 +61,14 @@ public enum AuthErrorCode {
    */
   PHONE_NUMBER_ALREADY_EXISTS,
 
+  /**
+   * The specified ID token has been revoked.
+   */
   REVOKED_ID_TOKEN,
 
+  /**
+   * The specified session cookie has been revoked.
+   */
   REVOKED_SESSION_COOKIE,
 
   /**

--- a/src/main/java/com/google/firebase/auth/FirebaseAuthException.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuthException.java
@@ -32,7 +32,6 @@ import com.google.firebase.internal.Nullable;
 public class FirebaseAuthException extends FirebaseException {
 
   private final AuthErrorCode errorCode;
-  private final String deprecatedErrorCode;
 
   FirebaseAuthException(
       @NonNull ErrorCode errorCode,
@@ -42,12 +41,6 @@ public class FirebaseAuthException extends FirebaseException {
       AuthErrorCode authErrorCode) {
     super(errorCode, message, cause, response);
     this.errorCode = authErrorCode;
-    this.deprecatedErrorCode = null;
-  }
-
-  @Deprecated
-  public FirebaseAuthException(@NonNull String errorCode, @NonNull String detailMessage) {
-    this(errorCode, detailMessage, null);
   }
 
   @Deprecated
@@ -56,17 +49,10 @@ public class FirebaseAuthException extends FirebaseException {
     super(detailMessage, throwable);
     checkArgument(!Strings.isNullOrEmpty(errorCode));
     this.errorCode = null;
-    this.deprecatedErrorCode = errorCode;
   }
 
   @Nullable
   public AuthErrorCode getAuthErrorCode() {
     return errorCode;
-  }
-
-  /** Returns an error code that may provide more information about the error. */
-  @Deprecated
-  public String getDeprecatedErrorCode() {
-    return deprecatedErrorCode;
   }
 }

--- a/src/main/java/com/google/firebase/auth/FirebaseTokenUtils.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseTokenUtils.java
@@ -82,6 +82,8 @@ final class FirebaseTokenUtils {
         .setJsonFactory(app.getOptions().getJsonFactory())
         .setPublicKeysManager(publicKeysManager)
         .setIdTokenVerifier(idTokenVerifier)
+        .setInvalidTokenErrorCode(AuthErrorCode.INVALID_ID_TOKEN)
+        .setExpiredTokenErrorCode(AuthErrorCode.EXPIRED_ID_TOKEN)
         .build();
   }
 
@@ -100,6 +102,8 @@ final class FirebaseTokenUtils {
         .setShortName("session cookie")
         .setMethod("verifySessionCookie()")
         .setDocUrl("https://firebase.google.com/docs/auth/admin/manage-cookies")
+        .setInvalidTokenErrorCode(AuthErrorCode.INVALID_SESSION_COOKIE)
+        .setExpiredTokenErrorCode(AuthErrorCode.EXPIRED_SESSION_COOKIE)
         .build();
   }
 

--- a/src/main/java/com/google/firebase/auth/FirebaseTokenVerifierImpl.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseTokenVerifierImpl.java
@@ -203,6 +203,7 @@ final class FirebaseTokenVerifierImpl implements FirebaseTokenVerifier {
           "Firebase %s has expired. Get a fresh %s and try again.",
           shortName,
           shortName);
+      // Also set the expired error code.
       errorCode = expiredTokenErrorCode;
     } else if (!idToken.verifyIssuedAtTime(
         currentTimeMillis, idTokenVerifier.getAcceptableTimeSkewSeconds())) {
@@ -218,8 +219,7 @@ final class FirebaseTokenVerifierImpl implements FirebaseTokenVerifier {
   }
 
   private FirebaseAuthException newException(String message, AuthErrorCode errorCode) {
-    return new FirebaseAuthException(
-        ErrorCode.INVALID_ARGUMENT, message, null, null, errorCode);
+    return newException(message, errorCode, null);
   }
 
   private FirebaseAuthException newException(

--- a/src/main/java/com/google/firebase/auth/RevocationCheckDecorator.java
+++ b/src/main/java/com/google/firebase/auth/RevocationCheckDecorator.java
@@ -20,30 +20,27 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Strings;
+import com.google.firebase.ErrorCode;
 
 /**
  * A decorator for adding token revocation checks to an existing {@link FirebaseTokenVerifier}.
  */
 class RevocationCheckDecorator implements FirebaseTokenVerifier {
 
-  static final String ID_TOKEN_REVOKED_ERROR = "id-token-revoked";
-  static final String SESSION_COOKIE_REVOKED_ERROR = "session-cookie-revoked";
-
   private final FirebaseTokenVerifier tokenVerifier;
   private final FirebaseUserManager userManager;
-  private final String errorCode;
+  private final AuthErrorCode errorCode;
   private final String shortName;
 
   private RevocationCheckDecorator(
       FirebaseTokenVerifier tokenVerifier,
       FirebaseUserManager userManager,
-      String errorCode,
+      AuthErrorCode errorCode,
       String shortName) {
     this.tokenVerifier = checkNotNull(tokenVerifier);
     this.userManager = checkNotNull(userManager);
-    checkArgument(!Strings.isNullOrEmpty(errorCode));
+    this.errorCode = checkNotNull(errorCode);
     checkArgument(!Strings.isNullOrEmpty(shortName));
-    this.errorCode = errorCode;
     this.shortName = shortName;
   }
 
@@ -55,8 +52,14 @@ class RevocationCheckDecorator implements FirebaseTokenVerifier {
   public FirebaseToken verifyToken(String token) throws FirebaseAuthException {
     FirebaseToken firebaseToken = tokenVerifier.verifyToken(token);
     if (isRevoked(firebaseToken)) {
-      throw new FirebaseAuthException(errorCode, "Firebase " + shortName + " revoked");
+      throw new FirebaseAuthException(
+          ErrorCode.INVALID_ARGUMENT,
+          "Firebase " + shortName + " is revoked.",
+          null,
+          null,
+          errorCode);
     }
+
     return firebaseToken;
   }
 
@@ -69,12 +72,12 @@ class RevocationCheckDecorator implements FirebaseTokenVerifier {
   static RevocationCheckDecorator decorateIdTokenVerifier(
       FirebaseTokenVerifier tokenVerifier, FirebaseUserManager userManager) {
     return new RevocationCheckDecorator(
-        tokenVerifier, userManager, ID_TOKEN_REVOKED_ERROR, "id token");
+        tokenVerifier, userManager, AuthErrorCode.REVOKED_ID_TOKEN, "id token");
   }
 
   static RevocationCheckDecorator decorateSessionCookieVerifier(
       FirebaseTokenVerifier tokenVerifier, FirebaseUserManager userManager) {
     return new RevocationCheckDecorator(
-        tokenVerifier, userManager, SESSION_COOKIE_REVOKED_ERROR, "session cookie");
+        tokenVerifier, userManager, AuthErrorCode.REVOKED_SESSION_COOKIE, "session cookie");
   }
 }

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -439,8 +439,8 @@ public class FirebaseAuthIT {
       fail("expecting exception");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
-      assertEquals(RevocationCheckDecorator.ID_TOKEN_REVOKED_ERROR,
-                   ((FirebaseAuthException) e.getCause()).getDeprecatedErrorCode());
+      assertEquals(AuthErrorCode.REVOKED_ID_TOKEN,
+          ((FirebaseAuthException) e.getCause()).getAuthErrorCode());
     }
     idToken = signInWithCustomToken(customToken);
     decoded = auth.verifyIdTokenAsync(idToken, true).get();
@@ -473,8 +473,8 @@ public class FirebaseAuthIT {
       fail("expecting exception");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
-      assertEquals(RevocationCheckDecorator.SESSION_COOKIE_REVOKED_ERROR,
-          ((FirebaseAuthException) e.getCause()).getDeprecatedErrorCode());
+      assertEquals(AuthErrorCode.REVOKED_SESSION_COOKIE,
+          ((FirebaseAuthException) e.getCause()).getAuthErrorCode());
     }
 
     idToken = signInWithCustomToken(customToken);

--- a/src/test/java/com/google/firebase/auth/FirebaseTokenVerifierImplTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseTokenVerifierImplTest.java
@@ -17,6 +17,7 @@
 package com.google.firebase.auth;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.api.client.auth.openidconnect.IdTokenVerifier;
@@ -29,15 +30,15 @@ import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.firebase.ErrorCode;
 import com.google.firebase.testing.ServiceAccount;
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class FirebaseTokenVerifierImplTest {
 
@@ -53,9 +54,6 @@ public class FirebaseTokenVerifierImplTest {
           + "U2NH0.ZWEpoHgIPCAz8Q-cNFBS8jiqClTJ3j27yuRkQo-QxyI";
 
   private static final String TEST_TOKEN_ISSUER = "https://test.token.issuer";
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   private FirebaseTokenVerifier tokenVerifier;
   private TestTokenFactory tokenFactory;
@@ -79,108 +77,188 @@ public class FirebaseTokenVerifierImplTest {
   }
 
   @Test
-  public void testVerifyTokenWithoutKeyId() throws Exception {
+  public void testVerifyTokenWithoutKeyId() {
     String token = createTokenWithoutKeyId();
 
-    thrown.expectMessage("Firebase test token has no \"kid\" claim.");
-    tokenVerifier.verifyToken(token);
+    try {
+      tokenVerifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      String message = "Firebase test token has no \"kid\" claim. "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      checkInvalidTokenException(e, message);
+    }
   }
 
   @Test
-  public void testVerifyTokenFirebaseCustomToken() throws Exception {
+  public void testVerifyTokenFirebaseCustomToken() {
     String token = createCustomToken();
 
-    thrown.expectMessage("verifyTestToken() expects a test token, but was given a custom token.");
-    tokenVerifier.verifyToken(token);
+    try {
+      tokenVerifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      String message = "verifyTestToken() expects a test token, but was given a custom token. "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      checkInvalidTokenException(e, message);
+    }
   }
 
   @Test
-  public void testVerifyTokenIncorrectAlgorithm() throws Exception {
+  public void testVerifyTokenIncorrectAlgorithm() {
     String token = createTokenWithIncorrectAlgorithm();
 
-    thrown.expectMessage("Firebase test token has incorrect algorithm.");
-    tokenVerifier.verifyToken(token);
+    try {
+      tokenVerifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      String message = "Firebase test token has incorrect algorithm. "
+          + "Expected \"RS256\" but got \"HSA\". "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      checkInvalidTokenException(e, message);
+    }
   }
 
   @Test
-  public void testVerifyTokenIncorrectAudience() throws Exception {
+  public void testVerifyTokenIncorrectAudience() {
     String token = createTokenWithIncorrectAudience();
 
-    thrown.expectMessage("Firebase test token has incorrect \"aud\" (audience) claim.");
-    tokenVerifier.verifyToken(token);
+    try {
+      tokenVerifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      String message = "Firebase test token has incorrect \"aud\" (audience) claim. "
+          + "Expected \"proj-test-101\" but got \"invalid-audience\". "
+          + "Make sure the test token comes from the same Firebase project as the service account "
+          + "used to authenticate this SDK. "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      checkInvalidTokenException(e, message);
+    }
   }
 
   @Test
-  public void testVerifyTokenIncorrectIssuer() throws Exception {
+  public void testVerifyTokenIncorrectIssuer() {
     String token = createTokenWithIncorrectIssuer();
 
-    thrown.expectMessage("Firebase test token has incorrect \"iss\" (issuer) claim.");
-    tokenVerifier.verifyToken(token);
+    try {
+      tokenVerifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      String message = "Firebase test token has incorrect \"iss\" (issuer) claim. "
+          + "Expected \"https://test.token.issuer\" but got "
+          + "\"https://incorrect.issuer.prefix/proj-test-101\". Make sure the test token comes "
+          + "from the same Firebase project as the service account used to authenticate this SDK. "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      checkInvalidTokenException(e, message);
+    }
   }
 
   @Test
-  public void testVerifyTokenMissingSubject() throws Exception {
+  public void testVerifyTokenMissingSubject() {
     String token = createTokenWithSubject(null);
 
-    thrown.expectMessage("Firebase test token has no \"sub\" (subject) claim.");
-    tokenVerifier.verifyToken(token);
+    try {
+      tokenVerifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      String message = "Firebase test token has no \"sub\" (subject) claim. "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      checkInvalidTokenException(e, message);
+    }
   }
 
   @Test
-  public void testVerifyTokenEmptySubject() throws Exception {
+  public void testVerifyTokenEmptySubject() {
     String token = createTokenWithSubject("");
 
-    thrown.expectMessage("Firebase test token has an empty string \"sub\" (subject) claim.");
-    tokenVerifier.verifyToken(token);
+    try {
+      tokenVerifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      String message = "Firebase test token has an empty string \"sub\" (subject) claim. "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      checkInvalidTokenException(e, message);
+    }
   }
 
   @Test
-  public void testVerifyTokenLongSubject() throws Exception {
+  public void testVerifyTokenLongSubject() {
     String token = createTokenWithSubject(Strings.repeat("a", 129));
 
-    thrown.expectMessage(
-        "Firebase test token has \"sub\" (subject) claim longer than 128 characters.");
-    tokenVerifier.verifyToken(token);
+    try {
+      tokenVerifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      String message = "Firebase test token has \"sub\" (subject) claim longer "
+          + "than 128 characters. "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      checkInvalidTokenException(e, message);
+    }
   }
 
   @Test
-  public void testVerifyTokenIssuedAtInFuture() throws Exception {
+  public void testVerifyTokenIssuedAtInFuture() {
     long tenMinutesIntoTheFuture = (TestTokenFactory.CLOCK.currentTimeMillis() / 1000)
         + TimeUnit.MINUTES.toSeconds(10);
     String token = createTokenWithTimestamps(
         tenMinutesIntoTheFuture,
         tenMinutesIntoTheFuture + TimeUnit.HOURS.toSeconds(1));
 
-    thrown.expectMessage("Firebase test token has expired or is not yet valid.");
-    tokenVerifier.verifyToken(token);
+    try {
+      tokenVerifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      String message = "Firebase test token is not yet valid. "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      checkInvalidTokenException(e, message);
+    }
   }
 
   @Test
-  public void testVerifyTokenExpired() throws Exception {
+  public void testVerifyTokenExpired() {
     long twoHoursInPast = (TestTokenFactory.CLOCK.currentTimeMillis() / 1000)
         - TimeUnit.HOURS.toSeconds(2);
     String token = createTokenWithTimestamps(
         twoHoursInPast,
         twoHoursInPast + TimeUnit.HOURS.toSeconds(1));
 
-    thrown.expectMessage("Firebase test token has expired or is not yet valid.");
-    tokenVerifier.verifyToken(token);
+    try {
+      tokenVerifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      String message = "Firebase test token has expired. "
+          + "Get a fresh test token and try again. "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      checkException(e, message, AuthErrorCode.EXPIRED_ID_TOKEN);
+    }
   }
 
   @Test
-  public void testVerifyTokenIncorrectCert() throws Exception {
+  public void testVerifyTokenSignatureMismatch() {
     String token = tokenFactory.createToken();
     GooglePublicKeysManager publicKeysManager = newPublicKeysManager(
         ServiceAccount.NONE.getCert());
     FirebaseTokenVerifier tokenVerifier = newTestTokenVerifier(publicKeysManager);
 
-    thrown.expectMessage("Failed to verify the signature of Firebase test token. "
-        + "See https://test.doc.url for details on how to retrieve a test token.");
-    tokenVerifier.verifyToken(token);
+    try {
+      tokenVerifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      String message = "Failed to verify the signature of Firebase test token. "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      checkInvalidTokenException(e, message);
+    }
   }
 
   @Test
-  public void verifyTokenCertificateError() {
+  public void testMalformedCert() {
+    String token = tokenFactory.createToken();
+    GooglePublicKeysManager publicKeysManager = newPublicKeysManager("malformed.cert");
+    FirebaseTokenVerifier tokenVerifier = newTestTokenVerifier(publicKeysManager);
+
+    try {
+      tokenVerifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      String message = "Error while fetching public key certificates: Could not parse certificate";
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertTrue(e.getMessage().startsWith(message));
+      assertTrue(e.getCause() instanceof GeneralSecurityException);
+      assertNull(e.getHttpResponse());
+      assertEquals(AuthErrorCode.CERTIFICATE_FETCH_FAILED, e.getAuthErrorCode());
+    }
+  }
+
+  @Test
+  public void testCertificateFetchError() {
     MockHttpTransport failingTransport = new MockHttpTransport() {
       @Override
       public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
@@ -194,26 +272,57 @@ public class FirebaseTokenVerifierImplTest {
     try {
       idTokenVerifier.verifyToken(token);
       Assert.fail("No exception thrown");
-    } catch (FirebaseAuthException expected) {
-      assertTrue(expected.getCause() instanceof IOException);
-      assertEquals("Expected error", expected.getCause().getMessage());
+    } catch (FirebaseAuthException e) {
+      String message = "Error while fetching public key certificates: Expected error";
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertEquals(message, e.getMessage());
+      assertTrue(e.getCause() instanceof IOException);
+      assertNull(e.getHttpResponse());
+      assertEquals(AuthErrorCode.CERTIFICATE_FETCH_FAILED, e.getAuthErrorCode());
     }
   }
 
   @Test
-  public void testLegacyCustomToken() throws Exception {
-    thrown.expectMessage(
-        "verifyTestToken() expects a test token, but was given a legacy custom token.");
-    tokenVerifier.verifyToken(LEGACY_CUSTOM_TOKEN);
+  public void testMalformedSignature() {
+    String token = tokenFactory.createToken();
+    String[] segments = token.split("\\.");
+    token = String.format("%s.%s.%s", segments[0], segments[1], "MalformedSignature");
+
+    try {
+      tokenVerifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      String message = "Failed to verify the signature of Firebase test token. "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      checkInvalidTokenException(e, message);
+    }
   }
 
   @Test
-  public void testMalformedToken() throws Exception {
-    thrown.expectMessage(
-        "Failed to parse Firebase test token. Make sure you passed a string that represents a "
-            + "complete and valid JWT. See https://test.doc.url for details on how to retrieve "
-            + "a test token.");
-    tokenVerifier.verifyToken("not.a.jwt");
+  public void testLegacyCustomToken() {
+    try {
+      tokenVerifier.verifyToken(LEGACY_CUSTOM_TOKEN);
+    } catch (FirebaseAuthException e) {
+      String message = "verifyTestToken() expects a test token, but was given a "
+          + "legacy custom token. "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      checkInvalidTokenException(e, message);
+    }
+  }
+
+  @Test
+  public void testMalformedToken() {
+    try {
+      tokenVerifier.verifyToken("not.a.jwt");
+    } catch (FirebaseAuthException e) {
+      String message = "Failed to parse Firebase test token. "
+          + "Make sure you passed a string that represents a complete and valid JWT. "
+          + "See https://test.doc.url for details on how to retrieve a test token.";
+      assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCodeNew());
+      assertEquals(message, e.getMessage());
+      assertTrue(e.getCause() instanceof IllegalArgumentException);
+      assertNull(e.getHttpResponse());
+      assertEquals(AuthErrorCode.INVALID_ID_TOKEN, e.getAuthErrorCode());
+    }
   }
 
   @Test(expected = NullPointerException.class)
@@ -272,6 +381,8 @@ public class FirebaseTokenVerifierImplTest {
         .setJsonFactory(TestTokenFactory.JSON_FACTORY)
         .setPublicKeysManager(publicKeysManager)
         .setIdTokenVerifier(newIdTokenVerifier())
+        .setInvalidTokenErrorCode(AuthErrorCode.INVALID_ID_TOKEN)
+        .setExpiredTokenErrorCode(AuthErrorCode.EXPIRED_ID_TOKEN)
         .build();
   }
 
@@ -336,5 +447,17 @@ public class FirebaseTokenVerifierImplTest {
     payload.setIssuedAtTimeSeconds(issuedAtSeconds);
     payload.setExpirationTimeSeconds(expirationSeconds);
     return tokenFactory.createToken(payload);
+  }
+
+  private void checkInvalidTokenException(FirebaseAuthException e, String message) {
+    checkException(e, message, AuthErrorCode.INVALID_ID_TOKEN);
+  }
+
+  private void checkException(FirebaseAuthException e, String message, AuthErrorCode errorCode) {
+    assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCodeNew());
+    assertEquals(message, e.getMessage());
+    assertNull(e.getCause());
+    assertNull(e.getHttpResponse());
+    assertEquals(errorCode, e.getAuthErrorCode());
   }
 }

--- a/src/test/java/com/google/firebase/snippets/FirebaseAuthSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseAuthSnippets.java
@@ -18,6 +18,7 @@ package com.google.firebase.snippets;
 
 import com.google.common.io.BaseEncoding;
 import com.google.firebase.auth.ActionCodeSettings;
+import com.google.firebase.auth.AuthErrorCode;
 import com.google.firebase.auth.ErrorInfo;
 import com.google.firebase.auth.ExportedUserRecord;
 import com.google.firebase.auth.FirebaseAuth;
@@ -254,7 +255,7 @@ public class FirebaseAuthSnippets {
       // Token is valid and not revoked.
       String uid = decodedToken.getUid();
     } catch (FirebaseAuthException e) {
-      if (e.getDeprecatedErrorCode().equals("id-token-revoked")) {
+      if (e.getAuthErrorCode() == AuthErrorCode.REVOKED_ID_TOKEN) {
         // Token has been revoked. Inform the user to re-authenticate or signOut() the user.
       } else {
         // Token is invalid.


### PR DESCRIPTION
Implementing the error handling revamp of the token verification APIs (`verifyIdToken()` and `verifySessionCookie()`)

1. Introduced several new Auth error codes to cover the new use cases.
2. Removed the old string error code from `FirebaseAuthException`. That's no longer used anywhere.
3. Added unit tests for token revocation checks, which we were missing until now.