### PR TITLE
chore: Setting the version of the Maven Javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
                     <plugin>
                         <!-- Generate API docs using Doclava for the developer site -->
                         <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.10.4</version>
                         <executions>
                             <execution>
                                 <phase>site</phase>
@@ -303,6 +304,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Doclava doesn't seem to work well with the latest versions (v3) of the Maven Javadoc plugin. Generated output hierarchy is different from what we are used to. Until we figure out a proper solution, I'm defaulting to the v2 of the plugin.