### PR TITLE
Error handling revamp for the project management API

### DIFF
--- a/src/main/java/com/google/firebase/internal/ErrorHandlingHttpClient.java
+++ b/src/main/java/com/google/firebase/internal/ErrorHandlingHttpClient.java
@@ -116,7 +116,7 @@ public final class ErrorHandlingHttpClient<T extends FirebaseException> {
     }
   }
 
-  private void parse(IncomingHttpResponse response, Object destination) throws T {
+  public void parse(IncomingHttpResponse response, Object destination) throws T {
     try {
       JsonParser parser = jsonFactory.createJsonParser(response.getContent());
       parser.parse(destination);

--- a/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementException.java
+++ b/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementException.java
@@ -15,18 +15,27 @@
 
 package com.google.firebase.projectmanagement;
 
+import com.google.firebase.ErrorCode;
 import com.google.firebase.FirebaseException;
-import com.google.firebase.internal.Nullable;
+import com.google.firebase.IncomingHttpResponse;
+import com.google.firebase.database.annotations.Nullable;
+import com.google.firebase.internal.NonNull;
 
 /**
  * An exception encountered while interacting with the Firebase Project Management Service.
  */
-public class FirebaseProjectManagementException extends FirebaseException {
-  FirebaseProjectManagementException(String detailMessage) {
-    this(detailMessage, null);
+public final class FirebaseProjectManagementException extends FirebaseException {
+
+  FirebaseProjectManagementException(@NonNull FirebaseException base) {
+    this(base, base.getMessage());
   }
 
-  FirebaseProjectManagementException(String detailMessage, @Nullable Throwable cause) {
-    super(detailMessage, cause);
+  FirebaseProjectManagementException(@NonNull FirebaseException base, @NonNull String message) {
+    super(base.getErrorCodeNew(), message, base.getCause(), base.getHttpResponse());
+  }
+
+  FirebaseProjectManagementException(
+      @NonNull ErrorCode code, @NonNull String message, @Nullable IncomingHttpResponse response) {
+    super(code, message, null, response);
   }
 }

--- a/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImpl.java
+++ b/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImpl.java
@@ -334,10 +334,6 @@ class FirebaseProjectManagementServiceImpl implements AndroidAppService, IosAppS
     };
   }
 
-  private String buildMessage(String resourceId, String resourceIdName, String description) {
-    return String.format("%s \"%s\": %s", resourceIdName, resourceId, description);
-  }
-
   private String pollOperation(String projectId, String operationName)
       throws FirebaseProjectManagementException {
     String url = String.format("%s/v1/%s", FIREBASE_PROJECT_MANAGEMENT_URL, operationName);
@@ -782,6 +778,10 @@ class FirebaseProjectManagementServiceImpl implements AndroidAppService, IosAppS
           "Unable to create App: exponential backoff interrupted.");
       throw new FirebaseProjectManagementException(ErrorCode.ABORTED, message, null);
     }
+  }
+
+  private String buildMessage(String resourceId, String resourceIdName, String description) {
+    return String.format("%s \"%s\": %s", resourceIdName, resourceId, description);
   }
 
   /* Helper types. */

--- a/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImpl.java
+++ b/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImpl.java
@@ -34,8 +34,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.firebase.ErrorCode;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.ImplFirebaseTrampolines;
-import com.google.firebase.internal.ApiClientUtils;
 import com.google.firebase.IncomingHttpResponse;
+import com.google.firebase.internal.ApiClientUtils;
 import com.google.firebase.internal.CallableOperation;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -58,7 +58,6 @@ class FirebaseProjectManagementServiceImpl implements AndroidAppService, IosAppS
   private final FirebaseApp app;
   private final Sleeper sleeper;
   private final Scheduler scheduler;
-  private final HttpRequestFactory requestFactory;
   private final HttpHelper httpHelper;
 
   private final CreateAndroidAppFromAppIdFunction createAndroidAppFromAppIdFunction =
@@ -80,13 +79,7 @@ class FirebaseProjectManagementServiceImpl implements AndroidAppService, IosAppS
     this.app = checkNotNull(app);
     this.sleeper = checkNotNull(sleeper);
     this.scheduler = checkNotNull(scheduler);
-    this.requestFactory = checkNotNull(requestFactory);
     this.httpHelper = new HttpHelper(app.getOptions().getJsonFactory(), requestFactory);
-  }
-
-  @VisibleForTesting
-  HttpRequestFactory getRequestFactory() {
-    return requestFactory;
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/firebase/projectmanagement/HttpHelper.java
+++ b/src/main/java/com/google/firebase/projectmanagement/HttpHelper.java
@@ -16,84 +16,63 @@
 
 package com.google.firebase.projectmanagement;
 
-import com.google.api.client.http.GenericUrl;
-import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
-import com.google.api.client.http.HttpResponse;
-import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpResponseInterceptor;
 import com.google.api.client.http.json.JsonHttpContent;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.JsonObjectParser;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Charsets;
-import com.google.common.collect.ImmutableMap;
-import com.google.firebase.internal.Nullable;
+import com.google.firebase.FirebaseException;
+import com.google.firebase.IncomingHttpResponse;
+import com.google.firebase.internal.AbstractPlatformErrorHandler;
+import com.google.firebase.internal.ErrorHandlingHttpClient;
+import com.google.firebase.internal.HttpRequestInfo;
 import com.google.firebase.internal.SdkUtils;
-import java.io.IOException;
 
-class HttpHelper {
+final class HttpHelper {
 
   @VisibleForTesting static final String PATCH_OVERRIDE_KEY = "X-HTTP-Method-Override";
   @VisibleForTesting static final String PATCH_OVERRIDE_VALUE = "PATCH";
-  private static final ImmutableMap<Integer, String> ERROR_CODES =
-      ImmutableMap.<Integer, String>builder()
-          .put(401, "Request not authorized.")
-          .put(403, "Client does not have sufficient privileges.")
-          .put(404, "Failed to find the resource.")
-          .put(409, "The resource already exists.")
-          .put(429, "Request throttled by the backend server.")
-          .put(500, "Internal server error.")
-          .put(503, "Backend servers are over capacity. Try again later.")
-          .build();
   private static final String CLIENT_VERSION_HEADER = "X-Client-Version";
 
   private final String clientVersion = "Java/Admin/" + SdkUtils.getVersion();
   private final JsonFactory jsonFactory;
-  private final HttpRequestFactory requestFactory;
+  private final ErrorHandlingHttpClient<FirebaseProjectManagementException> httpClient;
+
   private HttpResponseInterceptor interceptor;
 
   HttpHelper(JsonFactory jsonFactory, HttpRequestFactory requestFactory) {
     this.jsonFactory = jsonFactory;
-    this.requestFactory = requestFactory;
+    ProjectManagementErrorHandler errorHandler = new ProjectManagementErrorHandler(jsonFactory);
+    this.httpClient = new ErrorHandlingHttpClient<>(requestFactory, jsonFactory, errorHandler);
   }
 
   void setInterceptor(HttpResponseInterceptor interceptor) {
     this.interceptor = interceptor;
   }
 
-  <T> void makeGetRequest(
+  <T> IncomingHttpResponse makeGetRequest(
       String url,
       T parsedResponseInstance,
       String requestIdentifier,
       String requestIdentifierDescription) throws FirebaseProjectManagementException {
-    try {
-      makeRequest(
-          requestFactory.buildGetRequest(new GenericUrl(url)),
-          parsedResponseInstance,
-          requestIdentifier,
-          requestIdentifierDescription);
-    } catch (IOException e) {
-      handleError(requestIdentifier, requestIdentifierDescription, e);
-    }
+    return makeRequest(
+        HttpRequestInfo.buildGetRequest(url),
+        parsedResponseInstance,
+        requestIdentifier,
+        requestIdentifierDescription);
   }
 
-  <T> void makePostRequest(
+  <T> IncomingHttpResponse makePostRequest(
       String url,
       Object payload,
       T parsedResponseInstance,
       String requestIdentifier,
       String requestIdentifierDescription) throws FirebaseProjectManagementException {
-    try {
-      makeRequest(
-          requestFactory.buildPostRequest(
-              new GenericUrl(url), new JsonHttpContent(jsonFactory, payload)),
-          parsedResponseInstance,
-          requestIdentifier,
-          requestIdentifierDescription);
-    } catch (IOException e) {
-      handleError(requestIdentifier, requestIdentifierDescription, e);
-    }
+    return makeRequest(
+        HttpRequestInfo.buildPostRequest(url, new JsonHttpContent(jsonFactory, payload)),
+        parsedResponseInstance,
+        requestIdentifier,
+        requestIdentifierDescription);
   }
 
   <T> void makePatchRequest(
@@ -102,15 +81,11 @@ class HttpHelper {
       T parsedResponseInstance,
       String requestIdentifier,
       String requestIdentifierDescription) throws FirebaseProjectManagementException {
-    try {
-      HttpRequest baseRequest = requestFactory.buildPostRequest(
-          new GenericUrl(url), new JsonHttpContent(jsonFactory, payload));
-      baseRequest.getHeaders().set(PATCH_OVERRIDE_KEY, PATCH_OVERRIDE_VALUE);
-      makeRequest(
-          baseRequest, parsedResponseInstance, requestIdentifier, requestIdentifierDescription);
-    } catch (IOException e) {
-      handleError(requestIdentifier, requestIdentifierDescription, e);
-    }
+    HttpRequestInfo baseRequest = HttpRequestInfo.buildPostRequest(
+        url, new JsonHttpContent(jsonFactory, payload));
+    baseRequest.addHeader(PATCH_OVERRIDE_KEY, PATCH_OVERRIDE_VALUE);
+    makeRequest(
+        baseRequest, parsedResponseInstance, requestIdentifier, requestIdentifierDescription);
   }
 
   <T> void makeDeleteRequest(
@@ -118,69 +93,41 @@ class HttpHelper {
       T parsedResponseInstance,
       String requestIdentifier,
       String requestIdentifierDescription) throws FirebaseProjectManagementException {
-    try {
-      makeRequest(
-          requestFactory.buildDeleteRequest(new GenericUrl(url)),
-          parsedResponseInstance,
-          requestIdentifier,
-          requestIdentifierDescription);
-    } catch (IOException e) {
-      handleError(requestIdentifier, requestIdentifierDescription, e);
-    }
+    makeRequest(
+        HttpRequestInfo.buildDeleteRequest(url),
+        parsedResponseInstance,
+        requestIdentifier,
+        requestIdentifierDescription);
   }
 
-  <T> void makeRequest(
-      HttpRequest baseRequest,
+  <T> IncomingHttpResponse makeRequest(
+      HttpRequestInfo baseRequest,
       T parsedResponseInstance,
       String requestIdentifier,
       String requestIdentifierDescription) throws FirebaseProjectManagementException {
-    HttpResponse response = null;
     try {
-      baseRequest.getHeaders().set(CLIENT_VERSION_HEADER, clientVersion);
-      baseRequest.setParser(new JsonObjectParser(jsonFactory));
+      baseRequest.addHeader(CLIENT_VERSION_HEADER, clientVersion);
       baseRequest.setResponseInterceptor(interceptor);
-      response = baseRequest.execute();
-      jsonFactory.createJsonParser(response.getContent(), Charsets.UTF_8)
-          .parseAndClose(parsedResponseInstance);
-    } catch (Exception e) {
-      handleError(requestIdentifier, requestIdentifierDescription, e);
-    } finally {
-      disconnectQuietly(response);
+      IncomingHttpResponse response = httpClient.send(baseRequest);
+      httpClient.parse(response, parsedResponseInstance);
+      return response;
+    } catch (FirebaseProjectManagementException e) {
+      String message = String.format(
+          "%s \"%s\": %s", requestIdentifierDescription, requestIdentifier, e.getMessage());
+      throw new FirebaseProjectManagementException(e, message);
     }
   }
 
-  private static void disconnectQuietly(HttpResponse response) {
-    if (response != null) {
-      try {
-        response.disconnect();
-      } catch (IOException ignored) {
-        // Ignored.
-      }
-    }
-  }
+  private static class ProjectManagementErrorHandler
+      extends AbstractPlatformErrorHandler<FirebaseProjectManagementException> {
 
-  private static void handleError(
-      String requestIdentifier, String requestIdentifierDescription, Exception e)
-          throws FirebaseProjectManagementException {
-    String messageBody = "Error while invoking Firebase Project Management service.";
-    if (e instanceof HttpResponseException) {
-      int statusCode = ((HttpResponseException) e).getStatusCode();
-      if (ERROR_CODES.containsKey(statusCode)) {
-        messageBody = ERROR_CODES.get(statusCode);
-      }
+    ProjectManagementErrorHandler(JsonFactory jsonFactory) {
+      super(jsonFactory);
     }
-    throw createFirebaseProjectManagementException(
-        requestIdentifier, requestIdentifierDescription, messageBody, e);
-  }
 
-  static FirebaseProjectManagementException createFirebaseProjectManagementException(
-      String requestIdentifier,
-      String requestIdentifierDescription,
-      String messageBody,
-      @Nullable Exception cause) {
-    return new FirebaseProjectManagementException(
-        String.format(
-            "%s \"%s\": %s", requestIdentifierDescription, requestIdentifier, messageBody),
-        cause);
+    @Override
+    protected FirebaseProjectManagementException createException(FirebaseException base) {
+      return new FirebaseProjectManagementException(base);
+    }
   }
 }

--- a/src/test/java/com/google/firebase/internal/TestApiClientUtils.java
+++ b/src/test/java/com/google/firebase/internal/TestApiClientUtils.java
@@ -18,17 +18,14 @@ package com.google.firebase.internal;
 
 import static com.google.firebase.internal.ApiClientUtils.DEFAULT_RETRY_CONFIG;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpUnsuccessfulResponseHandler;
 import com.google.api.client.testing.util.MockSleeper;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.internal.RetryInitializer.RetryHandlerDecorator;
-import java.io.IOException;
 
 public class TestApiClientUtils {
 
@@ -38,8 +35,6 @@ public class TestApiClientUtils {
       .setMaxIntervalMillis(DEFAULT_RETRY_CONFIG.getMaxIntervalMillis())
       .setSleeper(new MockSleeper())
       .build();
-
-  private static final GenericUrl TEST_URL = new GenericUrl("https://firebase.google.com");
 
   /**
    * Creates a new {@code HttpRequestFactory} which provides authorization (OAuth2), timeouts and
@@ -65,20 +60,12 @@ public class TestApiClientUtils {
   }
 
   /**
-   * Checks whther the given HttpRequestFactory has been configured for authorization and
+   * Checks whether the given HttpRequest has been configured for authorization and
    * automatic retries.
    *
-   * @param requestFactory The HttpRequestFactory to check.
+   * @param request The HttpRequest to check.
    */
-  public static void assertAuthAndRetrySupport(HttpRequestFactory requestFactory) {
-    assertTrue(requestFactory.getInitializer() instanceof FirebaseRequestInitializer);
-    HttpRequest request;
-    try {
-      request = requestFactory.buildGetRequest(TEST_URL);
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to initialize request", e);
-    }
-
+  public static void assertAuthAndRetrySupport(HttpRequest request) {
     // Verify authorization
     assertTrue(request.getHeaders().getAuthorization().startsWith("Bearer "));
 
@@ -89,7 +76,7 @@ public class TestApiClientUtils {
         .getRetryConfig();
     assertEquals(DEFAULT_RETRY_CONFIG.getMaxRetries(), retryConfig.getMaxRetries());
     assertEquals(DEFAULT_RETRY_CONFIG.getMaxIntervalMillis(), retryConfig.getMaxIntervalMillis());
-    assertFalse(retryConfig.isRetryOnIOExceptions());
+    assertEquals(DEFAULT_RETRY_CONFIG.isRetryOnIOExceptions(), retryConfig.isRetryOnIOExceptions());
     assertEquals(DEFAULT_RETRY_CONFIG.getRetryStatusCodes(), retryConfig.getRetryStatusCodes());
   }
 }

--- a/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
+++ b/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
@@ -47,6 +47,7 @@ import com.google.firebase.FirebaseOptions;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.auth.MockGoogleCredentials;
 import com.google.firebase.internal.TestApiClientUtils;
+import com.google.firebase.internal.SdkUtils;
 import com.google.firebase.testing.MultiRequestMockHttpTransport;
 import com.google.firebase.testing.TestUtils;
 import java.io.ByteArrayOutputStream;
@@ -72,6 +73,7 @@ public class FirebaseProjectManagementServiceImplTest {
   private static final String IOS_APP_ID = "test-ios-app-id";
   private static final String IOS_APP_RESOURCE_NAME = "ios/11111";
   private static final String ANDROID_APP_RESOURCE_NAME = "android/11111";
+  private static final String CLIENT_VERSION = "Java/Admin/" + SdkUtils.getVersion();
   private static final IosAppMetadata IOS_APP_METADATA =
       new IosAppMetadata(IOS_APP_RESOURCE_NAME, IOS_APP_ID, DISPLAY_NAME, PROJECT_ID, BUNDLE_ID);
   private static final AndroidAppMetadata ANDROID_APP_METADATA =
@@ -1104,7 +1106,7 @@ public class FirebaseProjectManagementServiceImplTest {
         .setHttpTransport(TestUtils.createFaultyHttpTransport())
         .build();
     FirebaseApp app = FirebaseApp.initializeApp(options);
-    return new FirebaseProjectManagementServiceImpl(app, new MockSleeper(), new MockScheduler());
+    return new FirebaseProjectManagementServiceImpl(app);
   }
 
   private void checkRequestHeader(String expectedUrl, HttpMethod httpMethod) {
@@ -1119,6 +1121,7 @@ public class FirebaseProjectManagementServiceImplTest {
     assertEquals(httpMethod.name(), request.getRequestMethod());
     assertEquals(expectedUrl, request.getUrl().toString());
     assertEquals("Bearer test-token", request.getHeaders().getAuthorization());
+    assertEquals(CLIENT_VERSION, request.getHeaders().get("X-Client-Version"));
   }
 
   private void checkRequestPayload(Map<String, String> expected) throws IOException {

--- a/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementTest.java
+++ b/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementTest.java
@@ -26,6 +26,7 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.firebase.ErrorCode;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
@@ -52,7 +53,7 @@ public class FirebaseProjectManagementTest {
   private static final String TEST_PROJECT_ID = "hello-world";
   private static final String TEST_APP_BUNDLE_ID = "com.hello.world";
   private static final FirebaseProjectManagementException FIREBASE_PROJECT_MANAGEMENT_EXCEPTION =
-      new FirebaseProjectManagementException("Error!", null);
+      new FirebaseProjectManagementException(ErrorCode.UNKNOWN, "Error!", null);
 
   @Rule
   public final MockitoRule mockitoRule = MockitoJUnit.rule();

--- a/src/test/java/com/google/firebase/projectmanagement/IosAppTest.java
+++ b/src/test/java/com/google/firebase/projectmanagement/IosAppTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.firebase.ErrorCode;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
@@ -53,7 +54,7 @@ public class IosAppTest {
           + "<key>SOME_OTHER_KEY</key><string>some-other-value</string>"
           + "</dict></plist>";
   private static final FirebaseProjectManagementException FIREBASE_PROJECT_MANAGEMENT_EXCEPTION =
-      new FirebaseProjectManagementException("Error!", null);
+      new FirebaseProjectManagementException(ErrorCode.UNKNOWN, "Error!", null);
 
   private static final IosAppMetadata TEST_IOS_APP_METADATA = new IosAppMetadata(
       TEST_APP_NAME,


### PR DESCRIPTION
Implemented the new error handling scheme for the project management API (go/firebase-error-handling-java).

I've managed to retain the existing context-aware error message format used in this API (i.e. error messages include app/project ID strings), while injecting the platform error code into them.

go/firebase-error-handling-java