### PR TITLE
Add operation to list OIDC provider configs.

### DIFF
--- a/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
@@ -29,10 +29,10 @@ import com.google.common.base.Suppliers;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.FirebaseUserManager.EmailLinkType;
 import com.google.firebase.auth.FirebaseUserManager.UserImportRequest;
+import com.google.firebase.auth.ListProviderConfigsPage;
 import com.google.firebase.auth.ListProviderConfigsPage.DefaultOidcProviderConfigSource;
-import com.google.firebase.auth.ListProviderConfigsPage.ProviderConfigPageFactory;
+import com.google.firebase.auth.ListUsersPage;
 import com.google.firebase.auth.ListUsersPage.DefaultUserSource;
-import com.google.firebase.auth.ListUsersPage.UserPageFactory;
 import com.google.firebase.auth.UserRecord;
 import com.google.firebase.auth.internal.FirebaseTokenFactory;
 import com.google.firebase.internal.CallableOperation;
@@ -503,7 +503,7 @@ public abstract class AbstractFirebaseAuth {
     checkNotDestroyed();
     final FirebaseUserManager userManager = getUserManager();
     final DefaultUserSource source = new DefaultUserSource(userManager, jsonFactory);
-    final UserPageFactory factory = new UserPageFactory(source, maxResults, pageToken);
+    final ListUsersPage.Factory factory = new ListUsersPage.Factory(source, maxResults, pageToken);
     return new CallableOperation<ListUsersPage, FirebaseAuthException>() {
       @Override
       protected ListUsersPage execute() throws FirebaseAuthException {
@@ -1035,6 +1035,7 @@ public abstract class AbstractFirebaseAuth {
 
   /**
    * Similar to {@link #getOidcProviderConfig(String)} but performs the operation asynchronously.
+   * Page size will be limited to 100 provider configs.
    *
    * @param providerId A provider ID string.
    * @return An {@code ApiFuture} which will complete successfully with an
@@ -1079,7 +1080,7 @@ public abstract class AbstractFirebaseAuth {
 
   /**
    * Similar to {@link #listlistOidcProviderConfigs(String)} but performs the operation
-   * asynchronously.
+   * asynchronously. Page size will be limited to 100 provider configs.
    *
    * @param pageToken A non-empty page token string, or null to retrieve the first page of provider
    *     configs.
@@ -1120,8 +1121,8 @@ public abstract class AbstractFirebaseAuth {
     checkNotDestroyed();
     final FirebaseUserManager userManager = getUserManager();
     final DefaultOidcProviderConfigSource source = new DefaultOidcProviderConfigSource(userManager);
-    final ProviderConfigPageFactory<OidcProviderConfig> factory =
-        new ProviderConfigPageFactory<OidcProviderConfig>(source, maxResults, pageToken);
+    final ListProviderConfigsPage.Factory<OidcProviderConfig> factory =
+        new ListProviderConfigsPage.Factory<OidcProviderConfig>(source, maxResults, pageToken);
     return
       new CallableOperation<ListProviderConfigsPage<OidcProviderConfig>, FirebaseAuthException>() {
         @Override

--- a/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
@@ -29,8 +29,10 @@ import com.google.common.base.Suppliers;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.auth.FirebaseUserManager.EmailLinkType;
 import com.google.firebase.auth.FirebaseUserManager.UserImportRequest;
+import com.google.firebase.auth.ListProviderConfigsPage.DefaultOidcProviderConfigSource;
+import com.google.firebase.auth.ListProviderConfigsPage.ProviderConfigPageFactory;
 import com.google.firebase.auth.ListUsersPage.DefaultUserSource;
-import com.google.firebase.auth.ListUsersPage.PageFactory;
+import com.google.firebase.auth.ListUsersPage.UserPageFactory;
 import com.google.firebase.auth.UserRecord;
 import com.google.firebase.auth.internal.FirebaseTokenFactory;
 import com.google.firebase.internal.CallableOperation;
@@ -500,8 +502,8 @@ public abstract class AbstractFirebaseAuth {
       @Nullable final String pageToken, final int maxResults) {
     checkNotDestroyed();
     final FirebaseUserManager userManager = getUserManager();
-    final PageFactory factory =
-        new PageFactory(new DefaultUserSource(userManager, jsonFactory), maxResults, pageToken);
+    final DefaultUserSource source = new DefaultUserSource(userManager, jsonFactory);
+    final UserPageFactory factory = new UserPageFactory(source, maxResults, pageToken);
     return new CallableOperation<ListUsersPage, FirebaseAuthException>() {
       @Override
       protected ListUsersPage execute() throws FirebaseAuthException {
@@ -1055,6 +1057,78 @@ public abstract class AbstractFirebaseAuth {
       protected OidcProviderConfig execute() throws FirebaseAuthException {
         return userManager.getOidcProviderConfig(providerId);
       }
+    };
+  }
+
+  /**
+   * Gets a page of OIDC Auth provider configs starting from the specified {@code pageToken}.
+   *
+   * @param pageToken A non-empty page token string, or null to retrieve the first page of provider
+   *     configs.
+   * @param maxResults Maximum number of provider configs to include in the returned page. This may
+   *     not exceed 100.
+   * @return A {@link ListProviderConfigsPage} instance.
+   * @throws IllegalArgumentException If the specified page token is empty, or max results value is
+   *     invalid.
+   * @throws FirebaseAuthException If an error occurs while retrieving user data.
+   */
+  public ListProviderConfigsPage<OidcProviderConfig> listOidcProviderConfigs(
+        @Nullable String pageToken, int maxResults) throws FirebaseAuthException {
+    return listOidcProviderConfigsOp(pageToken, maxResults).call();
+  }
+
+  /**
+   * Similar to {@link #listlistOidcProviderConfigs(String)} but performs the operation
+   * asynchronously.
+   *
+   * @param pageToken A non-empty page token string, or null to retrieve the first page of provider
+   *     configs.
+   * @return An {@code ApiFuture} which will complete successfully with a
+   *     {@link ListProviderConfigsPage} instance. If an error occurs while retrieving provider
+   *     config data, the future throws an exception.
+   * @throws IllegalArgumentException If the specified page token is empty.
+   */
+  public ApiFuture<ListProviderConfigsPage<OidcProviderConfig>> listOidcProviderConfigsAsync(
+      @Nullable String pageToken) {
+    return listOidcProviderConfigsAsync(
+        pageToken,
+        FirebaseUserManager.MAX_LIST_PROVIDER_CONFIGS_RESULTS);
+  }
+
+  /**
+   * Similar to {@link #listOidcProviderConfigs(String, int)} but performs the operation
+   * asynchronously.
+   *
+   * @param pageToken A non-empty page token string, or null to retrieve the first page of provider
+   *     configs.
+   * @param maxResults Maximum number of provider configs to include in the returned page. This may
+   *     not exceed 100.
+   * @return An {@code ApiFuture} which will complete successfully with a
+   *     {@link ListProviderConfigsPage} instance. If an error occurs while retrieving provider
+   *     config data, the future throws an exception.
+   * @throws IllegalArgumentException If the specified page token is empty, or max results value is
+   *     invalid.
+   */
+  public ApiFuture<ListProviderConfigsPage<OidcProviderConfig>> listOidcProviderConfigsAsync(
+      @Nullable String pageToken,
+      int maxResults) {
+    return listOidcProviderConfigsOp(pageToken, maxResults).callAsync(firebaseApp);
+  }
+
+  private CallableOperation<ListProviderConfigsPage<OidcProviderConfig>, FirebaseAuthException>
+      listOidcProviderConfigsOp(@Nullable final String pageToken, final int maxResults) {
+    checkNotDestroyed();
+    final FirebaseUserManager userManager = getUserManager();
+    final DefaultOidcProviderConfigSource source = new DefaultOidcProviderConfigSource(userManager);
+    final ProviderConfigPageFactory<OidcProviderConfig> factory =
+        new ProviderConfigPageFactory<OidcProviderConfig>(source, maxResults, pageToken);
+    return
+      new CallableOperation<ListProviderConfigsPage<OidcProviderConfig>, FirebaseAuthException>() {
+        @Override
+        protected ListProviderConfigsPage<OidcProviderConfig> execute()
+            throws FirebaseAuthException {
+          return factory.create();
+        }
     };
   }
 

--- a/src/main/java/com/google/firebase/auth/ListProviderConfigsPage.java
+++ b/src/main/java/com/google/firebase/auth/ListProviderConfigsPage.java
@@ -89,8 +89,7 @@ public class ListProviderConfigsPage<T extends ProviderConfig> implements Page<T
   @Override
   public ListProviderConfigsPage<T> getNextPage() {
     if (hasNextPage()) {
-      ProviderConfigPageFactory<T> factory =
-          new ProviderConfigPageFactory<T>(source, maxResults, currentBatch.getPageToken());
+      Factory<T> factory = new Factory<T>(source, maxResults, currentBatch.getPageToken());
       try {
         return factory.create();
       } catch (FirebaseAuthException e) {
@@ -224,17 +223,17 @@ public class ListProviderConfigsPage<T extends ProviderConfig> implements Page<T
    * <p>Performs argument validation before attempting to load any provider config data (which is
    * expensive, and hence may be performed asynchronously on a separate thread).
    */
-  static class ProviderConfigPageFactory<T extends ProviderConfig> {
+  static class Factory<T extends ProviderConfig> {
 
     private final ProviderConfigSource<T> source;
     private final int maxResults;
     private final String pageToken;
 
-    ProviderConfigPageFactory(@NonNull ProviderConfigSource<T> source) {
+    Factory(@NonNull ProviderConfigSource<T> source) {
       this(source, FirebaseUserManager.MAX_LIST_PROVIDER_CONFIGS_RESULTS, null);
     }
 
-    ProviderConfigPageFactory(
+    Factory(
         @NonNull ProviderConfigSource source,
         int maxResults,
         @Nullable String pageToken) {

--- a/src/main/java/com/google/firebase/auth/ListProviderConfigsPage.java
+++ b/src/main/java/com/google/firebase/auth/ListProviderConfigsPage.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.auth;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.api.client.json.JsonFactory;
+import com.google.api.gax.paging.Page;
+import com.google.common.collect.ImmutableList;
+import com.google.firebase.auth.internal.DownloadAccountResponse;
+import com.google.firebase.auth.internal.ListOidcProviderConfigsResponse;
+import com.google.firebase.auth.internal.ListProviderConfigsResponse;
+import com.google.firebase.internal.NonNull;
+import com.google.firebase.internal.Nullable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Represents a page of {@link ProviderConfig} instances.
+ *
+ * <p>Provides methods for iterating over the provider configs in the current page, and calling up
+ * subsequent pages of provider configs.
+ *
+ * <p>Instances of this class are thread-safe and immutable.
+ */
+public class ListProviderConfigsPage<T extends ProviderConfig> implements Page<T> {
+
+  static final String END_OF_LIST = "";
+
+  private final ListProviderConfigsResponse<T> currentBatch;
+  private final ProviderConfigSource<T> source;
+  private final int maxResults;
+
+  private ListProviderConfigsPage(
+      @NonNull ListProviderConfigsResponse<T> currentBatch,
+      @NonNull ProviderConfigSource<T> source,
+      int maxResults) {
+    this.currentBatch = checkNotNull(currentBatch);
+    this.source = checkNotNull(source);
+    this.maxResults = maxResults;
+  }
+
+  /**
+   * Checks if there is another page of provider configs available to retrieve.
+   *
+   * @return true if another page is available, or false otherwise.
+   */
+  @Override
+  public boolean hasNextPage() {
+    return !END_OF_LIST.equals(currentBatch.getPageToken());
+  }
+
+  /**
+   * Returns the string token that identifies the next page.
+   *
+   * <p>Never returns null. Returns empty string if there are no more pages available to be
+   * retrieved.
+   *
+   * @return A non-null string token (possibly empty, representing no more pages)
+   */
+  @NonNull
+  @Override
+  public String getNextPageToken() {
+    return currentBatch.getPageToken();
+  }
+
+  /**
+   * Returns the next page of provider configs.
+   *
+   * @return A new {@link ListProviderConfigsPage} instance, or null if there are no more pages.
+   */
+  @Nullable
+  @Override
+  public ListProviderConfigsPage<T> getNextPage() {
+    if (hasNextPage()) {
+      ProviderConfigPageFactory<T> factory =
+          new ProviderConfigPageFactory<T>(source, maxResults, currentBatch.getPageToken());
+      try {
+        return factory.create();
+      } catch (FirebaseAuthException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns an {@link Iterable} that facilitates transparently iterating over all the provider
+   * configs in the current Firebase project, starting from this page.
+   *
+   * <p>The {@link Iterator} instances produced by the returned {@link Iterable} never buffers more
+   * than one page of provider configs at a time. It is safe to abandon the iterators (i.e. break
+   * the loops) at any time.
+   *
+   * @return a new {@link Iterable} instance.
+   */
+  @NonNull
+  @Override
+  public Iterable<T> iterateAll() {
+    return new ProviderConfigIterable(this);
+  }
+
+  /**
+   * Returns an {@link Iterable} over the provider configs in this page.
+   *
+   * @return a {@link Iterable} instance.
+   */
+  @NonNull
+  @Override
+  public Iterable<T> getValues() {
+    return currentBatch.getProviderConfigs();
+  }
+
+  private static class ProviderConfigIterable<T extends ProviderConfig> implements Iterable<T> {
+
+    private final ListProviderConfigsPage<T> startingPage;
+
+    ProviderConfigIterable(@NonNull ListProviderConfigsPage<T> startingPage) {
+      this.startingPage = checkNotNull(startingPage, "starting page must not be null");
+    }
+
+    @Override
+    @NonNull
+    public Iterator<T> iterator() {
+      return new ProviderConfigIterator<T>(startingPage);
+    }
+
+    /**
+     * An {@link Iterator} that cycles through provider configs, one at a time.
+     *
+     * <p>It buffers the last retrieved batch of provider configs in memory. The {@code maxResults}
+     * parameter is an upper bound on the batch size.
+     */
+    private static class ProviderConfigIterator<T extends ProviderConfig> implements Iterator<T> {
+
+      private ListProviderConfigsPage<T> currentPage;
+      private List<T> batch;
+      private int index = 0;
+
+      private ProviderConfigIterator(ListProviderConfigsPage<T> startingPage) {
+        setCurrentPage(startingPage);
+      }
+
+      @Override
+      public boolean hasNext() {
+        if (index == batch.size()) {
+          if (currentPage.hasNextPage()) {
+            setCurrentPage(currentPage.getNextPage());
+          } else {
+            return false;
+          }
+        }
+
+        return index < batch.size();
+      }
+
+      @Override
+      public T next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+        return batch.get(index++);
+      }
+
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException("remove operation not supported");
+      }
+
+      private void setCurrentPage(ListProviderConfigsPage<T> page) {
+        this.currentPage = checkNotNull(page);
+        this.batch = ImmutableList.copyOf(page.getValues());
+        this.index = 0;
+      }
+    }
+  }
+
+  /**
+   * Represents a source of provider config data that can be queried to load a batch of provider
+   * configs.
+   */
+  interface ProviderConfigSource<T extends ProviderConfig> {
+    @NonNull
+    ListProviderConfigsResponse<T> fetch(int maxResults, String pageToken)
+      throws FirebaseAuthException;
+  }
+
+  static class DefaultOidcProviderConfigSource implements ProviderConfigSource<OidcProviderConfig> {
+
+    private final FirebaseUserManager userManager;
+
+    DefaultOidcProviderConfigSource(FirebaseUserManager userManager) {
+      this.userManager = checkNotNull(userManager, "user manager must not be null");
+    }
+
+    @Override
+    public ListOidcProviderConfigsResponse fetch(int maxResults, String pageToken)
+        throws FirebaseAuthException {
+      return userManager.listOidcProviderConfigs(maxResults, pageToken);
+    }
+  }
+
+  // TODO(micahstairs): Add DefaultSamlProviderConfigSource class.
+
+  /**
+   * A simple factory class for {@link ProviderConfigsPage} instances.
+   *
+   * <p>Performs argument validation before attempting to load any provider config data (which is
+   * expensive, and hence may be performed asynchronously on a separate thread).
+   */
+  static class ProviderConfigPageFactory<T extends ProviderConfig> {
+
+    private final ProviderConfigSource<T> source;
+    private final int maxResults;
+    private final String pageToken;
+
+    ProviderConfigPageFactory(@NonNull ProviderConfigSource<T> source) {
+      this(source, FirebaseUserManager.MAX_LIST_PROVIDER_CONFIGS_RESULTS, null);
+    }
+
+    ProviderConfigPageFactory(
+        @NonNull ProviderConfigSource source,
+        int maxResults,
+        @Nullable String pageToken) {
+      checkArgument(
+          maxResults > 0 && maxResults <= FirebaseUserManager.MAX_LIST_PROVIDER_CONFIGS_RESULTS,
+          "maxResults must be a positive integer that does not exceed %s",
+          FirebaseUserManager.MAX_LIST_PROVIDER_CONFIGS_RESULTS);
+      checkArgument(!END_OF_LIST.equals(pageToken), "invalid end of list page token");
+      this.source = checkNotNull(source, "source must not be null");
+      this.maxResults = maxResults;
+      this.pageToken = pageToken;
+    }
+
+    ListProviderConfigsPage<T> create() throws FirebaseAuthException {
+      ListProviderConfigsResponse<T> batch = source.fetch(maxResults, pageToken);
+      return new ListProviderConfigsPage<T>(batch, source, maxResults);
+    }
+  }
+}
+

--- a/src/main/java/com/google/firebase/auth/ListTenantsPage.java
+++ b/src/main/java/com/google/firebase/auth/ListTenantsPage.java
@@ -113,7 +113,7 @@ public class ListTenantsPage implements Page<Tenant> {
   }
 
   /**
-   * Returns an {@link Iterable} over the users in this page.
+   * Returns an {@link Iterable} over the tenants in this page.
    *
    * @return a {@link Iterable} instance.
    */

--- a/src/main/java/com/google/firebase/auth/ListUsersPage.java
+++ b/src/main/java/com/google/firebase/auth/ListUsersPage.java
@@ -80,7 +80,8 @@ public class ListUsersPage implements Page<ExportedUserRecord> {
   @Override
   public ListUsersPage getNextPage() {
     if (hasNextPage()) {
-      PageFactory factory = new PageFactory(source, maxResults, currentBatch.getNextPageToken());
+      UserPageFactory factory =
+          new UserPageFactory(source, maxResults, currentBatch.getNextPageToken());
       try {
         return factory.create();
       } catch (FirebaseAuthException e) {
@@ -237,17 +238,17 @@ public class ListUsersPage implements Page<ExportedUserRecord> {
    * before attempting to load any user data (which is expensive, and hence may be performed
    * asynchronously on a separate thread).
    */
-  static class PageFactory {
+  static class UserPageFactory {
 
     private final UserSource source;
     private final int maxResults;
     private final String pageToken;
 
-    PageFactory(@NonNull UserSource source) {
+    UserPageFactory(@NonNull UserSource source) {
       this(source, FirebaseUserManager.MAX_LIST_USERS_RESULTS, null);
     }
 
-    PageFactory(@NonNull UserSource source, int maxResults, @Nullable String pageToken) {
+    UserPageFactory(@NonNull UserSource source, int maxResults, @Nullable String pageToken) {
       checkArgument(maxResults > 0 && maxResults <= FirebaseUserManager.MAX_LIST_USERS_RESULTS,
           "maxResults must be a positive integer that does not exceed %s",
           FirebaseUserManager.MAX_LIST_USERS_RESULTS);

--- a/src/main/java/com/google/firebase/auth/ListUsersPage.java
+++ b/src/main/java/com/google/firebase/auth/ListUsersPage.java
@@ -80,8 +80,7 @@ public class ListUsersPage implements Page<ExportedUserRecord> {
   @Override
   public ListUsersPage getNextPage() {
     if (hasNextPage()) {
-      UserPageFactory factory =
-          new UserPageFactory(source, maxResults, currentBatch.getNextPageToken());
+      Factory factory = new Factory(source, maxResults, currentBatch.getNextPageToken());
       try {
         return factory.create();
       } catch (FirebaseAuthException e) {
@@ -238,17 +237,17 @@ public class ListUsersPage implements Page<ExportedUserRecord> {
    * before attempting to load any user data (which is expensive, and hence may be performed
    * asynchronously on a separate thread).
    */
-  static class UserPageFactory {
+  static class Factory {
 
     private final UserSource source;
     private final int maxResults;
     private final String pageToken;
 
-    UserPageFactory(@NonNull UserSource source) {
+    Factory(@NonNull UserSource source) {
       this(source, FirebaseUserManager.MAX_LIST_USERS_RESULTS, null);
     }
 
-    UserPageFactory(@NonNull UserSource source, int maxResults, @Nullable String pageToken) {
+    Factory(@NonNull UserSource source, int maxResults, @Nullable String pageToken) {
       checkArgument(maxResults > 0 && maxResults <= FirebaseUserManager.MAX_LIST_USERS_RESULTS,
           "maxResults must be a positive integer that does not exceed %s",
           FirebaseUserManager.MAX_LIST_USERS_RESULTS);

--- a/src/main/java/com/google/firebase/auth/internal/ListOidcProviderConfigsResponse.java
+++ b/src/main/java/com/google/firebase/auth/internal/ListOidcProviderConfigsResponse.java
@@ -19,36 +19,44 @@ package com.google.firebase.auth.internal;
 import com.google.api.client.util.Key;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.firebase.auth.OidcProviderConfig;
 import com.google.firebase.auth.Tenant;
 import java.util.List;
 
 /**
- * JSON data binding for ListTenantsResponse messages sent by Google identity toolkit service.
+ * JSON data binding for ListOAuthIdpConfigsResponse messages sent by Google identity toolkit
+ * service.
  */
-public final class ListTenantsResponse {
+public final class ListOidcProviderConfigsResponse
+    implements ListProviderConfigsResponse<OidcProviderConfig> {
 
-  @Key("tenants")
-  private List<Tenant> tenants;
+  @Key("oauthIdpConfigs")
+  private List<OidcProviderConfig> providerConfigs;
 
-  @Key("pageToken")
+  @Key("nextPageToken")
   private String pageToken;
 
   @VisibleForTesting
-  public ListTenantsResponse(List<Tenant> tenants, String pageToken) {
-    this.tenants = tenants;
+  public ListOidcProviderConfigsResponse(
+      List<OidcProviderConfig> providerConfigs,
+      String pageToken) {
+    this.providerConfigs = providerConfigs;
     this.pageToken = pageToken;
   }
 
-  public ListTenantsResponse() { }
+  public ListOidcProviderConfigsResponse() { }
 
-  public List<Tenant> getTenants() {
-    return tenants == null ? ImmutableList.<Tenant>of() : tenants;
+  @Override
+  public List<OidcProviderConfig> getProviderConfigs() {
+    return providerConfigs == null ? ImmutableList.<OidcProviderConfig>of() : providerConfigs;
   }
 
-  public boolean hasTenants() {
-    return tenants != null && !tenants.isEmpty();
+  @Override
+  public boolean hasProviderConfigs() {
+    return providerConfigs != null && !providerConfigs.isEmpty();
   }
 
+  @Override
   public String getPageToken() {
     return pageToken == null ? "" : pageToken;
   }

--- a/src/main/java/com/google/firebase/auth/internal/ListProviderConfigsResponse.java
+++ b/src/main/java/com/google/firebase/auth/internal/ListProviderConfigsResponse.java
@@ -19,37 +19,19 @@ package com.google.firebase.auth.internal;
 import com.google.api.client.util.Key;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.firebase.auth.ListProviderConfigsPage;
+import com.google.firebase.auth.ProviderConfig;
 import com.google.firebase.auth.Tenant;
 import java.util.List;
 
 /**
- * JSON data binding for ListTenantsResponse messages sent by Google identity toolkit service.
+ * Interface for config list response messages sent by Google identity toolkit service.
  */
-public final class ListTenantsResponse {
+public interface ListProviderConfigsResponse<T extends ProviderConfig> {
 
-  @Key("tenants")
-  private List<Tenant> tenants;
+  public List<T> getProviderConfigs();
 
-  @Key("pageToken")
-  private String pageToken;
+  public boolean hasProviderConfigs();
 
-  @VisibleForTesting
-  public ListTenantsResponse(List<Tenant> tenants, String pageToken) {
-    this.tenants = tenants;
-    this.pageToken = pageToken;
-  }
-
-  public ListTenantsResponse() { }
-
-  public List<Tenant> getTenants() {
-    return tenants == null ? ImmutableList.<Tenant>of() : tenants;
-  }
-
-  public boolean hasTenants() {
-    return tenants != null && !tenants.isEmpty();
-  }
-
-  public String getPageToken() {
-    return pageToken == null ? "" : pageToken;
-  }
+  public String getPageToken();
 }

--- a/src/test/java/com/google/firebase/auth/ListUsersPageTest.java
+++ b/src/test/java/com/google/firebase/auth/ListUsersPageTest.java
@@ -27,8 +27,8 @@ import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.json.JsonFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
+import com.google.firebase.auth.ListUsersPage;
 import com.google.firebase.auth.ListUsersPage.ListUsersResult;
-import com.google.firebase.auth.ListUsersPage.UserPageFactory;
 import com.google.firebase.auth.internal.DownloadAccountResponse;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -46,7 +46,7 @@ public class ListUsersPageTest {
   @Test
   public void testSinglePage() throws FirebaseAuthException, IOException {
     TestUserSource source = new TestUserSource(3);
-    ListUsersPage page = new UserPageFactory(source).create();
+    ListUsersPage page = new ListUsersPage.Factory(source).create();
     assertFalse(page.hasNextPage());
     assertEquals(ListUsersPage.END_OF_LIST, page.getNextPageToken());
     assertNull(page.getNextPage());
@@ -69,7 +69,7 @@ public class ListUsersPageTest {
             newUser("user2", REDACTED_BASE64)),
         ListUsersPage.END_OF_LIST);
     TestUserSource source = new TestUserSource(result);
-    ListUsersPage page = new UserPageFactory(source).create();
+    ListUsersPage page = new ListUsersPage.Factory(source).create();
     assertFalse(page.hasNextPage());
     assertEquals(ListUsersPage.END_OF_LIST, page.getNextPageToken());
     assertNull(page.getNextPage());
@@ -90,7 +90,7 @@ public class ListUsersPageTest {
         ImmutableList.of(newUser("user0"), newUser("user1"), newUser("user2")),
         "token");
     TestUserSource source = new TestUserSource(result);
-    ListUsersPage page1 = new UserPageFactory(source).create();
+    ListUsersPage page1 = new ListUsersPage.Factory(source).create();
     assertTrue(page1.hasNextPage());
     assertEquals("token", page1.getNextPageToken());
     ImmutableList<ExportedUserRecord> users = ImmutableList.copyOf(page1.getValues());
@@ -137,7 +137,7 @@ public class ListUsersPageTest {
   @Test
   public void testListUsersIterable() throws FirebaseAuthException, IOException {
     TestUserSource source = new TestUserSource(3);
-    ListUsersPage page = new UserPageFactory(source).create();
+    ListUsersPage page = new ListUsersPage.Factory(source).create();
     Iterable<ExportedUserRecord> users = page.iterateAll();
 
     int iterations = 0;
@@ -163,7 +163,7 @@ public class ListUsersPageTest {
   @Test
   public void testListUsersIterator() throws FirebaseAuthException, IOException {
     TestUserSource source = new TestUserSource(3);
-    ListUsersPage page = new UserPageFactory(source).create();
+    ListUsersPage page = new ListUsersPage.Factory(source).create();
     Iterable<ExportedUserRecord> users = page.iterateAll();
     Iterator<ExportedUserRecord> iterator = users.iterator();
     int iterations = 0;
@@ -193,7 +193,7 @@ public class ListUsersPageTest {
         ImmutableList.of(newUser("user0"), newUser("user1"), newUser("user2")),
         "token");
     TestUserSource source = new TestUserSource(result);
-    ListUsersPage page = new UserPageFactory(source).create();
+    ListUsersPage page = new ListUsersPage.Factory(source).create();
     int iterations = 0;
     for (ExportedUserRecord user : page.iterateAll()) {
       assertEquals("user" + iterations, user.getUid());
@@ -219,7 +219,7 @@ public class ListUsersPageTest {
         ImmutableList.of(newUser("user0"), newUser("user1"), newUser("user2")),
         "token");
     TestUserSource source = new TestUserSource(result);
-    ListUsersPage page = new UserPageFactory(source).create();
+    ListUsersPage page = new ListUsersPage.Factory(source).create();
     Iterator<ExportedUserRecord> users = page.iterateAll().iterator();
     int iterations = 0;
     while (users.hasNext()) {
@@ -252,7 +252,7 @@ public class ListUsersPageTest {
         ImmutableList.<ExportedUserRecord>of(),
         ListUsersPage.END_OF_LIST);
     TestUserSource source = new TestUserSource(result);
-    ListUsersPage page = new UserPageFactory(source).create();
+    ListUsersPage page = new ListUsersPage.Factory(source).create();
     assertFalse(page.hasNextPage());
     assertEquals(ListUsersPage.END_OF_LIST, page.getNextPageToken());
     assertNull(page.getNextPage());
@@ -266,7 +266,7 @@ public class ListUsersPageTest {
         ImmutableList.<ExportedUserRecord>of(),
         ListUsersPage.END_OF_LIST);
     TestUserSource source = new TestUserSource(result);
-    ListUsersPage page = new UserPageFactory(source).create();
+    ListUsersPage page = new ListUsersPage.Factory(source).create();
     for (ExportedUserRecord user : page.iterateAll()) {
       fail("Should not be able to iterate, but got: " + user);
     }
@@ -280,7 +280,7 @@ public class ListUsersPageTest {
         ListUsersPage.END_OF_LIST);
     TestUserSource source = new TestUserSource(result);
 
-    ListUsersPage page = new UserPageFactory(source).create();
+    ListUsersPage page = new ListUsersPage.Factory(source).create();
     Iterator<ExportedUserRecord> iterator = page.iterateAll().iterator();
     while (iterator.hasNext()) {
       fail("Should not be able to iterate");
@@ -295,7 +295,7 @@ public class ListUsersPageTest {
         ListUsersPage.END_OF_LIST);
     TestUserSource source = new TestUserSource(result);
 
-    ListUsersPage page = new UserPageFactory(source).create();
+    ListUsersPage page = new ListUsersPage.Factory(source).create();
     Iterator<ExportedUserRecord> iterator = page.iterateAll().iterator();
     while (iterator.hasNext()) {
       assertNotNull(iterator.next());
@@ -309,14 +309,14 @@ public class ListUsersPageTest {
 
   @Test(expected = NullPointerException.class)
   public void testNullSource() {
-    new UserPageFactory(null);
+    new ListUsersPage.Factory(null);
   }
 
   @Test
   public void testInvalidPageToken() throws IOException {
     TestUserSource source = new TestUserSource(1);
     try {
-      new UserPageFactory(source, 1000, "");
+      new ListUsersPage.Factory(source, 1000, "");
       fail("No error thrown for empty page token");
     } catch (IllegalArgumentException expected) {
       // expected
@@ -327,21 +327,21 @@ public class ListUsersPageTest {
   public void testInvalidMaxResults() throws IOException {
     TestUserSource source = new TestUserSource(1);
     try {
-      new UserPageFactory(source, 1001, "");
+      new ListUsersPage.Factory(source, 1001, "");
       fail("No error thrown for maxResult > 1000");
     } catch (IllegalArgumentException expected) {
       // expected
     }
 
     try {
-      new UserPageFactory(source, 0, "next");
+      new ListUsersPage.Factory(source, 0, "next");
       fail("No error thrown for maxResult = 0");
     } catch (IllegalArgumentException expected) {
       // expected
     }
 
     try {
-      new UserPageFactory(source, -1, "next");
+      new ListUsersPage.Factory(source, -1, "next");
       fail("No error thrown for maxResult < 0");
     } catch (IllegalArgumentException expected) {
       // expected

--- a/src/test/java/com/google/firebase/auth/ListUsersPageTest.java
+++ b/src/test/java/com/google/firebase/auth/ListUsersPageTest.java
@@ -28,6 +28,7 @@ import com.google.api.client.json.JsonFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
 import com.google.firebase.auth.ListUsersPage.ListUsersResult;
+import com.google.firebase.auth.ListUsersPage.UserPageFactory;
 import com.google.firebase.auth.internal.DownloadAccountResponse;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,7 +46,7 @@ public class ListUsersPageTest {
   @Test
   public void testSinglePage() throws FirebaseAuthException, IOException {
     TestUserSource source = new TestUserSource(3);
-    ListUsersPage page = new ListUsersPage.PageFactory(source).create();
+    ListUsersPage page = new UserPageFactory(source).create();
     assertFalse(page.hasNextPage());
     assertEquals(ListUsersPage.END_OF_LIST, page.getNextPageToken());
     assertNull(page.getNextPage());
@@ -68,7 +69,7 @@ public class ListUsersPageTest {
             newUser("user2", REDACTED_BASE64)),
         ListUsersPage.END_OF_LIST);
     TestUserSource source = new TestUserSource(result);
-    ListUsersPage page = new ListUsersPage.PageFactory(source).create();
+    ListUsersPage page = new UserPageFactory(source).create();
     assertFalse(page.hasNextPage());
     assertEquals(ListUsersPage.END_OF_LIST, page.getNextPageToken());
     assertNull(page.getNextPage());
@@ -89,7 +90,7 @@ public class ListUsersPageTest {
         ImmutableList.of(newUser("user0"), newUser("user1"), newUser("user2")),
         "token");
     TestUserSource source = new TestUserSource(result);
-    ListUsersPage page1 = new ListUsersPage.PageFactory(source).create();
+    ListUsersPage page1 = new UserPageFactory(source).create();
     assertTrue(page1.hasNextPage());
     assertEquals("token", page1.getNextPageToken());
     ImmutableList<ExportedUserRecord> users = ImmutableList.copyOf(page1.getValues());
@@ -136,7 +137,7 @@ public class ListUsersPageTest {
   @Test
   public void testListUsersIterable() throws FirebaseAuthException, IOException {
     TestUserSource source = new TestUserSource(3);
-    ListUsersPage page = new ListUsersPage.PageFactory(source).create();
+    ListUsersPage page = new UserPageFactory(source).create();
     Iterable<ExportedUserRecord> users = page.iterateAll();
 
     int iterations = 0;
@@ -162,7 +163,7 @@ public class ListUsersPageTest {
   @Test
   public void testListUsersIterator() throws FirebaseAuthException, IOException {
     TestUserSource source = new TestUserSource(3);
-    ListUsersPage page = new ListUsersPage.PageFactory(source).create();
+    ListUsersPage page = new UserPageFactory(source).create();
     Iterable<ExportedUserRecord> users = page.iterateAll();
     Iterator<ExportedUserRecord> iterator = users.iterator();
     int iterations = 0;
@@ -192,7 +193,7 @@ public class ListUsersPageTest {
         ImmutableList.of(newUser("user0"), newUser("user1"), newUser("user2")),
         "token");
     TestUserSource source = new TestUserSource(result);
-    ListUsersPage page = new ListUsersPage.PageFactory(source).create();
+    ListUsersPage page = new UserPageFactory(source).create();
     int iterations = 0;
     for (ExportedUserRecord user : page.iterateAll()) {
       assertEquals("user" + iterations, user.getUid());
@@ -218,7 +219,7 @@ public class ListUsersPageTest {
         ImmutableList.of(newUser("user0"), newUser("user1"), newUser("user2")),
         "token");
     TestUserSource source = new TestUserSource(result);
-    ListUsersPage page = new ListUsersPage.PageFactory(source).create();
+    ListUsersPage page = new UserPageFactory(source).create();
     Iterator<ExportedUserRecord> users = page.iterateAll().iterator();
     int iterations = 0;
     while (users.hasNext()) {
@@ -251,7 +252,7 @@ public class ListUsersPageTest {
         ImmutableList.<ExportedUserRecord>of(),
         ListUsersPage.END_OF_LIST);
     TestUserSource source = new TestUserSource(result);
-    ListUsersPage page = new ListUsersPage.PageFactory(source).create();
+    ListUsersPage page = new UserPageFactory(source).create();
     assertFalse(page.hasNextPage());
     assertEquals(ListUsersPage.END_OF_LIST, page.getNextPageToken());
     assertNull(page.getNextPage());
@@ -265,7 +266,7 @@ public class ListUsersPageTest {
         ImmutableList.<ExportedUserRecord>of(),
         ListUsersPage.END_OF_LIST);
     TestUserSource source = new TestUserSource(result);
-    ListUsersPage page = new ListUsersPage.PageFactory(source).create();
+    ListUsersPage page = new UserPageFactory(source).create();
     for (ExportedUserRecord user : page.iterateAll()) {
       fail("Should not be able to iterate, but got: " + user);
     }
@@ -279,7 +280,7 @@ public class ListUsersPageTest {
         ListUsersPage.END_OF_LIST);
     TestUserSource source = new TestUserSource(result);
 
-    ListUsersPage page = new ListUsersPage.PageFactory(source).create();
+    ListUsersPage page = new UserPageFactory(source).create();
     Iterator<ExportedUserRecord> iterator = page.iterateAll().iterator();
     while (iterator.hasNext()) {
       fail("Should not be able to iterate");
@@ -294,7 +295,7 @@ public class ListUsersPageTest {
         ListUsersPage.END_OF_LIST);
     TestUserSource source = new TestUserSource(result);
 
-    ListUsersPage page = new ListUsersPage.PageFactory(source).create();
+    ListUsersPage page = new UserPageFactory(source).create();
     Iterator<ExportedUserRecord> iterator = page.iterateAll().iterator();
     while (iterator.hasNext()) {
       assertNotNull(iterator.next());
@@ -308,14 +309,14 @@ public class ListUsersPageTest {
 
   @Test(expected = NullPointerException.class)
   public void testNullSource() {
-    new ListUsersPage.PageFactory(null);
+    new UserPageFactory(null);
   }
 
   @Test
   public void testInvalidPageToken() throws IOException {
     TestUserSource source = new TestUserSource(1);
     try {
-      new ListUsersPage.PageFactory(source, 1000, "");
+      new UserPageFactory(source, 1000, "");
       fail("No error thrown for empty page token");
     } catch (IllegalArgumentException expected) {
       // expected
@@ -326,21 +327,21 @@ public class ListUsersPageTest {
   public void testInvalidMaxResults() throws IOException {
     TestUserSource source = new TestUserSource(1);
     try {
-      new ListUsersPage.PageFactory(source, 1001, "");
+      new UserPageFactory(source, 1001, "");
       fail("No error thrown for maxResult > 1000");
     } catch (IllegalArgumentException expected) {
       // expected
     }
 
     try {
-      new ListUsersPage.PageFactory(source, 0, "next");
+      new UserPageFactory(source, 0, "next");
       fail("No error thrown for maxResult = 0");
     } catch (IllegalArgumentException expected) {
       // expected
     }
 
     try {
-      new ListUsersPage.PageFactory(source, -1, "next");
+      new UserPageFactory(source, -1, "next");
       fail("No error thrown for maxResult < 0");
     } catch (IllegalArgumentException expected) {
       // expected

--- a/src/test/resources/listOidc.json
+++ b/src/test/resources/listOidc.json
@@ -1,0 +1,15 @@
+{
+  "oauthIdpConfigs" : [ {
+    "name": "projects/projectId/oauthIdpConfigs/oidc.provider-id1",
+    "displayName" : "DISPLAY_NAME",
+    "enabled" : true,
+    "clientId" : "CLIENT_ID",
+    "issuer" : "https://oidc.com/issuer"
+  }, {
+    "name": "projects/projectId/oauthIdpConfigs/oidc.provider-id2",
+    "displayName" : "DISPLAY_NAME",
+    "enabled" : true,
+    "clientId" : "CLIENT_ID",
+    "issuer" : "https://oidc.com/issuer"
+  } ]
+}


### PR DESCRIPTION
This adds an operation to list OIDC provider configs (can be done using either the tenant-aware or standard Firebase client). This is the last OIDC provider config operation that needs to be implemented.

This work is part of adding multi-tenancy support (see issue #332).

Please take note of the generics I have chosen to use in ListProviderConfigsPage. This should help reduce a lot of code duplication when it comes time to add support for SAML provider configs.