### PR TITLE
chore: Updated integration tests to use non-public rules

### DIFF
--- a/src/test/java/com/google/firebase/database/integration/OrderByTestIT.java
+++ b/src/test/java/com/google/firebase/database/integration/OrderByTestIT.java
@@ -19,7 +19,6 @@ package com.google.firebase.database.integration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import com.google.api.client.json.GenericJson;
 import com.google.common.collect.ImmutableList;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.database.ChildEventListener;
@@ -66,7 +65,9 @@ public class OrderByTestIT {
 
   @AfterClass
   public static void tearDownClass() throws IOException {
-    uploadRules(masterApp, "{\"rules\": {\".read\": true, \".write\": true}}");
+    uploadRules(
+        masterApp,
+        "{\"rules\": {\".read\": \"auth != null\", \".write\": \"auth != null\"}}");
   }
 
   @Before
@@ -81,7 +82,8 @@ public class OrderByTestIT {
 
   private static String formatRules(DatabaseReference ref, String rules) {
     return String.format(
-        "{\"rules\": {\".read\": true, \".write\": true, \"%s\": %s}}", ref.getKey(), rules);
+        "{\"rules\": {\".read\": \"auth != null\", \".write\": \"auth != null\", \"%s\": %s}}",
+        ref.getKey(), rules);
   }
 
   private static void uploadRules(FirebaseApp app, String rules) throws IOException {
@@ -922,7 +924,7 @@ public class OrderByTestIT {
 
   @Test
   public void testStartAtAndEndAtOnValueIndex()
-      throws InterruptedException, ExecutionException, TimeoutException, TestFailure, IOException {
+      throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp) ;
 
     Map<String, Object> initial =
@@ -982,7 +984,7 @@ public class OrderByTestIT {
 
   @Test
   public void testRemovingDefaultListener()
-      throws InterruptedException, ExecutionException, TimeoutException, TestFailure, IOException {
+      throws InterruptedException, ExecutionException, TimeoutException, TestFailure {
     DatabaseReference ref = IntegrationTestUtils.getRandomNode(masterApp) ;
 
     Object initialData = MapBuilder.of("key", "value");


### PR DESCRIPTION
Updating the integration test to not reset the RTDB rules to public after each invocation.