### PR TITLE
Add getTenant operation to TenantManager.

### DIFF
--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -228,27 +228,8 @@ class FirebaseUserManager {
     return new UserImportResult(request.getUsersCount(), response);
   }
 
-<<<<<<< HEAD
-  Tenant getTenantById(String tenantId) throws FirebaseAuthException {
-    GenericUrl url = new GenericUrl(tenantMgtBaseUrl + "/tenants:get");
-    url.put("name", tenantId);
-=======
-  void deleteTenant(String tenantId) throws FirebaseAuthException {
-    GenericUrl url = new GenericUrl(tenantMgtBaseUrl + "/tenants/" + tenantId);
-    GenericJson response = sendRequest("DELETE", url, null, GenericJson.class);
-    if (response == null) {
-      throw new FirebaseAuthException(TENANT_NOT_FOUND_ERROR,
-          "Failed to delete tenant: " + tenantId);
-    }
-  }
-
   Tenant getTenant(String tenantId) throws FirebaseAuthException {
-<<<<<<< HEAD
-    GenericUrl url = new GenericUrl(tenantMgtBaseUrl + "/tenants:" + tenantId);
->>>>>>> 4b78b4e... Address pull request feedback.
-=======
     GenericUrl url = new GenericUrl(tenantMgtBaseUrl + "/tenants/" + tenantId);
->>>>>>> 82ee04c... Assert that the requests are sent to the correct URL.
     Tenant response = sendRequest("GET", url, null, Tenant.class);
     if (Strings.isNullOrEmpty(response.getTenantId())) {
       throw new FirebaseAuthException(TENANT_NOT_FOUND_ERROR, "Failed to get tenant.");

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -65,6 +65,7 @@ import java.util.Map;
  */
 class FirebaseUserManager {
 
+  static final String TENANT_NOT_FOUND_ERROR = "tenant-not-found";
   static final String USER_NOT_FOUND_ERROR = "user-not-found";
   static final String INTERNAL_ERROR = "internal-error";
 

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -83,6 +83,7 @@ class FirebaseUserManager {
       .put("INVALID_PHONE_NUMBER", "invalid-phone-number")
       .put("PHONE_NUMBER_EXISTS", "phone-number-already-exists")
       .put("PROJECT_NOT_FOUND", "project-not-found")
+      .put("TENANT_NOT_FOUND", TENANT_NOT_FOUND_ERROR)
       .put("USER_NOT_FOUND", USER_NOT_FOUND_ERROR)
       .put("WEAK_PASSWORD", "invalid-password")
       .put("UNAUTHORIZED_DOMAIN", "unauthorized-continue-uri")
@@ -224,6 +225,34 @@ class FirebaseUserManager {
       throw new FirebaseAuthException(INTERNAL_ERROR, "Failed to import users.");
     }
     return new UserImportResult(request.getUsersCount(), response);
+  }
+
+<<<<<<< HEAD
+  Tenant getTenantById(String tenantId) throws FirebaseAuthException {
+    GenericUrl url = new GenericUrl(tenantMgtBaseUrl + "/tenants:get");
+    url.put("name", tenantId);
+=======
+  void deleteTenant(String tenantId) throws FirebaseAuthException {
+    GenericUrl url = new GenericUrl(tenantMgtBaseUrl + "/tenants/" + tenantId);
+    GenericJson response = sendRequest("DELETE", url, null, GenericJson.class);
+    if (response == null) {
+      throw new FirebaseAuthException(TENANT_NOT_FOUND_ERROR,
+          "Failed to delete tenant: " + tenantId);
+    }
+  }
+
+  Tenant getTenant(String tenantId) throws FirebaseAuthException {
+<<<<<<< HEAD
+    GenericUrl url = new GenericUrl(tenantMgtBaseUrl + "/tenants:" + tenantId);
+>>>>>>> 4b78b4e... Address pull request feedback.
+=======
+    GenericUrl url = new GenericUrl(tenantMgtBaseUrl + "/tenants/" + tenantId);
+>>>>>>> 82ee04c... Assert that the requests are sent to the correct URL.
+    Tenant response = sendRequest("GET", url, null, Tenant.class);
+    if (Strings.isNullOrEmpty(response.getTenantId())) {
+      throw new FirebaseAuthException(TENANT_NOT_FOUND_ERROR, "Failed to get tenant.");
+    }
+    return response;
   }
 
   ListTenantsResponse listTenants(int maxResults, String pageToken)

--- a/src/main/java/com/google/firebase/auth/TenantManager.java
+++ b/src/main/java/com/google/firebase/auth/TenantManager.java
@@ -34,8 +34,8 @@ import com.google.firebase.internal.Nullable;
  * This class can be used to perform a variety of tenant-related operations, including creating,
  * updating, and listing tenants.
  *
- * <p>TODO(micahstairs): Implement the following methods: getAuthForTenant(), getTenant(),
- * deleteTenant(), createTenant(), and updateTenant().
+ * <p>TODO(micahstairs): Implement the following methods: getAuthForTenant(), deleteTenant(),
+ * createTenant(), and updateTenant().
  */
 public final class TenantManager {
 
@@ -45,6 +45,42 @@ public final class TenantManager {
   TenantManager(FirebaseApp firebaseApp, FirebaseUserManager userManager) {
     this.firebaseApp = firebaseApp;
     this.userManager = userManager;
+  }
+
+  /**
+   * Gets the tenant corresponding to the specified tenant ID.
+   *
+   * @param tenantId A tenant ID string.
+   * @return A {@link Tenant} instance.
+   * @throws IllegalArgumentException If the tenant ID string is null or empty.
+   * @throws FirebaseAuthException If an error occurs while retrieving user data.
+   */
+  public Tenant getTenant(@NonNull String tenantId) throws FirebaseAuthException {
+    return getTenantOp(tenantId).call();
+  }
+
+  /**
+   * Similar to {@link #getTenant(String)} but performs the operation asynchronously.
+   *
+   * @param tenantId A tenantId string.
+   * @return An {@code ApiFuture} which will complete successfully with a {@link Tenant} instance
+   *     If an error occurs while retrieving tenant data or if the specified tenant ID does not
+   *     exist, the future throws a {@link FirebaseAuthException}.
+   * @throws IllegalArgumentException If the tenant ID string is null or empty.
+   */
+  public ApiFuture<Tenant> getTenantAsync(@NonNull String tenantId) {
+    return getTenantOp(tenantId).callAsync(firebaseApp);
+  }
+
+  private CallableOperation<Tenant, FirebaseAuthException> getTenantOp(final String tenantId) {
+    // TODO(micahstairs): Add a check to make sure the app has not been destroyed yet.
+    checkArgument(!Strings.isNullOrEmpty(tenantId), "tenantId must not be null or empty");
+    return new CallableOperation<Tenant, FirebaseAuthException>() {
+      @Override
+      protected Tenant execute() throws FirebaseAuthException {
+        return userManager.getTenant(tenantId);
+      }
+    };
   }
 
   /**

--- a/src/main/java/com/google/firebase/auth/TenantManager.java
+++ b/src/main/java/com/google/firebase/auth/TenantManager.java
@@ -34,8 +34,8 @@ import com.google.firebase.internal.Nullable;
  * This class can be used to perform a variety of tenant-related operations, including creating,
  * updating, and listing tenants.
  *
- * <p>TODO(micahstairs): Implement the following methods: getAuthForTenant(), deleteTenant(),
- * createTenant(), and updateTenant().
+ * <p>TODO(micahstairs): Implement the following methods: getAuthForTenant(), createTenant(), and
+ * updateTenant().
  */
 public final class TenantManager {
 

--- a/src/main/java/com/google/firebase/auth/TenantManager.java
+++ b/src/main/java/com/google/firebase/auth/TenantManager.java
@@ -16,10 +16,12 @@
 
 package com.google.firebase.auth;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.client.json.JsonFactory;
 import com.google.api.core.ApiFuture;
+import com.google.common.base.Strings;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.ListTenantsPage.DefaultTenantSource;
 import com.google.firebase.auth.ListTenantsPage.PageFactory;

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -442,12 +442,14 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testGetTenantWithNotFoundError() throws Exception {
-    TestResponseInterceptor interceptor = initializeAppForUserManagement("{}");
+    TestResponseInterceptor interceptor =
+        initializeAppForUserManagementWithStatusCode(404,
+            "{\"error\": {\"message\": \"TENANT_NOT_FOUND\"}}");
     try {
       FirebaseAuth.getInstance().getTenantManager().getTenantAsync("UNKNOWN").get();
       fail("No error thrown for invalid response");
     } catch (ExecutionException e) {
-      assertTrue(e.getCause() instanceof FirebaseAuthException);
+      assertThat(e.getCause(), instanceOf(FirebaseAuthException.class));
       FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
       assertEquals(FirebaseUserManager.TENANT_NOT_FOUND_ERROR, authException.getErrorCode());
     }

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -437,8 +437,7 @@ public class FirebaseUserManagerTest {
     Tenant tenant = FirebaseAuth.getInstance().getTenantManager().getTenantAsync("TENANT_1").get();
     checkTenant(tenant, "TENANT_1");
     checkRequestHeaders(interceptor);
-    checkUrl(interceptor,
-        "https://identitytoolkit.googleapis.com/v2/projects/test-project-id/tenants/TENANT_1");
+    checkUrl(interceptor, "GET", TENANTS_BASE_URL + "/TENANT_1");
   }
 
   @Test
@@ -452,8 +451,7 @@ public class FirebaseUserManagerTest {
       FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
       assertEquals(FirebaseUserManager.TENANT_NOT_FOUND_ERROR, authException.getErrorCode());
     }
-    checkUrl(interceptor,
-        "https://identitytoolkit.googleapis.com/v2/projects/test-project-id/tenants/UNKNOWN");
+    checkUrl(interceptor, "GET", TENANTS_BASE_URL + "/UNKNOWN");
   }
 
   @Test
@@ -1350,6 +1348,12 @@ public class FirebaseUserManagerTest {
 
     String clientVersion = "Java/Admin/" + SdkUtils.getVersion();
     assertEquals(clientVersion, headers.getFirstHeaderStringValue("X-Client-Version"));
+  }
+
+  private static void checkUrl(TestResponseInterceptor interceptor, String method, String url) {
+    HttpRequest request = interceptor.getResponse().getRequest();
+    assertEquals(method, request.getRequestMethod());
+    assertEquals(url, request.getUrl().toString());
   }
 
   private interface UserManagerOp {

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -16,10 +16,12 @@
 
 package com.google.firebase.auth;
 
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -74,6 +76,8 @@ public class FirebaseUserManagerTest {
           .build();
   private static final Map<String, Object> ACTION_CODE_SETTINGS_MAP =
           ACTION_CODE_SETTINGS.getProperties();
+  private static final String TENANTS_BASE_URL =
+          "https://identitytoolkit.googleapis.com/v2/projects/test-project-id/tenants";
 
   @After
   public void tearDown() {
@@ -1283,6 +1287,20 @@ public class FirebaseUserManagerTest {
       assertEquals("internal-error", e.getErrorCode());
       assertTrue(e.getCause() instanceof HttpResponseException);
     }
+  }
+
+  private static TestResponseInterceptor initializeAppForUserManagementWithStatusCode(
+      int statusCode, String response) {
+    FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+        .setCredentials(credentials)
+        .setHttpTransport(
+          MockHttpTransport.builder().setLowLevelHttpResponse(
+            new MockLowLevelHttpResponse().setContent(response).setStatusCode(statusCode)).build())
+        .setProjectId("test-project-id")
+        .build());
+    TestResponseInterceptor interceptor = new TestResponseInterceptor();
+    FirebaseAuth.getInstance().getUserManager().setInterceptor(interceptor);
+    return interceptor;
   }
 
   private static TestResponseInterceptor initializeAppForUserManagement(String ...responses) {

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -431,6 +431,32 @@ public class FirebaseUserManagerTest {
   }
 
   @Test
+  public void testGetTenant() throws Exception {
+    TestResponseInterceptor interceptor = initializeAppForUserManagement(
+        TestUtils.loadResource("getTenant.json"));
+    Tenant tenant = FirebaseAuth.getInstance().getTenantManager().getTenantAsync("TENANT_1").get();
+    checkTenant(tenant, "TENANT_1");
+    checkRequestHeaders(interceptor);
+    checkUrl(interceptor,
+        "https://identitytoolkit.googleapis.com/v2/projects/test-project-id/tenants/TENANT_1");
+  }
+
+  @Test
+  public void testGetTenantWithNotFoundError() throws Exception {
+    TestResponseInterceptor interceptor = initializeAppForUserManagement("{}");
+    try {
+      FirebaseAuth.getInstance().getTenantManager().getTenantAsync("UNKNOWN").get();
+      fail("No error thrown for invalid response");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof FirebaseAuthException);
+      FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
+      assertEquals(FirebaseUserManager.TENANT_NOT_FOUND_ERROR, authException.getErrorCode());
+    }
+    checkUrl(interceptor,
+        "https://identitytoolkit.googleapis.com/v2/projects/test-project-id/tenants/UNKNOWN");
+  }
+
+  @Test
   public void testListTenants() throws Exception {
     final TestResponseInterceptor interceptor = initializeAppForUserManagement(
         TestUtils.loadResource("listTenants.json"));

--- a/src/test/resources/getTenant.json
+++ b/src/test/resources/getTenant.json
@@ -1,0 +1,8 @@
+{
+  "name" : "TENANT_1",
+  "displayName" : "DISPLAY_NAME",
+  "allowPasswordSignup" : true,
+  "enableEmailLinkSignin" : false,
+  "disableAuth" : true,
+  "enableAnonymousUser" : false
+}


### PR DESCRIPTION
This pull request add getTenant to the TenantManager class. I've added the relevant unit tests to FirebaseUserManagerTest (based off of the getUser unit tests). This is part of the initiative to adding multi-tenancy support (see issue #332).

REST API: https://identitytoolkit.googleapis.com/$discovery/rest?version=v2