### PR TITLE
Removed old deprecated APIs

### DIFF
--- a/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/src/main/java/com/google/firebase/FirebaseApp.java
@@ -34,7 +34,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
-import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.firebase.internal.FirebaseAppStore;
 import com.google.firebase.internal.FirebaseScheduledExecutor;
@@ -121,7 +120,6 @@ public class FirebaseApp {
 
   /** Returns a list of all FirebaseApps. */
   public static List<FirebaseApp> getApps() {
-    // TODO: reenable persistence. See b/28158809.
     synchronized (appsLock) {
       return ImmutableList.copyOf(instances.values());
     }
@@ -582,18 +580,17 @@ public class FirebaseApp {
   private static FirebaseOptions getOptionsFromEnvironment() throws IOException {
     String defaultConfig = System.getenv(FIREBASE_CONFIG_ENV_VAR);
     if (Strings.isNullOrEmpty(defaultConfig)) {
-      return new FirebaseOptions.Builder()
+      return FirebaseOptions.builder()
           .setCredentials(APPLICATION_DEFAULT_CREDENTIALS)
           .build();
     }
     JsonFactory jsonFactory = Utils.getDefaultJsonFactory();
-    FirebaseOptions.Builder builder = new FirebaseOptions.Builder();
+    FirebaseOptions.Builder builder = FirebaseOptions.builder();
     JsonParser parser;
     if (defaultConfig.startsWith("{")) {
       parser = jsonFactory.createJsonParser(defaultConfig);
     } else {
-      FileReader reader;
-      reader = new FileReader(defaultConfig);
+      FileReader reader = new FileReader(defaultConfig);
       parser = jsonFactory.createJsonParser(reader);
     }
     parser.parseAndClose(builder);

--- a/src/main/java/com/google/firebase/FirebaseAppLifecycleListener.java
+++ b/src/main/java/com/google/firebase/FirebaseAppLifecycleListener.java
@@ -19,7 +19,7 @@ package com.google.firebase;
 /** 
  * A listener which gets notified when {@link com.google.firebase.FirebaseApp} gets deleted. 
  */
-// TODO: consider making it public in a future release.
+@Deprecated
 interface FirebaseAppLifecycleListener {
 
   /**

--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -224,6 +224,16 @@ public final class FirebaseOptions {
   }
 
   /**
+   * Creates a new Builder from the options object.
+   *
+   * <p>The new builder is not backed by this object's values, that is changes made to the new
+   * builder don't change the values of the origin object.
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  /**
    * Builder for constructing {@link FirebaseOptions}. 
    */
   public static final class Builder {
@@ -249,7 +259,12 @@ public final class FirebaseOptions {
     private int connectTimeout;
     private int readTimeout;
 
-    /** Constructs an empty builder. */
+    /**
+     * Constructs an empty builder.
+     *
+     * @deprecated Use {@link FirebaseOptions#builder()} instead.
+     */
+    @Deprecated
     public Builder() {}
 
     /**
@@ -257,7 +272,10 @@ public final class FirebaseOptions {
      *
      * <p>The new builder is not backed by this object's values, that is changes made to the new
      * builder don't change the values of the origin object.
+     *
+     * @deprecated Use {@link FirebaseOptions#toBuilder()} instead.
      */
+    @Deprecated
     public Builder(FirebaseOptions options) {
       databaseUrl = options.databaseUrl;
       storageBucket = options.storageBucket;

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -759,14 +759,6 @@ public class FirebaseAuth {
   }
 
   /**
-   * @deprecated Use {@link #setCustomUserClaims(String, Map)} instead.
-   */
-  public void setCustomClaims(@NonNull String uid,
-      @Nullable Map<String, Object> claims) throws FirebaseAuthException {
-    setCustomUserClaims(uid, claims);
-  }
-
-  /**
    * Similar to {@link #setCustomUserClaims(String, Map)} but performs the operation asynchronously.
    *
    * @param uid A user ID string.

--- a/src/main/java/com/google/firebase/database/core/JvmAuthTokenProvider.java
+++ b/src/main/java/com/google/firebase/database/core/JvmAuthTokenProvider.java
@@ -112,7 +112,7 @@ public class JvmAuthTokenProvider implements AuthTokenProvider {
     }
 
     @Override
-    public void onChanged(OAuth2Credentials credentials) throws IOException {
+    public void onChanged(OAuth2Credentials credentials) {
       // When this event fires, it is guaranteed that credentials.getAccessToken() will return a
       // valid OAuth2 token.
       final AccessToken accessToken = credentials.getAccessToken();

--- a/src/main/java/com/google/firebase/messaging/Notification.java
+++ b/src/main/java/com/google/firebase/messaging/Notification.java
@@ -33,33 +33,6 @@ public class Notification {
   @Key("image")
   private final String image;
 
-  /**
-   * Creates a new {@code Notification} using the given title and body.
-   *
-   * @param title Title of the notification.
-   * @param body Body of the notification.
-   *
-   * @deprecated Use {@link #Notification(Builder)} instead.
-   */
-  public Notification(String title, String body) {
-    this(title, body, null);
-  }
-
-  /**
-   * Creates a new {@code Notification} using the given title, body, and image.
-   *
-   * @param title Title of the notification.
-   * @param body Body of the notification.
-   * @param imageUrl URL of the image that is going to be displayed in the notification.
-   *
-   * @deprecated Use {@link #Notification(Builder)} instead.
-   */
-  public Notification(String title, String body, String imageUrl) {
-    this.title = title;
-    this.body = body;
-    this.image = imageUrl;
-  }
-
   private Notification(Builder builder) {
     this.title = builder.title;
     this.body = builder.body;

--- a/src/test/java/com/google/firebase/FirebaseAppTest.java
+++ b/src/test/java/com/google/firebase/FirebaseAppTest.java
@@ -35,13 +35,11 @@ import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.auth.oauth2.OAuth2Credentials.CredentialsChangedListener;
 import com.google.common.base.Defaults;
 import com.google.common.base.Strings;
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.firebase.FirebaseApp.TokenRefresher;
-import com.google.firebase.FirebaseOptions.Builder;
 import com.google.firebase.database.FirebaseDatabase;
 import com.google.firebase.testing.FirebaseAppRule;
 import com.google.firebase.testing.ServiceAccount;
@@ -74,7 +72,7 @@ import org.mockito.Mockito;
 public class FirebaseAppTest {
 
   private static final FirebaseOptions OPTIONS =
-      new FirebaseOptions.Builder()
+      FirebaseOptions.builder()
           .setCredentials(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
           .build();
 
@@ -110,7 +108,7 @@ public class FirebaseAppTest {
 
   @Test
   public void testGetProjectIdFromOptions() {
-    FirebaseOptions options = new FirebaseOptions.Builder(OPTIONS)
+    FirebaseOptions options = OPTIONS.toBuilder()
         .setProjectId("explicit-project-id")
         .build();
     FirebaseApp app = FirebaseApp.initializeApp(options, "myApp");
@@ -131,7 +129,7 @@ public class FirebaseAppTest {
     for (String variable : variables) {
       String gcloudProject = System.getenv(variable);
       TestUtils.setEnvironmentVariables(ImmutableMap.of(variable, "project-id-1"));
-      FirebaseOptions options = new FirebaseOptions.Builder()
+      FirebaseOptions options = FirebaseOptions.builder()
           .setCredentials(new MockGoogleCredentials())
           .build();
       try {
@@ -155,7 +153,7 @@ public class FirebaseAppTest {
 
     TestUtils.setEnvironmentVariables(ImmutableMap.of(
         "GCLOUD_PROJECT", "project-id-1", "GOOGLE_CLOUD_PROJECT", "project-id-2"));
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials())
         .build();
     try {
@@ -239,7 +237,7 @@ public class FirebaseAppTest {
   @Test
   public void testToString() throws IOException {
     FirebaseOptions options =
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
             .build();
     FirebaseApp app = FirebaseApp.initializeApp(options, "app");
@@ -461,14 +459,13 @@ public class FirebaseAppTest {
   @Test
   public void testAppWithAuthVariableOverrides() {
     Map<String, Object> authVariableOverrides = ImmutableMap.<String, Object>of("uid", "uid1");
-    FirebaseOptions options =
-        new FirebaseOptions.Builder(getMockCredentialOptions())
-            .setDatabaseAuthVariableOverride(authVariableOverrides)
-            .build();
+    FirebaseOptions options = getMockCredentialOptions().toBuilder()
+        .setDatabaseAuthVariableOverride(authVariableOverrides)
+        .build();
     FirebaseApp app = FirebaseApp.initializeApp(options, "testGetAppWithUid");
     assertEquals("uid1", app.getOptions().getDatabaseAuthVariableOverride().get("uid"));
     String token = TestOnlyImplFirebaseTrampolines.getToken(app, false);
-    Assert.assertTrue(!token.isEmpty());
+    Assert.assertFalse(token.isEmpty());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -599,7 +596,7 @@ public class FirebaseAppTest {
   }
 
   private static FirebaseOptions getMockCredentialOptions() {
-    return new Builder().setCredentials(new MockGoogleCredentials()).build();
+    return FirebaseOptions.builder().setCredentials(new MockGoogleCredentials()).build();
   }
 
   private static void invokePublicInstanceMethodWithDefaultValues(Object instance, Method method)

--- a/src/test/java/com/google/firebase/FirebaseOptionsTest.java
+++ b/src/test/java/com/google/firebase/FirebaseOptionsTest.java
@@ -48,7 +48,7 @@ public class FirebaseOptionsTest {
   private static final String FIREBASE_PROJECT_ID = "explicit-project-id";
 
   private static final FirebaseOptions ALL_VALUES_OPTIONS =
-      new FirebaseOptions.Builder()
+      FirebaseOptions.builder()
           .setDatabaseUrl(FIREBASE_DB_URL)
           .setStorageBucket(FIREBASE_STORAGE_BUCKET)
           .setProjectId(FIREBASE_PROJECT_ID)
@@ -77,7 +77,7 @@ public class FirebaseOptionsTest {
     NetHttpTransport httpTransport = new NetHttpTransport();
     FirestoreOptions firestoreOptions = FirestoreOptions.newBuilder().build();
     FirebaseOptions firebaseOptions =
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setDatabaseUrl(FIREBASE_DB_URL)
             .setStorageBucket(FIREBASE_STORAGE_BUCKET)
             .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
@@ -110,7 +110,7 @@ public class FirebaseOptionsTest {
   @Test
   public void createOptionsWithOnlyMandatoryValuesSet() throws IOException {
     FirebaseOptions firebaseOptions =
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
             .build();
     assertNotNull(firebaseOptions.getJsonFactory());
@@ -133,7 +133,7 @@ public class FirebaseOptionsTest {
   @Test
   public void createOptionsWithCustomFirebaseCredential() {
     FirebaseOptions firebaseOptions =
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setCredentials(new GoogleCredentials() {
               @Override
               public AccessToken refreshAccessToken() {
@@ -153,17 +153,17 @@ public class FirebaseOptionsTest {
 
   @Test(expected = NullPointerException.class)
   public void createOptionsWithCredentialMissing() {
-    new FirebaseOptions.Builder().build().getCredentials();
+    FirebaseOptions.builder().build().getCredentials();
   }
 
   @Test(expected = NullPointerException.class)
   public void createOptionsWithNullCredentials() {
-    new FirebaseOptions.Builder().setCredentials((GoogleCredentials) null).build();
+    FirebaseOptions.builder().setCredentials((GoogleCredentials) null).build();
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void createOptionsWithStorageBucketUrl() throws IOException {
-    new FirebaseOptions.Builder()
+    FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .setStorageBucket("gs://mock-storage-bucket")
         .build();
@@ -171,7 +171,7 @@ public class FirebaseOptionsTest {
 
   @Test(expected = NullPointerException.class)
   public void createOptionsWithNullThreadManager() {
-    new FirebaseOptions.Builder()
+    FirebaseOptions.builder()
         .setCredentials(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
         .setThreadManager(null)
         .build();
@@ -179,7 +179,7 @@ public class FirebaseOptionsTest {
 
   @Test
   public void checkToBuilderCreatesNewEquivalentInstance() {
-    FirebaseOptions allValuesOptionsCopy = new FirebaseOptions.Builder(ALL_VALUES_OPTIONS).build();
+    FirebaseOptions allValuesOptionsCopy = ALL_VALUES_OPTIONS.toBuilder().build();
     assertNotSame(ALL_VALUES_OPTIONS, allValuesOptionsCopy);
     assertEquals(ALL_VALUES_OPTIONS.getCredentials(), allValuesOptionsCopy.getCredentials());
     assertEquals(ALL_VALUES_OPTIONS.getDatabaseUrl(), allValuesOptionsCopy.getDatabaseUrl());
@@ -195,7 +195,7 @@ public class FirebaseOptionsTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void createOptionsWithInvalidConnectTimeout() {
-    new FirebaseOptions.Builder()
+    FirebaseOptions.builder()
         .setCredentials(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
         .setConnectTimeout(-1)
         .build();
@@ -203,7 +203,7 @@ public class FirebaseOptionsTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void createOptionsWithInvalidReadTimeout() {
-    new FirebaseOptions.Builder()
+    FirebaseOptions.builder()
         .setCredentials(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
         .setReadTimeout(-1)
         .build();
@@ -213,11 +213,11 @@ public class FirebaseOptionsTest {
   public void testNotEquals() throws IOException {
     GoogleCredentials credentials = GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream());
     FirebaseOptions options1 =
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setCredentials(credentials)
             .build();
     FirebaseOptions options2 =
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setCredentials(credentials)
             .setDatabaseUrl("https://test.firebaseio.com")
             .build();

--- a/src/test/java/com/google/firebase/ThreadManagerTest.java
+++ b/src/test/java/com/google/firebase/ThreadManagerTest.java
@@ -187,8 +187,7 @@ public class ThreadManagerTest {
   }
 
   @Test
-  public void testAppLifecycleWithMultipleServiceCalls()
-      throws ExecutionException, InterruptedException {
+  public void testAppLifecycleWithMultipleServiceCalls() {
     MockThreadManager threadManager = new MockThreadManager(executor);
 
     // Initializing an app should initialize the executor.
@@ -235,7 +234,7 @@ public class ThreadManagerTest {
   }
 
   private FirebaseOptions buildOptions(ThreadManager threadManager) {
-    return new FirebaseOptions.Builder()
+    return FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials())
         .setProjectId("mock-project-id")
         .setThreadManager(threadManager)
@@ -278,7 +277,7 @@ public class ThreadManagerTest {
     private final FirebaseApp app;
     private ExecutorService executor;
 
-    public Event(int type, @Nullable FirebaseApp app, @Nullable ExecutorService executor) {
+    Event(int type, @Nullable FirebaseApp app, @Nullable ExecutorService executor) {
       this.type = type;
       this.app = app;
       this.executor = executor;

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -405,7 +405,7 @@ public class FirebaseAuthIT {
     if (token == null) {
       token = credentials.refreshAccessToken();
     }
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.create(token))
         .setServiceAccountId(((ServiceAccountSigner) credentials).getAccount())
         .setProjectId(IntegrationTestUtils.getProjectId())

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
@@ -60,7 +60,7 @@ public class FirebaseAuthTest {
   private static final FirebaseAuthException testException = new FirebaseAuthException(
       ErrorCode.INVALID_ARGUMENT, "Test error message", null, null, null);
   private static final long VALID_SINCE = 1494364393;
-  public static final String TEST_USER = "testUser";
+  private static final String TEST_USER = "testUser";
 
   @After
   public void cleanup() {
@@ -539,7 +539,7 @@ public class FirebaseAuthTest {
     MockHttpTransport transport = new MockHttpTransport.Builder()
         .setLowLevelHttpResponse(new MockLowLevelHttpResponse().setContent(getUserResponse))
         .build();
-    return FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    return FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setHttpTransport(transport)
         .setProjectId("test-project-id")

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -83,7 +83,7 @@ public class FirebaseUserManagerTest {
 
   @Test
   public void testProjectIdRequired() {
-    FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp.initializeApp(FirebaseOptions.builder()
             .setCredentials(credentials)
             .build());
     FirebaseAuth auth = FirebaseAuth.getInstance();
@@ -682,7 +682,7 @@ public class FirebaseUserManagerTest {
   public void testTimeout() throws Exception {
     MockHttpTransport transport = new MultiRequestMockHttpTransport(ImmutableList.of(
         new MockLowLevelHttpResponse().setContent(TestUtils.loadResource("getUser.json"))));
-    FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(credentials)
         .setProjectId("test-project-id")
         .setHttpTransport(transport)
@@ -1279,7 +1279,7 @@ public class FirebaseUserManagerTest {
       mocks.add(new MockLowLevelHttpResponse().setContent(response));
     }
     MockHttpTransport transport = new MultiRequestMockHttpTransport(mocks);
-    FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(credentials)
         .setHttpTransport(transport)
         .setProjectId("test-project-id")
@@ -1295,7 +1295,7 @@ public class FirebaseUserManagerTest {
     final MockHttpTransport transport = new MockHttpTransport.Builder()
         .setLowLevelHttpResponse(response)
         .build();
-    final FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    final FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(credentials)
         .setProjectId("test-project-id")
         .setHttpTransport(transport)

--- a/src/test/java/com/google/firebase/auth/internal/CryptoSignersTest.java
+++ b/src/test/java/com/google/firebase/auth/internal/CryptoSignersTest.java
@@ -155,7 +155,7 @@ public class CryptoSignersTest {
         ImmutableList.of(
             new MockLowLevelHttpResponse().setContent("metadata-server@iam.gserviceaccount.com"),
             new MockLowLevelHttpResponse().setContent(response)));
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setHttpTransport(transport)
         .build();
@@ -185,7 +185,7 @@ public class CryptoSignersTest {
     MockHttpTransport transport = new MultiRequestMockHttpTransport(
         ImmutableList.of(
             new MockLowLevelHttpResponse().setContent(response)));
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setServiceAccountId("explicit-service-account@iam.gserviceaccount.com")
         .setCredentials(new MockGoogleCredentialsWithSigner("test-token"))
         .setHttpTransport(transport)
@@ -208,7 +208,7 @@ public class CryptoSignersTest {
   @Test
   public void testCredentialsWithSigner() throws Exception {
     // Should fall back to signing-enabled credential
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentialsWithSigner("test-token"))
         .build();
     FirebaseApp app = FirebaseApp.initializeApp(options, "customApp");

--- a/src/test/java/com/google/firebase/cloud/FirestoreClientTest.java
+++ b/src/test/java/com/google/firebase/cloud/FirestoreClientTest.java
@@ -12,7 +12,6 @@ import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOptions;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
-import com.google.firebase.FirebaseOptions.Builder;
 import com.google.firebase.ImplFirebaseTrampolines;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.auth.MockGoogleCredentials;
@@ -23,11 +22,10 @@ import org.junit.Test;
 
 public class FirestoreClientTest {
 
-  public static final FirestoreOptions FIRESTORE_OPTIONS = FirestoreOptions.newBuilder()
+  private static final FirestoreOptions FIRESTORE_OPTIONS = FirestoreOptions.newBuilder()
       // Setting credentials is not required (they get overridden by Admin SDK), but without
       // this Firestore logs an ugly warning during tests.
       .setCredentials(new MockGoogleCredentials("test-token"))
-      .setTimestampsInSnapshotsEnabled(true)
       .build();
 
   @After
@@ -37,7 +35,7 @@ public class FirestoreClientTest {
 
   @Test
   public void testExplicitProjectId() throws IOException {
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .setProjectId("explicit-project-id")
         .setFirestoreOptions(FIRESTORE_OPTIONS)
@@ -51,7 +49,7 @@ public class FirestoreClientTest {
 
   @Test
   public void testServiceAccountProjectId() throws IOException {
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .setFirestoreOptions(FIRESTORE_OPTIONS)
         .build());
@@ -64,7 +62,7 @@ public class FirestoreClientTest {
 
   @Test
   public void testFirestoreOptions() throws IOException {
-    FirebaseApp app = FirebaseApp.initializeApp(new Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .setProjectId("explicit-project-id")
         .setFirestoreOptions(FIRESTORE_OPTIONS)
@@ -80,11 +78,10 @@ public class FirestoreClientTest {
 
   @Test
   public void testFirestoreOptionsOverride() throws IOException {
-    FirebaseApp app = FirebaseApp.initializeApp(new Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .setProjectId("explicit-project-id")
         .setFirestoreOptions(FirestoreOptions.newBuilder()
-            .setTimestampsInSnapshotsEnabled(true)
             .setProjectId("other-project-id")
             .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
             .build())
@@ -104,7 +101,7 @@ public class FirestoreClientTest {
 
   @Test
   public void testAppDelete() throws IOException {
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .setProjectId("mock-project-id")
         .setFirestoreOptions(FIRESTORE_OPTIONS)

--- a/src/test/java/com/google/firebase/cloud/StorageClientTest.java
+++ b/src/test/java/com/google/firebase/cloud/StorageClientTest.java
@@ -41,7 +41,7 @@ public class StorageClientTest {
 
   @Test
   public void testInvalidConfiguration() throws IOException {
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .build());
     try {
@@ -54,7 +54,7 @@ public class StorageClientTest {
 
   @Test
   public void testInvalidBucketName() throws IOException {
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .setStorageBucket("mock-bucket-name")
         .build());
@@ -75,7 +75,7 @@ public class StorageClientTest {
 
   @Test
   public void testAppDelete() throws IOException {
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .setStorageBucket("mock-bucket-name")
         .build());
@@ -93,7 +93,7 @@ public class StorageClientTest {
 
   @Test
   public void testNonExistingBucket() throws IOException {
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .setStorageBucket("mock-bucket-name")
         .build());
@@ -115,7 +115,7 @@ public class StorageClientTest {
 
   @Test
   public void testBucket() throws IOException {
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
         .setStorageBucket("mock-bucket-name")
         .build());

--- a/src/test/java/com/google/firebase/database/DataSnapshotTest.java
+++ b/src/test/java/com/google/firebase/database/DataSnapshotTest.java
@@ -51,7 +51,7 @@ public class DataSnapshotTest {
   @BeforeClass
   public static void setUpClass() throws IOException {
     testApp = FirebaseApp.initializeApp(
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
             .setDatabaseUrl("https://admin-java-sdk.firebaseio.com")
             .build());

--- a/src/test/java/com/google/firebase/database/DatabaseReferenceTest.java
+++ b/src/test/java/com/google/firebase/database/DatabaseReferenceTest.java
@@ -64,7 +64,7 @@ public class DatabaseReferenceTest {
   @BeforeClass
   public static void setUpClass() throws IOException {
     testApp = FirebaseApp.initializeApp(
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
             .setDatabaseUrl(DB_URL)
             .build());

--- a/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
+++ b/src/test/java/com/google/firebase/database/FirebaseDatabaseTest.java
@@ -39,12 +39,12 @@ import org.junit.Test;
 public class FirebaseDatabaseTest {
   
   private static final FirebaseOptions firebaseOptions =
-      new FirebaseOptions.Builder()
+      FirebaseOptions.builder()
           .setCredentials(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
           .setDatabaseUrl("https://firebase-db-test.firebaseio.com")
           .build();
   private static final FirebaseOptions firebaseOptionsWithoutDatabaseUrl =
-      new FirebaseOptions.Builder()
+      FirebaseOptions.builder()
           .setCredentials(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
           .build();
 

--- a/src/test/java/com/google/firebase/database/core/JvmAuthTokenProviderTest.java
+++ b/src/test/java/com/google/firebase/database/core/JvmAuthTokenProviderTest.java
@@ -67,7 +67,7 @@ public class JvmAuthTokenProviderTest {
     credentials.refresh();
     assertEquals(1, refreshDetector.count);
 
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(credentials)
         .build();
     FirebaseApp app = FirebaseApp.initializeApp(options);
@@ -87,7 +87,7 @@ public class JvmAuthTokenProviderTest {
     credentials.refresh();
     assertEquals(1, refreshDetector.count);
 
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(credentials)
         .build();
     FirebaseApp app = FirebaseApp.initializeApp(options);
@@ -103,7 +103,7 @@ public class JvmAuthTokenProviderTest {
   public void testGetTokenWithAuthOverrides() throws InterruptedException, IOException {
     MockGoogleCredentials credentials = new MockGoogleCredentials("mock-token");
     Map<String, Object> auth = ImmutableMap.<String, Object>of("uid", "test");
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(credentials)
         .setDatabaseAuthVariableOverride(auth)
         .build();
@@ -119,11 +119,11 @@ public class JvmAuthTokenProviderTest {
   public void testGetTokenError() throws InterruptedException {
     MockGoogleCredentials credentials = new MockGoogleCredentials("mock-token") {
       @Override
-      public AccessToken refreshAccessToken() throws IOException {
+      public AccessToken refreshAccessToken() {
         throw new RuntimeException("Test error");
       }
     };
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(credentials)
         .build();
     FirebaseApp app = FirebaseApp.initializeApp(options);
@@ -139,13 +139,13 @@ public class JvmAuthTokenProviderTest {
     final AtomicInteger counter = new AtomicInteger(0);
     MockGoogleCredentials credentials = new MockGoogleCredentials() {
       @Override
-      public AccessToken refreshAccessToken() throws IOException {
+      public AccessToken refreshAccessToken() {
         Date expiry = new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1));
         return new AccessToken("token-" + counter.getAndIncrement(), expiry);
       }
     };
 
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(credentials)
         .build();
     FirebaseApp app = FirebaseApp.initializeApp(options);
@@ -172,7 +172,7 @@ public class JvmAuthTokenProviderTest {
   @Test
   public void testTokenChangeListenerThread() throws InterruptedException, IOException {
     MockGoogleCredentials credentials = new MockGoogleCredentials();
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(credentials)
         .build();
     FirebaseApp app = FirebaseApp.initializeApp(options);
@@ -210,12 +210,12 @@ public class JvmAuthTokenProviderTest {
     final Semaphore semaphore = new Semaphore(0);
     credentials.addChangeListener(new OAuth2Credentials.CredentialsChangedListener() {
       @Override
-      public void onChanged(OAuth2Credentials credentials) throws IOException {
+      public void onChanged(OAuth2Credentials credentials) {
         semaphore.release();
       }
     });
 
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(credentials)
         .build();
     FirebaseApp app = FirebaseApp.initializeApp(options);
@@ -234,7 +234,7 @@ public class JvmAuthTokenProviderTest {
 
     assertEquals(expectedToken, map.get("token"));
 
-    Map<String, Object> auth = (Map)map.get("auth");
+    Map auth = (Map) map.get("auth");
     DeepEquals.deepEquals(expectedAuth, auth);
   }
 
@@ -271,7 +271,7 @@ public class JvmAuthTokenProviderTest {
     private int count = 0;
 
     @Override
-    public void onChanged(OAuth2Credentials credentials) throws IOException {
+    public void onChanged(OAuth2Credentials credentials) {
       count++;
     }
   }

--- a/src/test/java/com/google/firebase/database/core/JvmPlatformTest.java
+++ b/src/test/java/com/google/firebase/database/core/JvmPlatformTest.java
@@ -56,7 +56,7 @@ public class JvmPlatformTest {
         return Executors.defaultThreadFactory();
       }
     };
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
         .setThreadManager(threadManager)
         .build();
@@ -80,7 +80,7 @@ public class JvmPlatformTest {
 
   @Test
   public void userAgentHasCorrectParts() {
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
         .build();
     FirebaseApp app = FirebaseApp.initializeApp(options, "userAgentApp");

--- a/src/test/java/com/google/firebase/database/core/RepoTest.java
+++ b/src/test/java/com/google/firebase/database/core/RepoTest.java
@@ -61,7 +61,7 @@ public class RepoTest {
   @BeforeClass
   public static void setUpClass() throws IOException {
     FirebaseApp testApp = FirebaseApp.initializeApp(
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
             .setDatabaseUrl("https://admin-java-sdk.firebaseio.com")
             .build());

--- a/src/test/java/com/google/firebase/database/core/SyncPointTest.java
+++ b/src/test/java/com/google/firebase/database/core/SyncPointTest.java
@@ -68,7 +68,7 @@ public class SyncPointTest {
   @BeforeClass
   public static void setUpClass() throws IOException {
     testApp = FirebaseApp.initializeApp(
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
             .setDatabaseUrl("https://admin-java-sdk.firebaseio.com")
             .build());

--- a/src/test/java/com/google/firebase/database/core/persistence/DefaultPersistenceManagerTest.java
+++ b/src/test/java/com/google/firebase/database/core/persistence/DefaultPersistenceManagerTest.java
@@ -56,7 +56,7 @@ public class DefaultPersistenceManagerTest {
   @BeforeClass
   public static void setUpClass() throws IOException {
     testApp = FirebaseApp.initializeApp(
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
             .setDatabaseUrl("https://admin-java-sdk.firebaseio.com")
             .build());

--- a/src/test/java/com/google/firebase/database/core/persistence/RandomPersistenceTest.java
+++ b/src/test/java/com/google/firebase/database/core/persistence/RandomPersistenceTest.java
@@ -73,7 +73,7 @@ public class RandomPersistenceTest {
   @BeforeClass
   public static void setUpClass() throws IOException {
     testApp = FirebaseApp.initializeApp(
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
             .setDatabaseUrl("https://admin-java-sdk.firebaseio.com")
             .build());

--- a/src/test/java/com/google/firebase/database/integration/FirebaseDatabaseAuthTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/FirebaseDatabaseAuthTestIT.java
@@ -78,7 +78,7 @@ public class FirebaseDatabaseAuthTestIT {
   @Test
   public void testAuthWithInvalidCertificateCredential() throws InterruptedException, IOException {
     FirebaseOptions options =
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setDatabaseUrl(IntegrationTestUtils.getDatabaseUrl())
             .setCredentials(GoogleCredentials.fromStream(ServiceAccount.NONE.asStream()))
             .build();
@@ -94,10 +94,9 @@ public class FirebaseDatabaseAuthTestIT {
         "uid", "test",
         "custom", "secret"
     );
-    FirebaseOptions options =
-        new FirebaseOptions.Builder(masterApp.getOptions())
-            .setDatabaseAuthVariableOverride(authVariableOverrides)
-            .build();
+    FirebaseOptions options = masterApp.getOptions().toBuilder()
+        .setDatabaseAuthVariableOverride(authVariableOverrides)
+        .build();
     FirebaseApp testUidApp = FirebaseApp.initializeApp(options, "testGetAppWithUid");
     FirebaseDatabase masterDb = FirebaseDatabase.getInstance(masterApp);
     FirebaseDatabase testAuthOverridesDb = FirebaseDatabase.getInstance(testUidApp);
@@ -114,10 +113,9 @@ public class FirebaseDatabaseAuthTestIT {
   
   @Test
   public void testDatabaseAuthVariablesNoAuthorization() throws InterruptedException {
-    FirebaseOptions options =
-        new FirebaseOptions.Builder(masterApp.getOptions())
-            .setDatabaseAuthVariableOverride(null)
-            .build();
+    FirebaseOptions options = masterApp.getOptions().toBuilder()
+        .setDatabaseAuthVariableOverride(null)
+        .build();
     FirebaseApp testUidApp =
         FirebaseApp.initializeApp(options, "testServiceAccountDatabaseWithNoAuth");
 

--- a/src/test/java/com/google/firebase/database/integration/FirebaseDatabaseTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/FirebaseDatabaseTestIT.java
@@ -255,7 +255,7 @@ public class FirebaseDatabaseTestIT {
   
   private static FirebaseApp appWithDbUrl(String dbUrl, String name) {
     try {
-      FirebaseOptions options = new FirebaseOptions.Builder()
+      FirebaseOptions options = FirebaseOptions.builder()
           .setDatabaseUrl(dbUrl)
           .setCredentials(GoogleCredentials.fromStream(
               IntegrationTestUtils.getServiceAccountCertificate()))
@@ -268,7 +268,7 @@ public class FirebaseDatabaseTestIT {
   
   private static FirebaseApp appWithoutDbUrl(String name) {
     try {
-      FirebaseOptions options = new FirebaseOptions.Builder()
+      FirebaseOptions options = FirebaseOptions.builder()
           .setCredentials(GoogleCredentials.fromStream(
               IntegrationTestUtils.getServiceAccountCertificate()))
           .build();

--- a/src/test/java/com/google/firebase/database/integration/RulesTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/RulesTestIT.java
@@ -103,7 +103,7 @@ public class RulesTestIT {
   public static void setUpClass() throws IOException {
     // Init app with non-admin privileges
     Map<String, Object> auth = MapBuilder.of("uid", "my-service-worker");
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(
             IntegrationTestUtils.getServiceAccountCertificate()))
         .setDatabaseUrl(IntegrationTestUtils.getDatabaseUrl())

--- a/src/test/java/com/google/firebase/database/integration/ShutdownExample.java
+++ b/src/test/java/com/google/firebase/database/integration/ShutdownExample.java
@@ -32,7 +32,7 @@ public class ShutdownExample {
 
     FirebaseApp app =
         FirebaseApp.initializeApp(
-            new FirebaseOptions.Builder()
+            FirebaseOptions.builder()
                 .setDatabaseUrl("https://admin-java-sdk.firebaseio.com")
                 .build());
 

--- a/src/test/java/com/google/firebase/iid/FirebaseInstanceIdTest.java
+++ b/src/test/java/com/google/firebase/iid/FirebaseInstanceIdTest.java
@@ -76,7 +76,7 @@ public class FirebaseInstanceIdTest {
 
   @Test
   public void testNoProjectId() {
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .build();
     FirebaseApp.initializeApp(options);
@@ -90,7 +90,7 @@ public class FirebaseInstanceIdTest {
 
   @Test
   public void testInvalidInstanceId() {
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setProjectId("test-project")
         .build();
@@ -122,7 +122,7 @@ public class FirebaseInstanceIdTest {
     MockHttpTransport transport = new MockHttpTransport.Builder()
         .setLowLevelHttpResponse(response)
         .build();
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setProjectId("test-project")
         .setHttpTransport(transport)
@@ -168,7 +168,7 @@ public class FirebaseInstanceIdTest {
     MockHttpTransport transport = new MockHttpTransport.Builder()
         .setLowLevelHttpResponse(response)
         .build();
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setProjectId("test-project")
         .setHttpTransport(transport)
@@ -205,7 +205,7 @@ public class FirebaseInstanceIdTest {
   @Test
   public void testDeleteInstanceIdTransportError() throws Exception {
     HttpTransport transport = TestUtils.createFaultyHttpTransport();
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setProjectId("test-project")
         .setHttpTransport(transport)
@@ -235,7 +235,7 @@ public class FirebaseInstanceIdTest {
     MockHttpTransport transport = new MockHttpTransport.Builder()
         .setLowLevelHttpResponse(response)
         .build();
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setProjectId("test-project")
         .setHttpTransport(transport)

--- a/src/test/java/com/google/firebase/internal/CallableOperationTest.java
+++ b/src/test/java/com/google/firebase/internal/CallableOperationTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.fail;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
-import com.google.firebase.FirebaseOptions.Builder;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.auth.MockGoogleCredentials;
 import com.google.firebase.internal.FirebaseThreadManagers.GlobalThreadManager;
@@ -38,7 +37,7 @@ import org.junit.Test;
 public class CallableOperationTest {
 
   private static final String TEST_FIREBASE_THREAD = "test-firebase-thread";
-  private static final FirebaseOptions OPTIONS = new Builder()
+  private static final FirebaseOptions OPTIONS = FirebaseOptions.builder()
       .setCredentials(new MockGoogleCredentials())
       .setThreadManager(new MockThreadManager())
       .build();

--- a/src/test/java/com/google/firebase/internal/ErrorHandlingHttpClientTest.java
+++ b/src/test/java/com/google/firebase/internal/ErrorHandlingHttpClientTest.java
@@ -204,7 +204,7 @@ public class ErrorHandlingHttpClientTest {
         .setLowLevelHttpRequest(request)
         .build();
 
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("token"))
         .setHttpTransport(transport)
         .build());
@@ -240,7 +240,7 @@ public class ErrorHandlingHttpClientTest {
         .setLowLevelHttpRequest(request)
         .build();
 
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials() {
           @Override
           public AccessToken refreshAccessToken() throws IOException {

--- a/src/test/java/com/google/firebase/internal/FirebaseAppStoreTest.java
+++ b/src/test/java/com/google/firebase/internal/FirebaseAppStoreTest.java
@@ -16,7 +16,7 @@
 
 package com.google.firebase.internal;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
@@ -34,7 +34,7 @@ public class FirebaseAppStoreTest {
   private static final String FIREBASE_DB_URL = "https://mock-project.firebaseio.com";
 
   private static final FirebaseOptions ALL_VALUES_OPTIONS =
-      new FirebaseOptions.Builder()
+      FirebaseOptions.builder()
           .setDatabaseUrl(FIREBASE_DB_URL)
           .setCredentials(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
           .build();
@@ -55,7 +55,7 @@ public class FirebaseAppStoreTest {
     FirebaseApp.initializeApp(ALL_VALUES_OPTIONS, name);
     TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
     FirebaseOptions options =
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
             .build();
     FirebaseApp.initializeApp(options, name);
@@ -66,7 +66,7 @@ public class FirebaseAppStoreTest {
     FirebaseApp.initializeApp(ALL_VALUES_OPTIONS);
     TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
     FirebaseOptions options =
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setCredentials(GoogleCredentials.fromStream(ServiceAccount.EDITOR.asStream()))
             .build();
     FirebaseApp.initializeApp(options);
@@ -78,6 +78,6 @@ public class FirebaseAppStoreTest {
     FirebaseApp.initializeApp(ALL_VALUES_OPTIONS, name);
     TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
     FirebaseAppStore appStore = FirebaseAppStore.getInstance();
-    assertTrue(!appStore.getAllPersistedAppNames().contains(name));
+    assertFalse(appStore.getAllPersistedAppNames().contains(name));
   }
 }

--- a/src/test/java/com/google/firebase/internal/FirebaseRequestInitializerTest.java
+++ b/src/test/java/com/google/firebase/internal/FirebaseRequestInitializerTest.java
@@ -46,7 +46,7 @@ public class FirebaseRequestInitializerTest {
 
   @Test
   public void testDefaultSettings() throws Exception {
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("token"))
         .build());
     HttpRequest request = TestUtils.createRequest();
@@ -65,7 +65,7 @@ public class FirebaseRequestInitializerTest {
 
   @Test
   public void testExplicitTimeouts() throws Exception {
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("token"))
         .setConnectTimeout(CONNECT_TIMEOUT_MILLIS)
         .setReadTimeout(READ_TIMEOUT_MILLIS)
@@ -85,7 +85,7 @@ public class FirebaseRequestInitializerTest {
 
   @Test
   public void testRetryConfig() throws Exception {
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("token"))
         .build());
     RetryConfig retryConfig = RetryConfig.builder()
@@ -106,7 +106,7 @@ public class FirebaseRequestInitializerTest {
 
   @Test
   public void testRetryConfigWithIOExceptionHandling() throws Exception {
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("token"))
         .build());
     RetryConfig retryConfig = RetryConfig.builder()
@@ -128,7 +128,7 @@ public class FirebaseRequestInitializerTest {
 
   @Test
   public void testCredentialsRetryHandler() throws Exception {
-    FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("token"))
         .build());
     RetryConfig retryConfig = RetryConfig.builder()

--- a/src/test/java/com/google/firebase/internal/FirebaseThreadManagersTest.java
+++ b/src/test/java/com/google/firebase/internal/FirebaseThreadManagersTest.java
@@ -49,7 +49,7 @@ public class FirebaseThreadManagersTest {
   @Test
   public void testGlobalThreadManager() {
     MockThreadManager threadManager = new MockThreadManager();
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials())
         .setThreadManager(threadManager)
         .build();
@@ -74,7 +74,7 @@ public class FirebaseThreadManagersTest {
   @Test
   public void testGlobalThreadManagerWithMultipleApps() {
     MockThreadManager threadManager = new MockThreadManager();
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials())
         .build();
     FirebaseApp defaultApp = FirebaseApp.initializeApp(options);
@@ -99,7 +99,7 @@ public class FirebaseThreadManagersTest {
   @Test
   public void testGlobalThreadManagerReInit() {
     MockThreadManager threadManager = new MockThreadManager();
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials())
         .setThreadManager(threadManager)
         .build();
@@ -125,7 +125,7 @@ public class FirebaseThreadManagersTest {
 
   @Test
   public void testDefaultThreadManager() throws Exception {
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials())
         .build();
     FirebaseApp defaultApp = FirebaseApp.initializeApp(options);

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
@@ -523,7 +523,7 @@ public class FirebaseMessagingClientImplTest {
 
   @Test
   public void testFromApp() throws IOException {
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setProjectId("test-project")
         .build();

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingIT.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingIT.java
@@ -101,17 +101,26 @@ public class FirebaseMessagingIT {
     List<Message> messages = new ArrayList<>();
     messages.add(
         Message.builder()
-          .setNotification(new Notification("Title", "Body"))
+          .setNotification(Notification.builder()
+              .setTitle("Title")
+              .setBody("Body")
+              .build())
           .setTopic("foo-bar")
           .build());
     messages.add(
         Message.builder()
-          .setNotification(new Notification("Title", "Body"))
+          .setNotification(Notification.builder()
+              .setTitle("Title")
+              .setBody("Body")
+              .build())
           .setTopic("foo-bar")
           .build());
     messages.add(
         Message.builder()
-          .setNotification(new Notification("Title", "Body"))
+          .setNotification(Notification.builder()
+              .setTitle("Title")
+              .setBody("Body")
+              .build())
           .setToken("not-a-token")
           .build());
 
@@ -163,7 +172,10 @@ public class FirebaseMessagingIT {
   @Test
   public void testSendMulticast() throws Exception {
     MulticastMessage multicastMessage = MulticastMessage.builder()
-        .setNotification(new Notification("Title", "Body"))
+        .setNotification(Notification.builder()
+            .setTitle("Title")
+            .setBody("Body")
+            .build())
         .addToken("not-a-token")
         .addToken("also-not-a-token")
         .build();

--- a/src/test/java/com/google/firebase/messaging/InstanceIdClientImplTest.java
+++ b/src/test/java/com/google/firebase/messaging/InstanceIdClientImplTest.java
@@ -368,7 +368,7 @@ public class InstanceIdClientImplTest {
     MockHttpTransport transport = new MockHttpTransport.Builder()
         .setLowLevelHttpResponse(response)
         .build();
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setHttpTransport(transport)
         .setProjectId("test-project")

--- a/src/test/java/com/google/firebase/messaging/MessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MessageTest.java
@@ -29,11 +29,8 @@ import com.google.firebase.messaging.AndroidConfig.Priority;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
@@ -94,7 +91,10 @@ public class MessageTest {
   @Test
   public void testNotificationMessageDeprecatedConstructor() throws IOException {
     Message message = Message.builder()
-        .setNotification(new Notification("title", "body"))
+        .setNotification(Notification.builder()
+            .setTitle("title")
+            .setBody("body")
+            .build())
         .setTopic("test-topic")
         .build();
     Map<String, String> data = ImmutableMap.of("title", "title", "body", "body");
@@ -729,7 +729,11 @@ public class MessageTest {
   @Test
   public void testImageInNotificationDeprecatedConstructor() throws IOException {
     Message message = Message.builder()
-        .setNotification(new Notification("title", "body", TEST_IMAGE_URL))
+        .setNotification(Notification.builder()
+            .setTitle("title")
+            .setBody("body")
+            .setImage(TEST_IMAGE_URL)
+            .build())
         .setTopic("test-topic")
         .build();
     Map<String, String> data = ImmutableMap.of(
@@ -755,7 +759,11 @@ public class MessageTest {
   @Test
   public void testImageInAndroidNotification() throws IOException {
     Message message = Message.builder()
-        .setNotification(new Notification("title", "body", TEST_IMAGE_URL))
+        .setNotification(Notification.builder()
+            .setTitle("title")
+            .setBody("body")
+            .setImage(TEST_IMAGE_URL)
+            .build())
         .setAndroidConfig(AndroidConfig.builder()
             .setNotification(AndroidNotification.builder()
                 .setTitle("android-title")
@@ -785,7 +793,11 @@ public class MessageTest {
   public void testImageInApnsNotification() throws IOException {
     Message message = Message.builder()
         .setTopic("test-topic")
-        .setNotification(new Notification("title", "body", TEST_IMAGE_URL))
+        .setNotification(Notification.builder()
+            .setTitle("title")
+            .setBody("body")
+            .setImage(TEST_IMAGE_URL)
+            .build())
         .setApnsConfig(
             ApnsConfig.builder().setAps(Aps.builder().build())
                 .setFcmOptions(ApnsFcmOptions.builder().setImage(TEST_IMAGE_URL_APNS).build())
@@ -812,7 +824,7 @@ public class MessageTest {
   }
 
   @Test
-  public void testInvalidColorInAndroidNotificationLightSettings() throws IOException {
+  public void testInvalidColorInAndroidNotificationLightSettings() {
     try {
       LightSettings.Builder lightSettingsBuilder = LightSettings.builder()
                       .setColorFromString("#01020K")
@@ -830,7 +842,10 @@ public class MessageTest {
   public void testExtendedAndroidNotificationParameters() throws IOException {
     long[] vibrateTimings = {1000L, 1001L};
     Message message = Message.builder()
-        .setNotification(new Notification("title", "body"))
+        .setNotification(Notification.builder()
+            .setTitle("title")
+            .setBody("body")
+            .build())
         .setAndroidConfig(AndroidConfig.builder()
             .setNotification(AndroidNotification.builder()
                 .setTitle("android-title")

--- a/src/test/java/com/google/firebase/messaging/MulticastMessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MulticastMessageTest.java
@@ -38,7 +38,10 @@ public class MulticastMessageTest {
   private static final WebpushConfig WEBPUSH = WebpushConfig.builder()
       .putData("key", "value")
       .build();
-  private static final Notification NOTIFICATION = new Notification("title", "body");
+  private static final Notification NOTIFICATION = Notification.builder()
+      .setTitle("title")
+      .setBody("body")
+      .build();
 
   @Test
   public void testMulticastMessage() {

--- a/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
+++ b/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImplTest.java
@@ -1043,7 +1043,7 @@ public class FirebaseProjectManagementServiceImplTest {
     List<MockLowLevelHttpResponse> mockResponses = ImmutableList.of(
         new MockLowLevelHttpResponse().setContent("{}"));
     MockHttpTransport transport = new MultiRequestMockHttpTransport(mockResponses);
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setProjectId(PROJECT_ID)
         .setHttpTransport(transport)
@@ -1066,7 +1066,7 @@ public class FirebaseProjectManagementServiceImplTest {
         firstRpcResponse.setStatusCode(503).setContent("{}"),
         new MockLowLevelHttpResponse().setContent("{}"));
     MockHttpTransport transport = new MultiRequestMockHttpTransport(mockResponses);
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setProjectId(PROJECT_ID)
         .setHttpTransport(transport)
@@ -1094,7 +1094,7 @@ public class FirebaseProjectManagementServiceImplTest {
       List<MockLowLevelHttpResponse> mockResponses,
       MultiRequestTestResponseInterceptor interceptor) {
     MockHttpTransport transport = new MultiRequestMockHttpTransport(mockResponses);
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setProjectId(PROJECT_ID)
         .setHttpTransport(transport)
@@ -1108,7 +1108,7 @@ public class FirebaseProjectManagementServiceImplTest {
   }
 
   private static FirebaseProjectManagementServiceImpl initServiceImplWithFaultyTransport() {
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setProjectId(PROJECT_ID)
         .setHttpTransport(TestUtils.createFaultyHttpTransport())

--- a/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementTest.java
+++ b/src/test/java/com/google/firebase/projectmanagement/FirebaseProjectManagementTest.java
@@ -68,7 +68,7 @@ public class FirebaseProjectManagementTest {
 
   @BeforeClass
   public static void setUpClass() {
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(new MockGoogleCredentials("test-token"))
         .setProjectId(TEST_PROJECT_ID)
         .build();

--- a/src/test/java/com/google/firebase/snippets/FirebaseAppSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseAppSnippets.java
@@ -33,7 +33,7 @@ public class FirebaseAppSnippets {
     // [START initialize_sdk_with_service_account]
     FileInputStream serviceAccount = new FileInputStream("path/to/serviceAccountKey.json");
 
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(serviceAccount))
         .setDatabaseUrl("https://<DATABASE_NAME>.firebaseio.com/")
         .build();
@@ -44,7 +44,7 @@ public class FirebaseAppSnippets {
 
   public void initializeWithDefaultCredentials() throws IOException {
     // [START initialize_sdk_with_application_default]
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.getApplicationDefault())
         .setDatabaseUrl("https://<DATABASE_NAME>.firebaseio.com/")
         .build();
@@ -57,7 +57,7 @@ public class FirebaseAppSnippets {
     // [START initialize_sdk_with_refresh_token]
     FileInputStream refreshToken = new FileInputStream("path/to/refreshToken.json");
 
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(refreshToken))
         .setDatabaseUrl("https://<DATABASE_NAME>.firebaseio.com/")
         .build();
@@ -73,7 +73,7 @@ public class FirebaseAppSnippets {
   }
 
   public void initializeDefaultApp() throws IOException {
-    FirebaseOptions defaultOptions = new FirebaseOptions.Builder()
+    FirebaseOptions defaultOptions = FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.getApplicationDefault())
         .build();
 
@@ -94,10 +94,10 @@ public class FirebaseAppSnippets {
   }
 
   public void initializeCustomApp() throws Exception {
-    FirebaseOptions defaultOptions = new FirebaseOptions.Builder()
+    FirebaseOptions defaultOptions = FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.getApplicationDefault())
         .build();
-    FirebaseOptions otherAppConfig = new FirebaseOptions.Builder()
+    FirebaseOptions otherAppConfig = FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.getApplicationDefault())
         .build();
 
@@ -123,7 +123,7 @@ public class FirebaseAppSnippets {
 
   public void initializeWithServiceAccountId() throws IOException {
     // [START initialize_sdk_with_service_account_id]
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.getApplicationDefault())
         .setServiceAccountId("my-client-id@my-project-id.iam.gserviceaccount.com")
         .build();

--- a/src/test/java/com/google/firebase/snippets/FirebaseDatabaseSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseDatabaseSnippets.java
@@ -677,7 +677,7 @@ public class FirebaseDatabaseSnippets {
     FileInputStream serviceAccount = new FileInputStream("path/to/serviceAccount.json");
 
     // Initialize the app with a service account, granting admin privileges
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(serviceAccount))
         .setDatabaseUrl("https://<databaseName>.firebaseio.com")
         .build();

--- a/src/test/java/com/google/firebase/snippets/FirebaseMessagingSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseMessagingSnippets.java
@@ -88,9 +88,10 @@ public class FirebaseMessagingSnippets {
 
     // See documentation on defining a message payload.
     Message message = Message.builder()
-        .setNotification(new Notification(
-            "$GOOG up 1.43% on the day",
-            "$GOOG gained 11.80 points to close at 835.67, up 1.43% on the day."))
+        .setNotification(Notification.builder()
+            .setTitle("$GOOG up 1.43% on the day")
+            .setBody("$GOOG gained 11.80 points to close at 835.67, up 1.43% on the day.")
+            .build())
         .setCondition(condition)
         .build();
 
@@ -125,12 +126,18 @@ public class FirebaseMessagingSnippets {
     // Create a list containing up to 500 messages.
     List<Message> messages = Arrays.asList(
         Message.builder()
-            .setNotification(new Notification("Price drop", "5% off all electronics"))
+            .setNotification(Notification.builder()
+                .setTitle("Price drop")
+                .setBody("5% off all electronics")
+                .build())
             .setToken(registrationToken)
             .build(),
         // ...
         Message.builder()
-            .setNotification(new Notification("Price drop", "2% off all books"))
+            .setNotification(Notification.builder()
+                .setTitle("Price drop")
+                .setBody("2% off all books")
+                .build())
             .setTopic("readers-club")
             .build()
     );
@@ -251,9 +258,10 @@ public class FirebaseMessagingSnippets {
   public Message allPlatformsMessage() {
     // [START multi_platforms_message]
     Message message = Message.builder()
-        .setNotification(new Notification(
-            "$GOOG up 1.43% on the day",
-            "$GOOG gained 11.80 points to close at 835.67, up 1.43% on the day."))
+        .setNotification(Notification.builder()
+            .setTitle("$GOOG up 1.43% on the day")
+            .setBody("$GOOG gained 11.80 points to close at 835.67, up 1.43% on the day.")
+            .build())
         .setAndroidConfig(AndroidConfig.builder()
             .setTtl(3600 * 1000)
             .setNotification(AndroidNotification.builder()

--- a/src/test/java/com/google/firebase/snippets/FirebaseStorageSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseStorageSnippets.java
@@ -33,7 +33,7 @@ public class FirebaseStorageSnippets {
     // [START init_admin_sdk_for_storage]
     FileInputStream serviceAccount = new FileInputStream("path/to/serviceAccountKey.json");
 
-    FirebaseOptions options = new FirebaseOptions.Builder()
+    FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(serviceAccount))
         .setStorageBucket("<BUCKET_NAME>.appspot.com")
         .build();

--- a/src/test/java/com/google/firebase/testing/IntegrationTestUtils.java
+++ b/src/test/java/com/google/firebase/testing/IntegrationTestUtils.java
@@ -121,7 +121,7 @@ public class IntegrationTestUtils {
 
   public static FirebaseApp initApp(String name) {
     FirebaseOptions options =
-        new FirebaseOptions.Builder()
+        FirebaseOptions.builder()
             .setDatabaseUrl(getDatabaseUrl())
             .setCredentials(TestUtils.getCertCredential(getServiceAccountCertificate()))
             .build();


### PR DESCRIPTION
* Removed the following deprecated APIs:
  - `Notification` constructor
  - `FirebaseAuth.setCustomClaims()`
* Deprecated the following APIs:
  - `FirebaseOption.Builder` constructors
  - `FirebaseAppLifecycleListener` -- not used for anything at the moment
* Added the following new APIs:
  - `FirebaseOptions.toBuilder()` to replace one of the deprecated constructors.