### PR TITLE
fix(auth): Make user import hashing classes final

### DIFF
--- a/src/main/java/com/google/firebase/auth/hash/Bcrypt.java
+++ b/src/main/java/com/google/firebase/auth/hash/Bcrypt.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * Represents the Bcrypt password hashing algorithm. Can be used as an instance of
  * {@link com.google.firebase.auth.UserImportHash} when importing users.
  */
-public class Bcrypt extends UserImportHash {
+public final class Bcrypt extends UserImportHash {
 
   private Bcrypt() {
     super("BCRYPT");

--- a/src/main/java/com/google/firebase/auth/hash/HmacMd5.java
+++ b/src/main/java/com/google/firebase/auth/hash/HmacMd5.java
@@ -20,7 +20,7 @@ package com.google.firebase.auth.hash;
  * Represents the HMAC MD5 password hashing algorithm. Can be used as an instance of
  * {@link com.google.firebase.auth.UserImportHash} when importing users.
  */
-public class HmacMd5 extends Hmac {
+public final class HmacMd5 extends Hmac {
 
   private HmacMd5(Builder builder) {
     super("HMAC_MD5", builder);

--- a/src/main/java/com/google/firebase/auth/hash/HmacSha1.java
+++ b/src/main/java/com/google/firebase/auth/hash/HmacSha1.java
@@ -20,7 +20,7 @@ package com.google.firebase.auth.hash;
  * Represents the HMAC SHA1 password hashing algorithm. Can be used as an instance of
  * {@link com.google.firebase.auth.UserImportHash} when importing users.
  */
-public class HmacSha1 extends Hmac {
+public final class HmacSha1 extends Hmac {
 
   private HmacSha1(Builder builder) {
     super("HMAC_SHA1", builder);

--- a/src/main/java/com/google/firebase/auth/hash/HmacSha256.java
+++ b/src/main/java/com/google/firebase/auth/hash/HmacSha256.java
@@ -20,7 +20,7 @@ package com.google.firebase.auth.hash;
  * Represents the HMAC SHA256 password hashing algorithm. Can be used as an instance of
  * {@link com.google.firebase.auth.UserImportHash} when importing users.
  */
-public class HmacSha256 extends Hmac {
+public final class HmacSha256 extends Hmac {
 
   private HmacSha256(Builder builder) {
     super("HMAC_SHA256", builder);

--- a/src/main/java/com/google/firebase/auth/hash/HmacSha512.java
+++ b/src/main/java/com/google/firebase/auth/hash/HmacSha512.java
@@ -20,7 +20,7 @@ package com.google.firebase.auth.hash;
  * Represents the HMAC SHA512 password hashing algorithm. Can be used as an instance of
  * {@link com.google.firebase.auth.UserImportHash} when importing users.
  */
-public class HmacSha512 extends Hmac {
+public final class HmacSha512 extends Hmac {
 
   private HmacSha512(Builder builder) {
     super("HMAC_SHA512", builder);

--- a/src/main/java/com/google/firebase/auth/hash/Md5.java
+++ b/src/main/java/com/google/firebase/auth/hash/Md5.java
@@ -20,7 +20,7 @@ package com.google.firebase.auth.hash;
  * Represents the MD5 password hashing algorithm. Can be used as an instance of
  * {@link com.google.firebase.auth.UserImportHash} when importing users.
  */
-public class Md5 extends RepeatableHash {
+public final class Md5 extends RepeatableHash {
 
   private Md5(Builder builder) {
     super("MD5", 0, 8192, builder);

--- a/src/main/java/com/google/firebase/auth/hash/Pbkdf2Sha256.java
+++ b/src/main/java/com/google/firebase/auth/hash/Pbkdf2Sha256.java
@@ -20,7 +20,7 @@ package com.google.firebase.auth.hash;
  * Represents the PBKDF2 SHA256 password hashing algorithm. Can be used as an instance of
  * {@link com.google.firebase.auth.UserImportHash} when importing users.
  */
-public class Pbkdf2Sha256 extends RepeatableHash {
+public final class Pbkdf2Sha256 extends RepeatableHash {
 
   private Pbkdf2Sha256(Builder builder) {
     super("PBKDF2_SHA256", 0, 120000, builder);

--- a/src/main/java/com/google/firebase/auth/hash/PbkdfSha1.java
+++ b/src/main/java/com/google/firebase/auth/hash/PbkdfSha1.java
@@ -20,7 +20,7 @@ package com.google.firebase.auth.hash;
  * Represents the PBKDF SHA1 password hashing algorithm. Can be used as an instance of
  * {@link com.google.firebase.auth.UserImportHash} when importing users.
  */
-public class PbkdfSha1 extends RepeatableHash {
+public final class PbkdfSha1 extends RepeatableHash {
 
   private PbkdfSha1(Builder builder) {
     super("PBKDF_SHA1", 0, 120000, builder);

--- a/src/main/java/com/google/firebase/auth/hash/Sha1.java
+++ b/src/main/java/com/google/firebase/auth/hash/Sha1.java
@@ -20,7 +20,7 @@ package com.google.firebase.auth.hash;
  * Represents the SHA1 password hashing algorithm. Can be used as an instance of
  * {@link com.google.firebase.auth.UserImportHash} when importing users.
  */
-public class Sha1 extends RepeatableHash {
+public final class Sha1 extends RepeatableHash {
 
   private Sha1(Builder builder) {
     super("SHA1", 1, 8192, builder);

--- a/src/main/java/com/google/firebase/auth/hash/Sha256.java
+++ b/src/main/java/com/google/firebase/auth/hash/Sha256.java
@@ -20,7 +20,7 @@ package com.google.firebase.auth.hash;
  * Represents the SHA256 password hashing algorithm. Can be used as an instance of
  * {@link com.google.firebase.auth.UserImportHash} when importing users.
  */
-public class Sha256 extends RepeatableHash {
+public final class Sha256 extends RepeatableHash {
 
   private Sha256(Builder builder) {
     super("SHA256", 1, 8192, builder);

--- a/src/main/java/com/google/firebase/auth/hash/Sha512.java
+++ b/src/main/java/com/google/firebase/auth/hash/Sha512.java
@@ -20,7 +20,7 @@ package com.google.firebase.auth.hash;
  * Represents the SHA512 password hashing algorithm. Can be used as an instance of
  * {@link com.google.firebase.auth.UserImportHash} when importing users.
  */
-public class Sha512 extends RepeatableHash {
+public final class Sha512 extends RepeatableHash {
 
   private Sha512(Builder builder) {
     super("SHA512", 1, 8192, builder);

--- a/src/main/java/com/google/firebase/auth/hash/StandardScrypt.java
+++ b/src/main/java/com/google/firebase/auth/hash/StandardScrypt.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * Represents the Standard Scrypt password hashing algorithm. Can be used as an instance of
  * {@link com.google.firebase.auth.UserImportHash} when importing users.
  */
-public class StandardScrypt extends UserImportHash {
+public final class StandardScrypt extends UserImportHash {
 
   private final int derivedKeyLength;
   private final int blockSize;


### PR DESCRIPTION
While working on the .NET port of user imports I brought up the fact that these classes weren't final in the Java version; this PR revisits that idea.

API CHANGE: All public implementations of `UserImportHash` class are now marked `final`.