### PR TITLE
Add deleteTenant operation to TenantManager.

### DIFF
--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -227,8 +227,7 @@ class FirebaseUserManager {
   }
 
   void deleteTenant(String tenantId) throws FirebaseAuthException {
-    GenericUrl url = new GenericUrl(tenantMgtBaseUrl + "/tenants:delete");
-    url.put("name", tenantId);
+    GenericUrl url = new GenericUrl(tenantMgtBaseUrl + "/tenants/" + tenantId);
     GenericJson response = sendRequest("DELETE", url, null, GenericJson.class);
     if (response == null) {
       throw new FirebaseAuthException(INTERNAL_ERROR, "Failed to delete tenant: " + tenantId);

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -226,6 +226,15 @@ class FirebaseUserManager {
     return new UserImportResult(request.getUsersCount(), response);
   }
 
+  void deleteTenant(String tenantId) throws FirebaseAuthException {
+    GenericUrl url = new GenericUrl(tenantMgtBaseUrl + "/tenants:delete");
+    url.put("name", tenantId);
+    GenericJson response = sendRequest("DELETE", url, null, GenericJson.class);
+    if (response == null) {
+      throw new FirebaseAuthException(INTERNAL_ERROR, "Failed to delete tenant: " + tenantId);
+    }
+  }
+
   ListTenantsResponse listTenants(int maxResults, String pageToken)
       throws FirebaseAuthException {
     ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object>builder()
@@ -287,7 +296,7 @@ class FirebaseUserManager {
 
   private <T> T sendRequest(
           String method, GenericUrl url,
-          @Nullable Object content, Class<T> clazz) throws FirebaseAuthException {
+          Object content, Class<T> clazz) throws FirebaseAuthException {
 
     checkArgument(!Strings.isNullOrEmpty(method), "method must not be null or empty");
     checkNotNull(url, "url must not be null");

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -298,7 +298,7 @@ class FirebaseUserManager {
 
   private <T> T sendRequest(
           String method, GenericUrl url,
-          Object content, Class<T> clazz) throws FirebaseAuthException {
+          @Nullable Object content, Class<T> clazz) throws FirebaseAuthException {
 
     checkArgument(!Strings.isNullOrEmpty(method), "method must not be null or empty");
     checkNotNull(url, "url must not be null");

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -65,6 +65,7 @@ import java.util.Map;
  */
 class FirebaseUserManager {
 
+  static final String TENANT_NOT_FOUND_ERROR = "tenant-not-found";
   static final String USER_NOT_FOUND_ERROR = "user-not-found";
   static final String INTERNAL_ERROR = "internal-error";
 
@@ -82,6 +83,7 @@ class FirebaseUserManager {
       .put("INVALID_PAGE_SELECTION", "invalid-page-token")
       .put("INVALID_PHONE_NUMBER", "invalid-phone-number")
       .put("PHONE_NUMBER_EXISTS", "phone-number-already-exists")
+      .put("TENANT_NOT_FOUND", TENANT_NOT_FOUND_ERROR)
       .put("PROJECT_NOT_FOUND", "project-not-found")
       .put("USER_NOT_FOUND", USER_NOT_FOUND_ERROR)
       .put("WEAK_PASSWORD", "invalid-password")
@@ -230,7 +232,8 @@ class FirebaseUserManager {
     GenericUrl url = new GenericUrl(tenantMgtBaseUrl + "/tenants/" + tenantId);
     GenericJson response = sendRequest("DELETE", url, null, GenericJson.class);
     if (response == null) {
-      throw new FirebaseAuthException(INTERNAL_ERROR, "Failed to delete tenant: " + tenantId);
+      throw new FirebaseAuthException(TENANT_NOT_FOUND_ERROR,
+          "Failed to delete tenant: " + tenantId);
     }
   }
 

--- a/src/main/java/com/google/firebase/auth/TenantManager.java
+++ b/src/main/java/com/google/firebase/auth/TenantManager.java
@@ -16,10 +16,12 @@
 
 package com.google.firebase.auth;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.client.json.JsonFactory;
 import com.google.api.core.ApiFuture;
+import com.google.common.base.Strings;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.ListTenantsPage.DefaultTenantSource;
 import com.google.firebase.auth.ListTenantsPage.PageFactory;
@@ -112,6 +114,42 @@ public final class TenantManager {
       @Override
       protected ListTenantsPage execute() throws FirebaseAuthException {
         return factory.create();
+      }
+    };
+  }
+
+  /**
+   * Deletes the tenant identified by the specified tenant ID.
+   *
+   * @param tenantId A tenant ID string.
+   * @throws IllegalArgumentException If the tenant ID string is null or empty.
+   * @throws FirebaseAuthException If an error occurs while deleting the tenant.
+   */
+  public void deleteTenant(@NonNull String tenantId) throws FirebaseAuthException {
+    deleteTenantOp(tenantId).call();
+  }
+
+  /**
+   * Similar to {@link #deleteTenant(String)} but performs the operation asynchronously.
+   *
+   * @param tenantId A tenant ID string.
+   * @return An {@code ApiFuture} which will complete successfully when the specified tenant account
+   *     has been deleted. If an error occurs while deleting the tenant account, the future throws a
+   *     {@link FirebaseAuthException}.
+   * @throws IllegalArgumentException If the tenant ID string is null or empty.
+   */
+  public ApiFuture<Void> deleteTenantAsync(String tenantId) {
+    return deleteTenantOp(tenantId).callAsync(firebaseApp);
+  }
+
+  private CallableOperation<Void, FirebaseAuthException> deleteTenantOp(final String tenantId) {
+    // TODO(micahstairs): Add a check to make sure the app has not been destroyed yet.
+    checkArgument(!Strings.isNullOrEmpty(tenantId), "tenantId must not be null or empty");
+    return new CallableOperation<Void, FirebaseAuthException>() {
+      @Override
+      protected Void execute() throws FirebaseAuthException {
+        userManager.deleteTenant(tenantId);
+        return null;
       }
     };
   }

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -482,6 +482,8 @@ public class FirebaseUserManagerTest {
     // should not throw
     FirebaseAuth.getInstance().getTenantManager().deleteTenantAsync("TENANT_1").get();
     checkRequestHeaders(interceptor);
+    checkUrl(interceptor,
+        "https://identitytoolkit.googleapis.com/v2/projects/test-project-id/tenants/TENANT_1");
   }
 
   @Test
@@ -1332,6 +1334,10 @@ public class FirebaseUserManagerTest {
 
     String clientVersion = "Java/Admin/" + SdkUtils.getVersion();
     assertEquals(clientVersion, headers.getFirstHeaderStringValue("X-Client-Version"));
+  }
+
+  private static void checkUrl(TestResponseInterceptor interceptor, String expectedUrl) {
+    assertEquals(expectedUrl, interceptor.getResponse().getRequest().getUrl().toString());
   }
 
   private interface UserManagerOp {

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -477,6 +477,14 @@ public class FirebaseUserManagerTest {
   }
 
   @Test
+  public void testDeleteTenant() throws Exception {
+    TestResponseInterceptor interceptor = initializeAppForUserManagement("{}");
+    // should not throw
+    FirebaseAuth.getInstance().getTenantManager().deleteTenantAsync("TENANT_1").get();
+    checkRequestHeaders(interceptor);
+  }
+
+  @Test
   public void testCreateSessionCookie() throws Exception {
     TestResponseInterceptor interceptor = initializeAppForUserManagement(
         TestUtils.loadResource("createSessionCookie.json"));

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -1344,8 +1344,9 @@ public class FirebaseUserManagerTest {
   }
 
   private static void checkUrl(TestResponseInterceptor interceptor, String method, String url) {
-    assertEquals(method, interceptor.getResponse().getRequest().getRequestMethod());
-    assertEquals(url, interceptor.getResponse().getRequest().getUrl().toString());
+    HttpRequest request = interceptor.getResponse().getRequest();
+    assertEquals(method, request.getRequestMethod());
+    assertEquals(url, request.getUrl().toString());
   }
 
   private interface UserManagerOp {


### PR DESCRIPTION
This pull request add deleteTenant to the TenantManager class. I've added the relevant unit tests to FirebaseUserManagerTest (based off of the getTenant unit test). This is part of the initiative to adding multi-tenancy support (see issue #332).

REST API: https://identitytoolkit.googleapis.com/$discovery/rest?version=v2