### PR TITLE
Renamed getErrorCodeNew() to getErrorCode()

### DIFF
--- a/src/main/java/com/google/firebase/FirebaseException.java
+++ b/src/main/java/com/google/firebase/FirebaseException.java
@@ -31,16 +31,6 @@ public class FirebaseException extends Exception {
   private final ErrorCode errorCode;
   private final IncomingHttpResponse httpResponse;
 
-  @Deprecated
-  public FirebaseException(@NonNull String detailMessage) {
-    this(detailMessage, null);
-  }
-
-  @Deprecated
-  public FirebaseException(@NonNull String detailMessage, Throwable cause) {
-    this(ErrorCode.UNKNOWN, detailMessage, cause, null);
-  }
-
   public FirebaseException(
       @NonNull ErrorCode errorCode,
       @NonNull String message,
@@ -64,8 +54,7 @@ public class FirebaseException extends Exception {
    *
    * @return A Firebase error code.
    */
-  // TODO: Rename this method to getErrorCode when the child classes are refactored.
-  public ErrorCode getErrorCodeNew() {
+  public final ErrorCode getErrorCode() {
     return errorCode;
   }
 
@@ -76,7 +65,7 @@ public class FirebaseException extends Exception {
    * @return An HTTP response or null.
    */
   @Nullable
-  public IncomingHttpResponse getHttpResponse() {
+  public final IncomingHttpResponse getHttpResponse() {
     return httpResponse;
   }
 }

--- a/src/main/java/com/google/firebase/auth/FirebaseAuthException.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuthException.java
@@ -40,13 +40,8 @@ public class FirebaseAuthException extends FirebaseException {
     this.errorCode = authErrorCode;
   }
 
-  public FirebaseAuthException(
-      @NonNull ErrorCode errorCode, @NonNull String message, Throwable throwable) {
-    this(errorCode, message, throwable, null, null);
-  }
-
   public FirebaseAuthException(FirebaseException base) {
-    this(base.getErrorCodeNew(), base.getMessage(), base.getCause(), base.getHttpResponse(), null);
+    this(base.getErrorCode(), base.getMessage(), base.getCause(), base.getHttpResponse(), null);
   }
 
   @Nullable

--- a/src/main/java/com/google/firebase/iid/FirebaseInstanceIdException.java
+++ b/src/main/java/com/google/firebase/iid/FirebaseInstanceIdException.java
@@ -24,6 +24,6 @@ import com.google.firebase.FirebaseException;
 public final class FirebaseInstanceIdException extends FirebaseException {
 
   FirebaseInstanceIdException(FirebaseException base, String message) {
-    super(base.getErrorCodeNew(), message, base.getCause(), base.getHttpResponse());
+    super(base.getErrorCode(), message, base.getCause(), base.getHttpResponse());
   }
 }

--- a/src/main/java/com/google/firebase/internal/AbstractPlatformErrorHandler.java
+++ b/src/main/java/com/google/firebase/internal/AbstractPlatformErrorHandler.java
@@ -46,7 +46,7 @@ public abstract class AbstractPlatformErrorHandler<T extends FirebaseException>
     FirebaseException base = super.httpResponseErrorToBaseException(e, response);
     PlatformErrorResponse parsedError = this.parseErrorResponse(e.getContent());
 
-    ErrorCode code = base.getErrorCodeNew();
+    ErrorCode code = base.getErrorCode();
     String status = parsedError.getStatus();
     if (!Strings.isNullOrEmpty(status)) {
       code = Enum.valueOf(ErrorCode.class, parsedError.getStatus());

--- a/src/main/java/com/google/firebase/messaging/FirebaseMessagingException.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessagingException.java
@@ -45,7 +45,7 @@ public final class FirebaseMessagingException extends FirebaseException {
   static FirebaseMessagingException withMessagingErrorCode(
       FirebaseException base, @Nullable MessagingErrorCode errorCode) {
     return new FirebaseMessagingException(
-        base.getErrorCodeNew(),
+        base.getErrorCode(),
         base.getMessage(),
         base.getCause(),
         base.getHttpResponse(),
@@ -54,7 +54,7 @@ public final class FirebaseMessagingException extends FirebaseException {
 
   static FirebaseMessagingException withCustomMessage(FirebaseException base, String message) {
     return new FirebaseMessagingException(
-        base.getErrorCodeNew(),
+        base.getErrorCode(),
         message,
         base.getCause(),
         base.getHttpResponse(),

--- a/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementException.java
+++ b/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementException.java
@@ -31,7 +31,7 @@ public final class FirebaseProjectManagementException extends FirebaseException 
   }
 
   FirebaseProjectManagementException(@NonNull FirebaseException base, @NonNull String message) {
-    super(base.getErrorCodeNew(), message, base.getCause(), base.getHttpResponse());
+    super(base.getErrorCode(), message, base.getCause(), base.getHttpResponse());
   }
 
   FirebaseProjectManagementException(

--- a/src/test/java/com/google/firebase/FirebaseExceptionTest.java
+++ b/src/test/java/com/google/firebase/FirebaseExceptionTest.java
@@ -67,7 +67,7 @@ public class FirebaseExceptionTest {
         null,
         null);
 
-    assertEquals(ErrorCode.INTERNAL, exception.getErrorCodeNew());
+    assertEquals(ErrorCode.INTERNAL, exception.getErrorCode());
     assertEquals("Test error", exception.getMessage());
     assertNull(exception.getHttpResponse());
     assertNull(exception.getCause());
@@ -86,7 +86,7 @@ public class FirebaseExceptionTest {
         null,
         response);
 
-    assertEquals(ErrorCode.INTERNAL, exception.getErrorCodeNew());
+    assertEquals(ErrorCode.INTERNAL, exception.getErrorCode());
     assertEquals("Test error", exception.getMessage());
     assertSame(response, exception.getHttpResponse());
     assertNull(exception.getCause());
@@ -101,30 +101,10 @@ public class FirebaseExceptionTest {
         "Test error",
         cause);
 
-    assertEquals(ErrorCode.INTERNAL, exception.getErrorCodeNew());
+    assertEquals(ErrorCode.INTERNAL, exception.getErrorCode());
     assertEquals("Test error", exception.getMessage());
     assertNull(exception.getHttpResponse());
     assertSame(cause, exception.getCause());
-  }
-
-  @Test
-  public void testFirebaseExceptionLegacyConstructor() {
-    FirebaseException exception = new FirebaseException("Test error");
-
-    assertEquals(ErrorCode.UNKNOWN, exception.getErrorCodeNew());
-    assertEquals("Test error", exception.getMessage());
-    assertNull(exception.getHttpResponse());
-    assertNull(exception.getCause());
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testFirebaseExceptionNullDetail() {
-    new FirebaseException(null);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testFirebaseExceptionEmptyDetail() {
-    new FirebaseException("");
   }
 
   private HttpResponseException createHttpResponseException() throws IOException {

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -101,7 +101,7 @@ public class FirebaseAuthIT {
       assertEquals(
           "No user record found for the provided user ID: non.existing",
           authException.getMessage());
-      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCodeNew());
+      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCode());
       assertNull(authException.getCause());
       assertNotNull(authException.getHttpResponse());
       assertEquals(AuthErrorCode.USER_NOT_FOUND, authException.getAuthErrorCode());
@@ -119,7 +119,7 @@ public class FirebaseAuthIT {
       assertEquals(
           "No user record found for the provided email: non.existing@definitely.non.existing",
           authException.getMessage());
-      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCodeNew());
+      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCode());
       assertNull(authException.getCause());
       assertNotNull(authException.getHttpResponse());
       assertEquals(AuthErrorCode.USER_NOT_FOUND, authException.getAuthErrorCode());
@@ -137,7 +137,7 @@ public class FirebaseAuthIT {
       assertEquals(
           "No user record found for the given identifier (USER_NOT_FOUND).",
           authException.getMessage());
-      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCodeNew());
+      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCode());
       assertNotNull(authException.getCause());
       assertNotNull(authException.getHttpResponse());
       assertEquals(AuthErrorCode.USER_NOT_FOUND, authException.getAuthErrorCode());
@@ -155,7 +155,7 @@ public class FirebaseAuthIT {
       assertEquals(
           "No user record found for the given identifier (USER_NOT_FOUND).",
           authException.getMessage());
-      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCodeNew());
+      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCode());
       assertNotNull(authException.getCause());
       assertNotNull(authException.getHttpResponse());
       assertEquals(AuthErrorCode.USER_NOT_FOUND, authException.getAuthErrorCode());
@@ -272,7 +272,7 @@ public class FirebaseAuthIT {
       assertEquals(
           "No user record found for the provided user ID: " + userRecord.getUid(),
           authException.getMessage());
-      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCodeNew());
+      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCode());
       assertNull(authException.getCause());
       assertNotNull(authException.getHttpResponse());
       assertEquals(AuthErrorCode.USER_NOT_FOUND, authException.getAuthErrorCode());
@@ -724,7 +724,7 @@ public class FirebaseAuthIT {
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
       FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
-      assertEquals(ErrorCode.ALREADY_EXISTS, authException.getErrorCodeNew());
+      assertEquals(ErrorCode.ALREADY_EXISTS, authException.getErrorCode());
       assertEquals(
           "The user with the provided uid already exists (DUPLICATE_LOCAL_ID).",
           authException.getMessage());

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
@@ -255,7 +255,7 @@ public class FirebaseAuthTest {
       auth.verifyIdToken("idtoken", true);
       fail("No error thrown for revoked ID token");
     } catch (FirebaseAuthException e) {
-      assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
       assertEquals("Firebase id token is revoked.", e.getMessage());
       assertNull(e.getCause());
       assertNull(e.getHttpResponse());
@@ -422,7 +422,7 @@ public class FirebaseAuthTest {
       auth.verifySessionCookie("cookie", true);
       fail("No error thrown for revoked session cookie");
     } catch (FirebaseAuthException e) {
-      assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
       assertEquals("Firebase session cookie is revoked.", e.getMessage());
       assertNull(e.getCause());
       assertNull(e.getHttpResponse());

--- a/src/test/java/com/google/firebase/auth/FirebaseTokenVerifierImplTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseTokenVerifierImplTest.java
@@ -249,7 +249,7 @@ public class FirebaseTokenVerifierImplTest {
       tokenVerifier.verifyToken(token);
     } catch (FirebaseAuthException e) {
       String message = "Error while fetching public key certificates: Could not parse certificate";
-      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCode());
       assertTrue(e.getMessage().startsWith(message));
       assertTrue(e.getCause() instanceof GeneralSecurityException);
       assertNull(e.getHttpResponse());
@@ -274,7 +274,7 @@ public class FirebaseTokenVerifierImplTest {
       Assert.fail("No exception thrown");
     } catch (FirebaseAuthException e) {
       String message = "Error while fetching public key certificates: Expected error";
-      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCode());
       assertEquals(message, e.getMessage());
       assertTrue(e.getCause() instanceof IOException);
       assertNull(e.getHttpResponse());
@@ -317,7 +317,7 @@ public class FirebaseTokenVerifierImplTest {
       String message = "Failed to parse Firebase test token. "
           + "Make sure you passed a string that represents a complete and valid JWT. "
           + "See https://test.doc.url for details on how to retrieve a test token.";
-      assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
       assertEquals(message, e.getMessage());
       assertTrue(e.getCause() instanceof IllegalArgumentException);
       assertNull(e.getHttpResponse());
@@ -454,7 +454,7 @@ public class FirebaseTokenVerifierImplTest {
   }
 
   private void checkException(FirebaseAuthException e, String message, AuthErrorCode errorCode) {
-    assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCodeNew());
+    assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
     assertEquals(message, e.getMessage());
     assertNull(e.getCause());
     assertNull(e.getHttpResponse());

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -117,7 +117,7 @@ public class FirebaseUserManagerTest {
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
       FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
-      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCodeNew());
+      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCode());
       assertEquals(
           "No user record found for the provided user ID: testuser", authException.getMessage());
       assertNull(authException.getCause());
@@ -145,7 +145,7 @@ public class FirebaseUserManagerTest {
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
       FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
-      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCodeNew());
+      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCode());
       assertEquals(
           "No user record found for the provided email: testuser@example.com",
           authException.getMessage());
@@ -174,7 +174,7 @@ public class FirebaseUserManagerTest {
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
       FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
-      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCodeNew());
+      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCode());
       assertEquals(
           "No user record found for the provided phone number: +1234567890",
           authException.getMessage());
@@ -588,7 +588,7 @@ public class FirebaseUserManagerTest {
         } catch (ExecutionException e) {
           assertTrue(e.getCause() instanceof FirebaseAuthException);
           FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
-          assertEquals(codes.get(code), authException.getErrorCodeNew());
+          assertEquals(codes.get(code), authException.getErrorCode());
           String msg = String.format("Unexpected HTTP response with status: %d\n{}", code);
           assertEquals(msg, authException.getMessage());
           assertTrue(authException.getCause() instanceof HttpResponseException);
@@ -608,7 +608,7 @@ public class FirebaseUserManagerTest {
       }  catch (ExecutionException e) {
         assertTrue(e.getCause().toString(), e.getCause() instanceof FirebaseAuthException);
         FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
-        assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCodeNew());
+        assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCode());
         assertEquals(
             "No user record found for the given identifier (USER_NOT_FOUND).",
             authException.getMessage());
@@ -628,7 +628,7 @@ public class FirebaseUserManagerTest {
       }  catch (ExecutionException e) {
         assertTrue(e.getCause().toString(), e.getCause() instanceof FirebaseAuthException);
         FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
-        assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCodeNew());
+        assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCode());
         assertEquals(
             "No user record found for the given identifier (USER_NOT_FOUND): Extra details",
             authException.getMessage());
@@ -648,7 +648,7 @@ public class FirebaseUserManagerTest {
     }  catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
       FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
-      assertEquals(ErrorCode.UNKNOWN, authException.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, authException.getErrorCode());
       assertTrue(
           authException.getMessage().startsWith("Error while parsing HTTP response: "));
       assertTrue(authException.getCause() instanceof IOException);
@@ -669,7 +669,7 @@ public class FirebaseUserManagerTest {
     }  catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
       FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
-      assertEquals(ErrorCode.INTERNAL, authException.getErrorCodeNew());
+      assertEquals(ErrorCode.INTERNAL, authException.getErrorCode());
       assertEquals("Unexpected HTTP response with status: 500\n{\"not\" json}",
           authException.getMessage());
       assertTrue(authException.getCause() instanceof HttpResponseException);
@@ -1224,7 +1224,7 @@ public class FirebaseUserManagerTest {
       userManager.getEmailActionLink(EmailLinkType.PASSWORD_RESET, "test@example.com", null);
       fail("No exception thrown for HTTP error");
     } catch (FirebaseAuthException e) {
-      assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
       assertEquals(
           "The domain of the continue URL is not whitelisted (UNAUTHORIZED_DOMAIN).",
           e.getMessage());
@@ -1246,7 +1246,7 @@ public class FirebaseUserManagerTest {
       userManager.getEmailActionLink(EmailLinkType.PASSWORD_RESET, "test@example.com", null);
       fail("No exception thrown for HTTP error");
     } catch (FirebaseAuthException e) {
-      assertEquals(ErrorCode.INTERNAL, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INTERNAL, e.getErrorCode());
       assertEquals("Unexpected HTTP response with status: 500\n" + content, e.getMessage());
       assertNull(e.getAuthErrorCode());
       assertTrue(e.getCause() instanceof HttpResponseException);
@@ -1265,7 +1265,7 @@ public class FirebaseUserManagerTest {
       userManager.getEmailActionLink(EmailLinkType.PASSWORD_RESET, "test@example.com", null);
       fail("No exception thrown for HTTP error");
     } catch (FirebaseAuthException e) {
-      assertEquals(ErrorCode.INTERNAL, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INTERNAL, e.getErrorCode());
       assertEquals("Unexpected HTTP response with status: 500\n{}", e.getMessage());
       assertTrue(e.getCause() instanceof HttpResponseException);
       assertNotNull(e.getHttpResponse());

--- a/src/test/java/com/google/firebase/auth/internal/CryptoSignersTest.java
+++ b/src/test/java/com/google/firebase/auth/internal/CryptoSignersTest.java
@@ -104,7 +104,7 @@ public class CryptoSignersTest {
     try {
       signer.sign("foo".getBytes());
     } catch (FirebaseAuthException e) {
-      assertEquals(ErrorCode.INTERNAL, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INTERNAL, e.getErrorCode());
       assertEquals("Test error", e.getMessage());
       assertNotNull(e.getCause());
       assertNotNull(e.getHttpResponse());

--- a/src/test/java/com/google/firebase/iid/FirebaseInstanceIdTest.java
+++ b/src/test/java/com/google/firebase/iid/FirebaseInstanceIdTest.java
@@ -220,7 +220,7 @@ public class FirebaseInstanceIdTest {
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseInstanceIdException);
       FirebaseInstanceIdException error = (FirebaseInstanceIdException) e.getCause();
-      assertEquals(ErrorCode.UNKNOWN, error.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, error.getErrorCode());
       assertEquals(
           "Unknown error while making a remote service call: transport error",
           error.getMessage());
@@ -254,7 +254,7 @@ public class FirebaseInstanceIdTest {
   }
 
   private void checkFirebaseInstanceIdException(FirebaseInstanceIdException error, int statusCode) {
-    assertEquals(ERROR_CODES.get(statusCode), error.getErrorCodeNew());
+    assertEquals(ERROR_CODES.get(statusCode), error.getErrorCode());
     assertEquals(ERROR_MESSAGES.get(statusCode), error.getMessage());
     assertTrue(error.getCause() instanceof HttpResponseException);
 

--- a/src/test/java/com/google/firebase/internal/AbstractPlatformErrorHandlerTest.java
+++ b/src/test/java/com/google/firebase/internal/AbstractPlatformErrorHandlerTest.java
@@ -56,7 +56,7 @@ public class AbstractPlatformErrorHandlerTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (MockFirebaseException e) {
-      assertEquals(ErrorCode.UNAVAILABLE, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNAVAILABLE, e.getErrorCode());
       assertEquals("Test error", e.getMessage());
       assertHttpResponse(e, HttpStatusCodes.STATUS_CODE_SERVER_ERROR, payload);
       assertNotNull(e.getCause());
@@ -75,7 +75,7 @@ public class AbstractPlatformErrorHandlerTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (MockFirebaseException e) {
-      assertEquals(ErrorCode.INTERNAL, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INTERNAL, e.getErrorCode());
       assertEquals("Unexpected HTTP response with status: 500\nnot json", e.getMessage());
       assertHttpResponse(e, HttpStatusCodes.STATUS_CODE_SERVER_ERROR, payload);
       assertNotNull(e.getCause());
@@ -94,7 +94,7 @@ public class AbstractPlatformErrorHandlerTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (MockFirebaseException e) {
-      assertEquals(ErrorCode.INTERNAL, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INTERNAL, e.getErrorCode());
       assertEquals("Test error", e.getMessage());
       assertHttpResponse(e, HttpStatusCodes.STATUS_CODE_SERVER_ERROR, payload);
       assertNotNull(e.getCause());
@@ -113,7 +113,7 @@ public class AbstractPlatformErrorHandlerTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (MockFirebaseException e) {
-      assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INVALID_ARGUMENT, e.getErrorCode());
       assertEquals("Unexpected HTTP response with status: 500\n" + payload, e.getMessage());
       assertHttpResponse(e, HttpStatusCodes.STATUS_CODE_SERVER_ERROR, payload);
       assertNotNull(e.getCause());
@@ -132,7 +132,7 @@ public class AbstractPlatformErrorHandlerTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (MockFirebaseException e) {
-      assertEquals(ErrorCode.INTERNAL, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INTERNAL, e.getErrorCode());
       assertEquals("Unexpected HTTP response with status: 500\n" + payload, e.getMessage());
       assertHttpResponse(e, HttpStatusCodes.STATUS_CODE_SERVER_ERROR, payload);
       assertNotNull(e.getCause());
@@ -148,7 +148,7 @@ public class AbstractPlatformErrorHandlerTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (MockFirebaseException e) {
-      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCode());
       assertEquals(
           "Unknown error while making a remote service call: Test", e.getMessage());
       assertNull(e.getHttpResponse());
@@ -165,7 +165,7 @@ public class AbstractPlatformErrorHandlerTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (MockFirebaseException e) {
-      assertEquals(ErrorCode.DEADLINE_EXCEEDED, e.getErrorCodeNew());
+      assertEquals(ErrorCode.DEADLINE_EXCEEDED, e.getErrorCode());
       assertEquals(
           "Timed out while making an API call: Test", e.getMessage());
       assertNull(e.getHttpResponse());
@@ -182,7 +182,7 @@ public class AbstractPlatformErrorHandlerTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (MockFirebaseException e) {
-      assertEquals(ErrorCode.UNAVAILABLE, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNAVAILABLE, e.getErrorCode());
       assertEquals(
           "Failed to establish a connection: Test", e.getMessage());
       assertNull(e.getHttpResponse());
@@ -199,7 +199,7 @@ public class AbstractPlatformErrorHandlerTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (MockFirebaseException e) {
-      assertEquals(ErrorCode.UNAVAILABLE, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNAVAILABLE, e.getErrorCode());
       assertEquals(
           "Failed to establish a connection: Test", e.getMessage());
       assertNull(e.getHttpResponse());
@@ -218,7 +218,7 @@ public class AbstractPlatformErrorHandlerTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (MockFirebaseException e) {
-      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCode());
       assertTrue(e.getMessage().startsWith("Error while parsing HTTP response: "));
       assertHttpResponse(e, HttpStatusCodes.STATUS_CODE_OK, payload);
       assertNotNull(e.getCause());
@@ -237,7 +237,7 @@ public class AbstractPlatformErrorHandlerTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (MockFirebaseException e) {
-      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCode());
       assertEquals("Test error", e.getMessage());
       assertHttpResponse(e, 512, payload);
       assertNotNull(e.getCause());
@@ -292,7 +292,7 @@ public class AbstractPlatformErrorHandlerTest {
 
   private static class MockFirebaseException extends FirebaseException {
     MockFirebaseException(FirebaseException base) {
-      super(base.getErrorCodeNew(), base.getMessage(), base.getCause(), base.getHttpResponse());
+      super(base.getErrorCode(), base.getMessage(), base.getCause(), base.getHttpResponse());
     }
   }
 }

--- a/src/test/java/com/google/firebase/internal/ErrorHandlingHttpClientTest.java
+++ b/src/test/java/com/google/firebase/internal/ErrorHandlingHttpClientTest.java
@@ -150,7 +150,7 @@ public class ErrorHandlingHttpClientTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (FirebaseException e) {
-      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCode());
       assertEquals("IO error: Test", e.getMessage());
       assertNull(e.getHttpResponse());
       assertSame(exception, e.getCause());
@@ -169,7 +169,7 @@ public class ErrorHandlingHttpClientTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (FirebaseException e) {
-      assertEquals(ErrorCode.INTERNAL, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INTERNAL, e.getErrorCode());
       assertEquals("Example error message: {}", e.getMessage());
       assertHttpResponse(e, HttpStatusCodes.STATUS_CODE_SERVER_ERROR, "{}");
       IncomingHttpResponse httpResponse = e.getHttpResponse();
@@ -190,7 +190,7 @@ public class ErrorHandlingHttpClientTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (FirebaseException e) {
-      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCode());
       assertEquals("Parse error", e.getMessage());
       assertHttpResponse(e, HttpStatusCodes.STATUS_CODE_OK, payload);
       assertNotNull(e.getCause());
@@ -222,7 +222,7 @@ public class ErrorHandlingHttpClientTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (FirebaseException e) {
-      assertEquals(ErrorCode.INTERNAL, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INTERNAL, e.getErrorCode());
       assertEquals("Example error message: null", e.getMessage());
       assertHttpResponse(e, HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE, null);
       assertNotNull(e.getCause());
@@ -257,7 +257,7 @@ public class ErrorHandlingHttpClientTest {
       client.sendAndParse(TEST_REQUEST, GenericData.class);
       fail("No exception thrown for HTTP error response");
     } catch (FirebaseException e) {
-      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCode());
       assertEquals("IO error: Failed to fetch credentials", e.getMessage());
       assertNull(e.getHttpResponse());
       assertNotNull(e.getCause());

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
@@ -151,7 +151,7 @@ public class FirebaseMessagingClientImplTest {
       client.send(EMPTY_MESSAGE, DRY_RUN_DISABLED);
       fail("No error thrown for HTTP error");
     } catch (FirebaseMessagingException error) {
-      assertEquals(ErrorCode.UNKNOWN, error.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, error.getErrorCode());
       assertEquals("Unknown error while making a remote service call: transport error",
           error.getMessage());
       assertTrue(error.getCause() instanceof IOException);
@@ -171,7 +171,7 @@ public class FirebaseMessagingClientImplTest {
         client.send(entry.getKey(), DRY_RUN_DISABLED);
         fail("No error thrown for malformed response");
       } catch (FirebaseMessagingException error) {
-        assertEquals(ErrorCode.UNKNOWN, error.getErrorCodeNew());
+        assertEquals(ErrorCode.UNKNOWN, error.getErrorCode());
         assertTrue(error.getMessage().startsWith("Error while parsing HTTP response: "));
         assertNotNull(error.getCause());
         assertNotNull(error.getHttpResponse());
@@ -405,7 +405,7 @@ public class FirebaseMessagingClientImplTest {
       client.sendAll(MESSAGE_LIST, DRY_RUN_DISABLED);
       fail("No error thrown for HTTP error");
     } catch (FirebaseMessagingException error) {
-      assertEquals(ErrorCode.UNKNOWN, error.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, error.getErrorCode());
       assertEquals(
           "Unknown error while making a remote service call: transport error", error.getMessage());
       assertTrue(error.getCause() instanceof IOException);
@@ -625,7 +625,7 @@ public class FirebaseMessagingClientImplTest {
 
       FirebaseMessagingException exception = sendResponse.getException();
       assertNotNull(exception);
-      assertEquals(ErrorCode.INVALID_ARGUMENT, exception.getErrorCodeNew());
+      assertEquals(ErrorCode.INVALID_ARGUMENT, exception.getErrorCode());
       assertNull(exception.getCause());
       assertNull(exception.getHttpResponse());
       assertEquals(MessagingErrorCode.INVALID_ARGUMENT, exception.getMessagingErrorCode());
@@ -680,7 +680,7 @@ public class FirebaseMessagingClientImplTest {
       ErrorCode expectedCode,
       MessagingErrorCode expectedMessagingCode,
       String expectedMessage) {
-    assertEquals(expectedCode, error.getErrorCodeNew());
+    assertEquals(expectedCode, error.getErrorCode());
     assertEquals(expectedMessage, error.getMessage());
     assertTrue(error.getCause() instanceof HttpResponseException);
     assertEquals(expectedMessagingCode, error.getMessagingErrorCode());

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingIT.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingIT.java
@@ -89,7 +89,7 @@ public class FirebaseMessagingIT {
       messaging.sendAsync(message, true).get();
     } catch (ExecutionException e) {
       FirebaseMessagingException cause = (FirebaseMessagingException) e.getCause();
-      assertEquals(ErrorCode.INVALID_ARGUMENT, cause.getErrorCodeNew());
+      assertEquals(ErrorCode.INVALID_ARGUMENT, cause.getErrorCode());
       assertEquals(MessagingErrorCode.INVALID_ARGUMENT, cause.getMessagingErrorCode());
       assertNotNull(cause.getHttpResponse());
       assertTrue(cause.getCause() instanceof HttpResponseException);
@@ -134,7 +134,7 @@ public class FirebaseMessagingIT {
     assertNull(responses.get(2).getMessageId());
     FirebaseMessagingException exception = responses.get(2).getException();
     assertNotNull(exception);
-    assertEquals(ErrorCode.INVALID_ARGUMENT, exception.getErrorCodeNew());
+    assertEquals(ErrorCode.INVALID_ARGUMENT, exception.getErrorCode());
   }
 
   @Test

--- a/src/test/java/com/google/firebase/messaging/InstanceIdClientImplTest.java
+++ b/src/test/java/com/google/firebase/messaging/InstanceIdClientImplTest.java
@@ -185,7 +185,7 @@ public class InstanceIdClientImplTest {
       client.subscribeToTopic("test-topic", ImmutableList.of("id1", "id2"));
       fail("No error thrown for HTTP error");
     } catch (FirebaseMessagingException error) {
-      assertEquals(ErrorCode.UNKNOWN, error.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, error.getErrorCode());
       assertEquals(
           "Unknown error while making a remote service call: transport error", error.getMessage());
       assertTrue(error.getCause() instanceof IOException);
@@ -203,7 +203,7 @@ public class InstanceIdClientImplTest {
       client.subscribeToTopic("test-topic", ImmutableList.of("id1", "id2"));
       fail("No error thrown for HTTP error");
     } catch (FirebaseMessagingException error) {
-      assertEquals(ErrorCode.UNKNOWN, error.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, error.getErrorCode());
       assertTrue(error.getMessage().startsWith("Error while parsing HTTP response: "));
       assertTrue(error.getCause() instanceof IOException);
     }
@@ -323,7 +323,7 @@ public class InstanceIdClientImplTest {
       client.unsubscribeFromTopic("test-topic", ImmutableList.of("id1", "id2"));
       fail("No error thrown for HTTP error");
     } catch (FirebaseMessagingException error) {
-      assertEquals(ErrorCode.UNKNOWN, error.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, error.getErrorCode());
       assertEquals(
           "Unknown error while making a remote service call: transport error", error.getMessage());
       assertTrue(error.getCause() instanceof IOException);
@@ -341,7 +341,7 @@ public class InstanceIdClientImplTest {
       client.unsubscribeFromTopic("test-topic", ImmutableList.of("id1", "id2"));
       fail("No error thrown for HTTP error");
     } catch (FirebaseMessagingException error) {
-      assertEquals(ErrorCode.UNKNOWN, error.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, error.getErrorCode());
       assertTrue(error.getMessage().startsWith("Error while parsing HTTP response: "));
       assertTrue(error.getCause() instanceof IOException);
     }
@@ -437,7 +437,7 @@ public class InstanceIdClientImplTest {
 
   private void checkExceptionFromHttpResponse(
       FirebaseMessagingException error, int statusCode, String expectedMessage) {
-    assertEquals(HTTP_2_ERROR.get(statusCode), error.getErrorCodeNew());
+    assertEquals(HTTP_2_ERROR.get(statusCode), error.getErrorCode());
     assertEquals(expectedMessage, error.getMessage());
     assertTrue(error.getCause() instanceof HttpResponseException);
     assertNull(error.getMessagingErrorCode());

--- a/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
+++ b/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
@@ -48,6 +48,7 @@ import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.auth.MockGoogleCredentials;
 import com.google.firebase.internal.SdkUtils;
 import com.google.firebase.internal.TestApiClientUtils;
+import com.google.firebase.internal.SdkUtils;
 import com.google.firebase.testing.MultiRequestMockHttpTransport;
 import com.google.firebase.testing.TestUtils;
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
+++ b/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
@@ -48,7 +48,6 @@ import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.auth.MockGoogleCredentials;
 import com.google.firebase.internal.SdkUtils;
 import com.google.firebase.internal.TestApiClientUtils;
-import com.google.firebase.internal.SdkUtils;
 import com.google.firebase.testing.MultiRequestMockHttpTransport;
 import com.google.firebase.testing.TestUtils;
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
+++ b/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
@@ -278,7 +278,7 @@ public class FirebaseProjectManagementServiceImplTest {
       serviceImpl.getIosApp(IOS_APP_ID);
       fail("No exception thrown for HTTP error");
     } catch (FirebaseProjectManagementException e) {
-      assertEquals(ErrorCode.INTERNAL, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INTERNAL, e.getErrorCode());
       assertEquals(
           "App ID \"test-ios-app-id\": Unexpected HTTP response with status: 500\n{}",
           e.getMessage());
@@ -298,7 +298,7 @@ public class FirebaseProjectManagementServiceImplTest {
       serviceImpl.getIosApp(IOS_APP_ID);
       fail("No exception thrown for HTTP error");
     } catch (FirebaseProjectManagementException e) {
-      assertEquals(ErrorCode.NOT_FOUND, e.getErrorCodeNew());
+      assertEquals(ErrorCode.NOT_FOUND, e.getErrorCode());
       assertEquals("App ID \"test-ios-app-id\": Test error", e.getMessage());
       assertNotNull(e.getCause());
       assertNotNull(e.getHttpResponse());
@@ -314,7 +314,7 @@ public class FirebaseProjectManagementServiceImplTest {
       serviceImpl.getIosApp(IOS_APP_ID);
       fail("No exception thrown for HTTP error");
     } catch (FirebaseProjectManagementException e) {
-      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCode());
       assertTrue(e.getMessage().startsWith(
           "App ID \"test-ios-app-id\": Error while parsing HTTP response"));
       assertNotNull(e.getCause());
@@ -330,7 +330,7 @@ public class FirebaseProjectManagementServiceImplTest {
       serviceImpl.getIosApp(IOS_APP_ID);
       fail("No exception thrown for HTTP error");
     } catch (FirebaseProjectManagementException e) {
-      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCode());
       assertEquals(
           "App ID \"test-ios-app-id\": Unknown error while making a remote service call: "
               + "transport error",
@@ -618,7 +618,7 @@ public class FirebaseProjectManagementServiceImplTest {
       serviceImpl.getAndroidApp(ANDROID_APP_ID);
       fail("No exception thrown for HTTP error");
     } catch (FirebaseProjectManagementException e) {
-      assertEquals(ErrorCode.INTERNAL, e.getErrorCodeNew());
+      assertEquals(ErrorCode.INTERNAL, e.getErrorCode());
       assertEquals(
           "App ID \"test-android-app-id\": Unexpected HTTP response with status: 500\n{}",
           e.getMessage());
@@ -638,7 +638,7 @@ public class FirebaseProjectManagementServiceImplTest {
       serviceImpl.getAndroidApp(ANDROID_APP_ID);
       fail("No exception thrown for HTTP error");
     } catch (FirebaseProjectManagementException e) {
-      assertEquals(ErrorCode.NOT_FOUND, e.getErrorCodeNew());
+      assertEquals(ErrorCode.NOT_FOUND, e.getErrorCode());
       assertEquals("App ID \"test-android-app-id\": Test error", e.getMessage());
       assertNotNull(e.getCause());
       assertNotNull(e.getHttpResponse());
@@ -654,7 +654,7 @@ public class FirebaseProjectManagementServiceImplTest {
       serviceImpl.getAndroidApp(ANDROID_APP_ID);
       fail("No exception thrown for HTTP error");
     } catch (FirebaseProjectManagementException e) {
-      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCode());
       assertTrue(e.getMessage().startsWith(
           "App ID \"test-android-app-id\": Error while parsing HTTP response"));
       assertNotNull(e.getCause());
@@ -670,7 +670,7 @@ public class FirebaseProjectManagementServiceImplTest {
       serviceImpl.getAndroidApp(ANDROID_APP_ID);
       fail("No exception thrown for HTTP error");
     } catch (FirebaseProjectManagementException e) {
-      assertEquals(ErrorCode.UNKNOWN, e.getErrorCodeNew());
+      assertEquals(ErrorCode.UNKNOWN, e.getErrorCode());
       assertEquals(
           "App ID \"test-android-app-id\": Unknown error while making a remote service call: "
               + "transport error",


### PR DESCRIPTION
Renaming the method and removing the deprecated constructors on `FirebaseException` class.