### PR TITLE
Add OIDC Auth provider config class

### DIFF
--- a/src/main/java/com/google/firebase/auth/AuthProviderConfig.java
+++ b/src/main/java/com/google/firebase/auth/AuthProviderConfig.java
@@ -84,7 +84,7 @@ public abstract class AuthProviderConfig {
     }
 
     /**
-     * Sets whether to allow the user to sign in with the provider..
+     * Sets whether to allow the user to sign in with the provider.
      *
      * @param enabled a boolean indicating whether the user can sign in with the provider
      */

--- a/src/main/java/com/google/firebase/auth/AuthProviderConfig.java
+++ b/src/main/java/com/google/firebase/auth/AuthProviderConfig.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.auth;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.api.client.util.Key;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The base class for Auth providers.
+ */
+public abstract class AuthProviderConfig {
+
+  @Key("name")
+  private String providerId;
+
+  @Key("displayName")
+  private String displayName;
+
+  @Key("enabled")
+  private boolean enabled;
+
+  public String getProviderId() {
+    return providerId;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  /**
+   * A base specification class for creating a new provider.
+   *
+   * <p>Set the initial attributes of the new provider by calling various setter methods available
+   * in this class.
+   */
+  public abstract static class CreateRequest {
+
+    final Map<String,Object> properties = new HashMap<>();
+
+    /**
+     * Sets the ID for the new provider.
+     *
+     * @param providerId a non-null, non-empty provider ID string.
+     */
+    public CreateRequest setProviderId(String providerId) {
+      checkArgument(
+          !Strings.isNullOrEmpty(providerId), "provider ID name must not be null or empty");
+      properties.put("name", providerId);
+      return this;
+    }
+
+    /**
+     * Sets the display name for the new provider.
+     *
+     * @param displayName a non-null, non-empty display name string.
+     */
+    public CreateRequest setDisplayName(String displayName) {
+      checkArgument(!Strings.isNullOrEmpty(displayName), "display name must not be null or empty");
+      properties.put("displayName", displayName);
+      return this;
+    }
+
+    /**
+     * Sets whether to allow the user to sign in with the provider..
+     *
+     * @param enabled a boolean indicating whether the user can sign in with the provider
+     */
+    public CreateRequest setEnabled(boolean enabled) {
+      properties.put("enabled", enabled);
+      return this;
+    }
+
+    Map<String, Object> getProperties() {
+      return ImmutableMap.copyOf(properties);
+    }
+  }
+}

--- a/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
+++ b/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.auth;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.api.client.util.Key;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Contains metadata associated with an OIDC Auth provider.
+ *
+ * <p>Instances of this class are immutable and thread safe.
+ */
+public final class OidcProviderConfig extends AuthProviderConfig {
+
+  @Key("clientId")
+  private String clientId;
+
+  @Key("issuer")
+  private String issuer;
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public String getIssuer() {
+    return issuer;
+  }
+
+  /**
+   * A specification class for creating a new OIDC Auth provider.
+   *
+   * <p>Set the initial attributes of the new provider by calling various setter methods available
+   * in this class.
+   */
+  public static final class CreateRequest extends AuthProviderConfig.CreateRequest {
+
+    /**
+     * Creates a new {@link CreateRequest}, which can be used to create a new OIDC Auth provider.
+     *
+     * <p>The returned object should be passed to
+     * {@link TenantAwareFirebaseAuth#createProviderConfig(CreateRequest)} to register the provider
+     * information persistently.
+     */
+    public CreateRequest() { }
+
+    /**
+     * Sets the client ID for the new provider.
+     *
+     * @param clientId a non-null, non-empty client ID string.
+     */
+    public CreateRequest setClientId(String clientId) {
+      checkArgument(!Strings.isNullOrEmpty(clientId), "client ID must not be null or empty");
+      properties.put("clientId", clientId);
+      return this;
+    }
+
+    /**
+     * Sets the issuer for the new provider.
+     *
+     * @param issuer a non-null, non-empty issuer string.
+     */
+    public CreateRequest setIssuer(String issuer) {
+      checkArgument(!Strings.isNullOrEmpty(issuer), "issuer must not be null or empty");
+      properties.put("issuer", issuer);
+      return this;
+    }
+  }
+}

--- a/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
+++ b/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
@@ -21,6 +21,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.api.client.util.Key;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -80,6 +82,11 @@ public final class OidcProviderConfig extends AuthProviderConfig {
      */
     public CreateRequest setIssuer(String issuer) {
       checkArgument(!Strings.isNullOrEmpty(issuer), "issuer must not be null or empty");
+      try {
+        new URL(issuer);
+      } catch (MalformedURLException e) {
+        throw new IllegalArgumentException(issuer + " is a malformed URL", e);
+      }
       properties.put("issuer", issuer);
       return this;
     }

--- a/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
+++ b/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.auth;
+
+import org.junit.Test;
+
+public class OidcProviderConfigTest {
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidIssuerUrl() {
+    new OidcProviderConfig.CreateRequest().setIssuer("not a valid url");
+  }
+}


### PR DESCRIPTION
This provider class only includes a `CreateRequest` inner class for the time being. An `UpdateRequest` inner class will be added in the future.

In addition to `OidcProviderConfig`, this pull request also includes a base class, which will be shared by a future `SamlProviderConfig` class.

This is part of adding multi-tenancy support (see issue #332).