### PR TITLE
Add operation to update OIDC provider configs.

### DIFF
--- a/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
@@ -979,6 +979,46 @@ public abstract class AbstractFirebaseAuth {
   }
 
   /**
+   * Updates an existing OIDC Auth provider config with the attributes contained in the specified
+   * {@link OidcProviderConfig.UpdateRequest}.
+   *
+   * @param request A non-null {@link OidcProviderConfig.UpdateRequest} instance.
+   * @return A {@link OidcProviderConfig} instance corresponding to the updated provider config.
+   * @throws NullPointerException if the provided update request is null.
+   * @throws FirebaseAuthException if an error occurs while updating the provider config.
+   */
+  public OidcProviderConfig updateOidcProviderConfig(
+      @NonNull OidcProviderConfig.UpdateRequest request) throws FirebaseAuthException {
+    return updateOidcProviderConfigOp(request).call();
+  }
+
+  /**
+   * Similar to {@link #updateOidcProviderConfig} but performs the operation asynchronously.
+   *
+   * @param request A non-null {@link OidcProviderConfig.UpdateRequest} instance.
+   * @return An {@code ApiFuture} which will complete successfully with a {@link OidcProviderConfig}
+   *     instance corresponding to the updated provider config. If an error occurs while updating
+   *     the provider config, the future throws a {@link FirebaseAuthException}.
+   */
+  public ApiFuture<OidcProviderConfig> updateOidcProviderConfigAsync(
+      @NonNull OidcProviderConfig.UpdateRequest request) {
+    return updateOidcProviderConfigOp(request).callAsync(firebaseApp);
+  }
+
+  private CallableOperation<OidcProviderConfig, FirebaseAuthException> updateOidcProviderConfigOp(
+      final OidcProviderConfig.UpdateRequest request) {
+    checkNotDestroyed();
+    checkNotNull(request, "update request must not be null");
+    final FirebaseUserManager userManager = getUserManager();
+    return new CallableOperation<OidcProviderConfig, FirebaseAuthException>() {
+      @Override
+      protected OidcProviderConfig execute() throws FirebaseAuthException {
+        return userManager.updateOidcProviderConfig(request);
+      }
+    };
+  }
+
+  /**
    * Gets the provider OIDC Auth config corresponding to the specified provider ID.
    *
    * @param providerId A provider ID string.

--- a/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
+++ b/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
@@ -134,7 +134,6 @@ public final class OidcProviderConfig extends ProviderConfig {
      */
     public UpdateRequest(String providerId) {
       super(providerId);
-      checkArgument(!Strings.isNullOrEmpty(providerId), "provider ID must not be null or empty");
     }
 
     /**

--- a/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
+++ b/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
@@ -22,6 +22,7 @@ import com.google.api.client.util.Key;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.auth.ProviderConfig.AbstractCreateRequest;
+import com.google.firebase.auth.ProviderConfig.AbstractUpdateRequest;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
@@ -46,6 +47,24 @@ public final class OidcProviderConfig extends ProviderConfig {
 
   public String getIssuer() {
     return issuer;
+  }
+
+  /**
+   * Returns a new {@link UpdateRequest}, which can be used to update the attributes of this
+   * provider config.
+   *
+   * @return a non-null {@link UpdateRequest} instance.
+   */
+  public UpdateRequest updateRequest() {
+    return new UpdateRequest(getProviderId());
+  }
+
+  private static void assertValidUrl(String url) throws IllegalArgumentException {
+    try {
+      new URL(url);
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException(url + " is a malformed URL", e);
+    }
   }
 
   /**
@@ -83,16 +102,65 @@ public final class OidcProviderConfig extends ProviderConfig {
      */
     public CreateRequest setIssuer(String issuer) {
       checkArgument(!Strings.isNullOrEmpty(issuer), "issuer must not be null or empty");
-      try {
-        new URL(issuer);
-      } catch (MalformedURLException e) {
-        throw new IllegalArgumentException(issuer + " is a malformed URL", e);
-      }
+      assertValidUrl(issuer);
       properties.put("issuer", issuer);
       return this;
     }
 
     CreateRequest getThis() {
+      return this;
+    }
+  }
+
+  /**
+   * A specification class for updating an existing OIDC Auth provider.
+   *
+   * <p>An instance of this class can be obtained via a {@link OidcProviderConfig} object, or from
+   * a provider ID string. Specify the changes to be made to the provider config by calling the
+   * various setter methods available in this class.
+   */
+  public static final class UpdateRequest extends AbstractUpdateRequest<UpdateRequest> {
+
+    /**
+     * Creates a new {@link UpdateRequest}, which can be used to updates an existing OIDC Auth
+     * provider.
+     *
+     * <p>The returned object should be passed to
+     * {@link AbstractFirebaseAuth#updateOidcProviderConfig(CreateRequest)} to update the provider
+     * information persistently.
+     *
+     * @param tenantId a non-null, non-empty provider ID string.
+     * @throws IllegalArgumentException If the provider ID is null or empty.
+     */
+    public UpdateRequest(String providerId) {
+      super(providerId);
+      checkArgument(!Strings.isNullOrEmpty(providerId), "provider ID must not be null or empty");
+    }
+
+    /**
+     * Sets the client ID for the exsting provider.
+     *
+     * @param clientId a non-null, non-empty client ID string.
+     */
+    public UpdateRequest setClientId(String clientId) {
+      checkArgument(!Strings.isNullOrEmpty(clientId), "client ID must not be null or empty");
+      properties.put("clientId", clientId);
+      return this;
+    }
+
+    /**
+     * Sets the issuer for the existing provider.
+     *
+     * @param issuer a non-null, non-empty issuer string.
+     */
+    public UpdateRequest setIssuer(String issuer) {
+      checkArgument(!Strings.isNullOrEmpty(issuer), "issuer must not be null or empty");
+      assertValidUrl(issuer);
+      properties.put("issuer", issuer);
+      return this;
+    }
+
+    UpdateRequest getThis() {
       return this;
     }
   }

--- a/src/main/java/com/google/firebase/auth/ProviderConfig.java
+++ b/src/main/java/com/google/firebase/auth/ProviderConfig.java
@@ -114,6 +114,7 @@ public abstract class ProviderConfig {
     final Map<String,Object> properties = new HashMap<>();
 
     AbstractUpdateRequest(String providerId) {
+      checkArgument(!Strings.isNullOrEmpty(providerId), "provider ID must not be null or empty");
       this.providerId = providerId;
     }
 

--- a/src/main/java/com/google/firebase/auth/ProviderConfig.java
+++ b/src/main/java/com/google/firebase/auth/ProviderConfig.java
@@ -104,4 +104,48 @@ public abstract class ProviderConfig {
 
     abstract T getThis();
   }
+
+  /**
+   * A base class for updating the attributes of an existing provider.
+   */
+  public abstract static class AbstractUpdateRequest<T extends AbstractUpdateRequest<T>> {
+
+    final String providerId;
+    final Map<String,Object> properties = new HashMap<>();
+
+    AbstractUpdateRequest(String providerId) {
+      this.providerId = providerId;
+    }
+
+    String getProviderId() {
+      return providerId;
+    }
+
+    /**
+     * Sets the display name for the existing provider.
+     *
+     * @param displayName a non-null, non-empty display name string.
+     */
+    public T setDisplayName(String displayName) {
+      checkArgument(!Strings.isNullOrEmpty(displayName), "display name must not be null or empty");
+      properties.put("displayName", displayName);
+      return getThis();
+    }
+
+    /**
+     * Sets whether to allow the user to sign in with the provider.
+     *
+     * @param enabled a boolean indicating whether the user can sign in with the provider
+     */
+    public T setEnabled(boolean enabled) {
+      properties.put("enabled", enabled);
+      return getThis();
+    }
+
+    Map<String, Object> getProperties() {
+      return ImmutableMap.copyOf(properties);
+    }
+
+    abstract T getThis();
+  }
 }

--- a/src/main/java/com/google/firebase/auth/Tenant.java
+++ b/src/main/java/com/google/firebase/auth/Tenant.java
@@ -60,10 +60,9 @@ public final class Tenant {
   }
 
   /**
-   * Returns a new {@link UpdateRequest}, which can be used to update the attributes
-   * of this tenant.
+   * Returns a new {@link UpdateRequest}, which can be used to update the attributes of this tenant.
    *
-   * @return a non-null Tenant.UpdateRequest instance.
+   * @return a non-null {@link UpdateRequest} instance.
    */
   public UpdateRequest updateRequest() {
     return new UpdateRequest(getTenantId());
@@ -157,7 +156,7 @@ public final class Tenant {
     }
 
     /**
-     * Sets the display name of the existingtenant.
+     * Sets the display name of the existing tenant.
      *
      * @param displayName a non-null, non-empty display name string.
      */

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -973,6 +973,7 @@ public class FirebaseAuthIT {
     OidcProviderConfig config = auth.createOidcProviderConfigAsync(createRequest).get();
     assertEquals(providerId, config.getProviderId());
     assertEquals("DisplayName", config.getDisplayName());
+    assertTrue(config.isEnabled());
     assertEquals("ClientId", config.getClientId());
     assertEquals("https://oidc.com/issuer", config.getIssuer());
 
@@ -981,11 +982,23 @@ public class FirebaseAuthIT {
       config = auth.getOidcProviderConfigAsync(providerId).get();
       assertEquals(providerId, config.getProviderId());
       assertEquals("DisplayName", config.getDisplayName());
+      assertTrue(config.isEnabled());
       assertEquals("ClientId", config.getClientId());
       assertEquals("https://oidc.com/issuer", config.getIssuer());
 
-      // TODO(micahstairs): Test updateProviderConfig operation
-
+      // Update config provider
+      OidcProviderConfig.UpdateRequest updateRequest =
+          new OidcProviderConfig.UpdateRequest(providerId)
+              .setDisplayName("NewDisplayName")
+              .setEnabled(false)
+              .setClientId("NewClientId")
+              .setIssuer("https://oidc.com/new-issuer");
+      config = auth.updateOidcProviderConfigAsync(updateRequest).get();
+      assertEquals(providerId, config.getProviderId());
+      assertEquals("NewDisplayName", config.getDisplayName());
+      assertFalse(config.isEnabled());
+      assertEquals("NewClientId", config.getClientId());
+      assertEquals("https://oidc.com/new-issuer", config.getIssuer());
     } finally {
       // Delete config provider
       auth.deleteProviderConfigAsync(providerId).get();
@@ -1028,8 +1041,19 @@ public class FirebaseAuthIT {
         assertEquals("ClientId", config.getClientId());
         assertEquals("https://oidc.com/issuer", config.getIssuer());
 
-        // TODO(micahstairs): Test updateProviderConfig operation
-
+        // Update config provider
+        OidcProviderConfig.UpdateRequest updateRequest =
+            new OidcProviderConfig.UpdateRequest(providerId)
+                .setDisplayName("NewDisplayName")
+                .setEnabled(false)
+                .setClientId("NewClientId")
+                .setIssuer("https://oidc.com/new-issuer");
+        config = tenantAwareAuth.updateOidcProviderConfigAsync(updateRequest).get();
+        assertEquals(providerId, config.getProviderId());
+        assertEquals("NewDisplayName", config.getDisplayName());
+        assertFalse(config.isEnabled());
+        assertEquals("NewClientId", config.getClientId());
+        assertEquals("https://oidc.com/new-issuer", config.getIssuer());
       } finally {
         // Delete config provider
         tenantAwareAuth.deleteProviderConfigAsync(providerId).get();

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -1531,10 +1531,8 @@ public class FirebaseUserManagerTest {
     GenericUrl url = interceptor.getResponse().getRequest().getUrl();
     assertEquals("displayName", url.getFirst("updateMask"));
     GenericJson parsed = parseRequestContent(interceptor);
+    assertEquals(1, parsed.size());
     assertEquals("DISPLAY_NAME", parsed.get("displayName"));
-    assertNull(parsed.get("enabled"));
-    assertNull(parsed.get("clientId"));
-    assertNull(parsed.get("issuer"));
   }
 
   @Test

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -1492,6 +1492,110 @@ public class FirebaseUserManagerTest {
   }
 
   @Test
+  public void testUpdateOidcProvider() throws Exception {
+    TestResponseInterceptor interceptor = initializeAppForUserManagement(
+        TestUtils.loadResource("oidc.json"));
+    OidcProviderConfig.UpdateRequest request =
+        new OidcProviderConfig.UpdateRequest("oidc.provider-id")
+            .setDisplayName("DISPLAY_NAME")
+            .setEnabled(true)
+            .setClientId("CLIENT_ID")
+            .setIssuer("https://oidc.com/issuer");
+
+    OidcProviderConfig config = FirebaseAuth.getInstance().updateOidcProviderConfig(request);
+
+    checkOidcProviderConfig(config);
+    checkRequestHeaders(interceptor);
+    checkUrl(interceptor, "PATCH", PROJECT_BASE_URL + "/oauthIdpConfigs/oidc.provider-id");
+    GenericUrl url = interceptor.getResponse().getRequest().getUrl();
+    assertEquals("clientId,displayName,enabled,issuer", url.getFirst("updateMask"));
+    GenericJson parsed = parseRequestContent(interceptor);
+    assertEquals("DISPLAY_NAME", parsed.get("displayName"));
+    assertTrue((boolean) parsed.get("enabled"));
+    assertEquals("CLIENT_ID", parsed.get("clientId"));
+    assertEquals("https://oidc.com/issuer", parsed.get("issuer"));
+  }
+
+  @Test
+  public void testUpdateOidcProviderMinimal() throws Exception {
+    TestResponseInterceptor interceptor = initializeAppForUserManagement(
+        TestUtils.loadResource("oidc.json"));
+    OidcProviderConfig.UpdateRequest request =
+        new OidcProviderConfig.UpdateRequest("oidc.provider-id").setDisplayName("DISPLAY_NAME");
+
+    OidcProviderConfig config = FirebaseAuth.getInstance().updateOidcProviderConfig(request);
+
+    checkOidcProviderConfig(config);
+    checkRequestHeaders(interceptor);
+    checkUrl(interceptor, "PATCH", PROJECT_BASE_URL + "/oauthIdpConfigs/oidc.provider-id");
+    GenericUrl url = interceptor.getResponse().getRequest().getUrl();
+    assertEquals("displayName", url.getFirst("updateMask"));
+    GenericJson parsed = parseRequestContent(interceptor);
+    assertEquals("DISPLAY_NAME", parsed.get("displayName"));
+    assertNull(parsed.get("enabled"));
+    assertNull(parsed.get("clientId"));
+    assertNull(parsed.get("issuer"));
+  }
+
+  @Test
+  public void testUpdateOidcProviderConfigNoValues() throws Exception {
+    TestResponseInterceptor interceptor = initializeAppForUserManagement(
+        TestUtils.loadResource("oidc.json"));
+    try {
+      FirebaseAuth.getInstance().updateOidcProviderConfig(
+          new OidcProviderConfig.UpdateRequest("oidc.provider-id"));
+      fail("No error thrown for empty provider config update");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testUpdateOidcProviderConfigError() throws Exception {
+    TestResponseInterceptor interceptor =
+        initializeAppForUserManagementWithStatusCode(404,
+            "{\"error\": {\"message\": \"INTERNAL_ERROR\"}}");
+    OidcProviderConfig.UpdateRequest request =
+        new OidcProviderConfig.UpdateRequest("oidc.provider-id").setDisplayName("DISPLAY_NAME");
+    try {
+      FirebaseAuth.getInstance().updateOidcProviderConfig(request);
+      fail("No error thrown for invalid response");
+    } catch (FirebaseAuthException e) {
+      assertEquals(FirebaseUserManager.INTERNAL_ERROR, e.getErrorCode());
+    }
+    checkUrl(interceptor, "PATCH", PROJECT_BASE_URL + "/oauthIdpConfigs/oidc.provider-id");
+  }
+
+  @Test
+  public void testTenantAwareUpdateOidcProvider() throws Exception {
+    TestResponseInterceptor interceptor = initializeAppForTenantAwareUserManagement(
+        "TENANT_ID",
+        TestUtils.loadResource("oidc.json"));
+    TenantAwareFirebaseAuth tenantAwareAuth =
+        FirebaseAuth.getInstance().getTenantManager().getAuthForTenant("TENANT_ID");
+    OidcProviderConfig.UpdateRequest request =
+        new OidcProviderConfig.UpdateRequest("oidc.provider-id")
+            .setDisplayName("DISPLAY_NAME")
+            .setEnabled(true)
+            .setClientId("CLIENT_ID")
+            .setIssuer("https://oidc.com/issuer");
+
+    OidcProviderConfig config = tenantAwareAuth.updateOidcProviderConfig(request);
+
+    checkOidcProviderConfig(config);
+    checkRequestHeaders(interceptor);
+    String expectedUrl = TENANTS_BASE_URL + "/TENANT_ID/oauthIdpConfigs/oidc.provider-id";
+    checkUrl(interceptor, "PATCH", expectedUrl);
+    GenericUrl url = interceptor.getResponse().getRequest().getUrl();
+    assertEquals("clientId,displayName,enabled,issuer", url.getFirst("updateMask"));
+    GenericJson parsed = parseRequestContent(interceptor);
+    assertEquals("DISPLAY_NAME", parsed.get("displayName"));
+    assertTrue((boolean) parsed.get("enabled"));
+    assertEquals("CLIENT_ID", parsed.get("clientId"));
+    assertEquals("https://oidc.com/issuer", parsed.get("issuer"));
+  }
+
+  @Test
   public void testGetOidcProviderConfig() throws Exception {
     TestResponseInterceptor interceptor = initializeAppForUserManagement(
         TestUtils.loadResource("oidc.json"));

--- a/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
+++ b/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
@@ -105,6 +105,11 @@ public class OidcProviderConfigTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
+  public void testUpdateRequestMissingProviderId() {
+    new OidcProviderConfig.UpdateRequest(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
   public void testUpdateRequestInvalidIssuerUrl() {
     new OidcProviderConfig.UpdateRequest("oidc.provider-id").setIssuer("not a valid url");
   }

--- a/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
+++ b/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
@@ -71,6 +71,11 @@ public class OidcProviderConfigTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
+  public void testCreateRequestMissingClientId() {
+    new OidcProviderConfig.CreateRequest().setClientId(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
   public void testCreateRequestInvalidIssuerUrl() {
     new OidcProviderConfig.CreateRequest().setIssuer("not a valid url");
   }
@@ -107,6 +112,11 @@ public class OidcProviderConfigTest {
   @Test(expected = IllegalArgumentException.class)
   public void testUpdateRequestMissingProviderId() {
     new OidcProviderConfig.UpdateRequest(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testUpdateRequestMissingClientId() {
+    new OidcProviderConfig.UpdateRequest("oidc.provider-id").setClientId(null);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
+++ b/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
@@ -71,7 +71,41 @@ public class OidcProviderConfigTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testInvalidIssuerUrl() {
+  public void testCreateRequestInvalidIssuerUrl() {
     new OidcProviderConfig.CreateRequest().setIssuer("not a valid url");
+  }
+
+  @Test
+  public void testUpdateRequestFromOidcProviderConfig() throws IOException {
+    OidcProviderConfig config = jsonFactory.fromString(OIDC_JSON_STRING, OidcProviderConfig.class);
+
+    OidcProviderConfig.UpdateRequest updateRequest = config.updateRequest();
+
+    assertEquals("oidc.provider-id", updateRequest.getProviderId());
+    assertTrue(updateRequest.getProperties().isEmpty());
+  }
+
+  @Test
+  public void testUpdateRequest() throws IOException {
+    OidcProviderConfig.UpdateRequest updateRequest =
+        new OidcProviderConfig.UpdateRequest("oidc.provider-id");
+    updateRequest
+      .setDisplayName("DISPLAY_NAME")
+      .setEnabled(false)
+      .setClientId("CLIENT_ID")
+      .setIssuer("https://oidc.com/issuer");
+
+    assertEquals("oidc.provider-id", updateRequest.getProviderId());
+    Map<String,Object> properties = updateRequest.getProperties();
+    assertEquals(properties.size(), 4);
+    assertEquals("DISPLAY_NAME", (String) properties.get("displayName"));
+    assertFalse((boolean) properties.get("enabled"));
+    assertEquals("CLIENT_ID", (String) properties.get("clientId"));
+    assertEquals("https://oidc.com/issuer", (String) properties.get("issuer"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testUpdateRequestInvalidIssuerUrl() {
+    new OidcProviderConfig.UpdateRequest("oidc.provider-id").setIssuer("not a valid url");
   }
 }


### PR DESCRIPTION
This adds an operation to update OIDC provider configs (can be done using either the tenant-aware or standard Firebase client).

This work is part of adding multi-tenancy support (see issue #332).