### PR TITLE
Refactor user test utilities and use TemporaryUser in tenant-aware integration tests.

### DIFF
--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -47,6 +47,8 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.ImplFirebaseTrampolines;
 import com.google.firebase.auth.ProviderConfigTestUtils.TemporaryProviderConfig;
+import com.google.firebase.auth.UserTestUtils.RandomUser;
+import com.google.firebase.auth.UserTestUtils.TemporaryUser;
 import com.google.firebase.auth.hash.Scrypt;
 import com.google.firebase.internal.Nullable;
 import com.google.firebase.testing.IntegrationTestUtils;
@@ -56,8 +58,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -85,7 +85,7 @@ public class FirebaseAuthIT {
   private static final FirebaseAuth auth = FirebaseAuth.getInstance(
       IntegrationTestUtils.ensureDefaultApp());
 
-  @Rule public final TemporaryUser temporaryUser = new TemporaryUser();
+  @Rule public final TemporaryUser temporaryUser = new TemporaryUser(auth);
   @Rule public final TemporaryProviderConfig temporaryProviderConfig =
       new TemporaryProviderConfig(auth);
 
@@ -139,22 +139,21 @@ public class FirebaseAuthIT {
 
   @Test
   public void testCreateUserWithParams() throws Exception {
-    RandomUser randomUser = RandomUser.create();
-    String phone = randomPhoneNumber();
+    RandomUser randomUser = UserTestUtils.generateRandomUserInfo();
     UserRecord.CreateRequest user = new UserRecord.CreateRequest()
-        .setUid(randomUser.uid)
-        .setEmail(randomUser.email)
-        .setPhoneNumber(phone)
+        .setUid(randomUser.getUid())
+        .setEmail(randomUser.getEmail())
+        .setPhoneNumber(randomUser.getPhoneNumber())
         .setDisplayName("Random User")
         .setPhotoUrl("https://example.com/photo.png")
         .setEmailVerified(true)
         .setPassword("password");
 
     UserRecord userRecord = temporaryUser.create(user);
-    assertEquals(randomUser.uid, userRecord.getUid());
+    assertEquals(randomUser.getUid(), userRecord.getUid());
     assertEquals("Random User", userRecord.getDisplayName());
-    assertEquals(randomUser.email, userRecord.getEmail());
-    assertEquals(phone, userRecord.getPhoneNumber());
+    assertEquals(randomUser.getEmail(), userRecord.getEmail());
+    assertEquals(randomUser.getPhoneNumber(), userRecord.getPhoneNumber());
     assertEquals("https://example.com/photo.png", userRecord.getPhotoUrl());
     assertTrue(userRecord.isEmailVerified());
     assertFalse(userRecord.isDisabled());
@@ -167,7 +166,7 @@ public class FirebaseAuthIT {
     assertTrue(providers.contains("password"));
     assertTrue(providers.contains("phone"));
 
-    checkRecreateUser(randomUser.uid);
+    checkRecreateUser(randomUser.getUid());
   }
 
   @Test
@@ -192,12 +191,11 @@ public class FirebaseAuthIT {
     assertTrue(userRecord.getCustomClaims().isEmpty());
 
     // Update user
-    RandomUser randomUser = RandomUser.create();
-    String phone = randomPhoneNumber();
+    RandomUser randomUser = UserTestUtils.generateRandomUserInfo();
     UserRecord.UpdateRequest request = userRecord.updateRequest()
         .setDisplayName("Updated Name")
-        .setEmail(randomUser.email)
-        .setPhoneNumber(phone)
+        .setEmail(randomUser.getEmail())
+        .setPhoneNumber(randomUser.getPhoneNumber())
         .setPhotoUrl("https://example.com/photo.png")
         .setEmailVerified(true)
         .setPassword("secret");
@@ -205,8 +203,8 @@ public class FirebaseAuthIT {
     assertEquals(uid, userRecord.getUid());
     assertNull(userRecord.getTenantId());
     assertEquals("Updated Name", userRecord.getDisplayName());
-    assertEquals(randomUser.email, userRecord.getEmail());
-    assertEquals(phone, userRecord.getPhoneNumber());
+    assertEquals(randomUser.getEmail(), userRecord.getEmail());
+    assertEquals(randomUser.getPhoneNumber(), userRecord.getPhoneNumber());
     assertEquals("https://example.com/photo.png", userRecord.getPhotoUrl());
     assertTrue(userRecord.isEmailVerified());
     assertFalse(userRecord.isDisabled());
@@ -227,7 +225,7 @@ public class FirebaseAuthIT {
     assertEquals(uid, userRecord.getUid());
     assertNull(userRecord.getTenantId());
     assertNull(userRecord.getDisplayName());
-    assertEquals(randomUser.email, userRecord.getEmail());
+    assertEquals(randomUser.getEmail(), userRecord.getEmail());
     assertNull(userRecord.getPhoneNumber());
     assertNull(userRecord.getPhotoUrl());
     assertTrue(userRecord.isEmailVerified());
@@ -237,7 +235,7 @@ public class FirebaseAuthIT {
 
     // Delete user
     auth.deleteUserAsync(userRecord.getUid()).get();
-    assertUserDoesNotExist(auth, userRecord.getUid());
+    UserTestUtils.assertUserDoesNotExist(auth, userRecord.getUid());
   }
 
   @Test
@@ -454,29 +452,29 @@ public class FirebaseAuthIT {
 
   @Test
   public void testImportUsers() throws Exception {
-    RandomUser randomUser = RandomUser.create();
+    RandomUser randomUser = UserTestUtils.generateRandomUserInfo();
     ImportUserRecord user = ImportUserRecord.builder()
-        .setUid(randomUser.uid)
-        .setEmail(randomUser.email)
+        .setUid(randomUser.getUid())
+        .setEmail(randomUser.getEmail())
         .build();
 
     UserImportResult result = auth.importUsersAsync(ImmutableList.of(user)).get();
-    temporaryUser.registerUid(randomUser.uid);
+    temporaryUser.registerUid(randomUser.getUid());
     assertEquals(1, result.getSuccessCount());
     assertEquals(0, result.getFailureCount());
 
-    UserRecord savedUser = auth.getUserAsync(randomUser.uid).get();
-    assertEquals(randomUser.email, savedUser.getEmail());
+    UserRecord savedUser = auth.getUserAsync(randomUser.getUid()).get();
+    assertEquals(randomUser.getEmail(), savedUser.getEmail());
   }
 
   @Test
   public void testImportUsersWithPassword() throws Exception {
-    RandomUser randomUser = RandomUser.create();
+    RandomUser randomUser = UserTestUtils.generateRandomUserInfo();
     final byte[] passwordHash = BaseEncoding.base64().decode(
         "V358E8LdWJXAO7muq0CufVpEOXaj8aFiC7T/rcaGieN04q/ZPJ08WhJEHGjj9lz/2TT+/86N5VjVoc5DdBhBiw==");
     ImportUserRecord user = ImportUserRecord.builder()
-        .setUid(randomUser.uid)
-        .setEmail(randomUser.email)
+        .setUid(randomUser.getUid())
+        .setEmail(randomUser.getEmail())
         .setPasswordHash(passwordHash)
         .setPasswordSalt("NaCl".getBytes())
         .build();
@@ -492,46 +490,46 @@ public class FirebaseAuthIT {
             .setRounds(8)
             .setMemoryCost(14)
             .build())).get();
-    temporaryUser.registerUid(randomUser.uid);
+    temporaryUser.registerUid(randomUser.getUid());
     assertEquals(1, result.getSuccessCount());
     assertEquals(0, result.getFailureCount());
 
-    UserRecord savedUser = auth.getUserAsync(randomUser.uid).get();
-    assertEquals(randomUser.email, savedUser.getEmail());
-    String idToken = signInWithPassword(randomUser.email, "password");
+    UserRecord savedUser = auth.getUserAsync(randomUser.getUid()).get();
+    assertEquals(randomUser.getEmail(), savedUser.getEmail());
+    String idToken = signInWithPassword(randomUser.getEmail(), "password");
     assertFalse(Strings.isNullOrEmpty(idToken));
   }
 
   @Test
   public void testGeneratePasswordResetLink() throws Exception {
-    RandomUser user = RandomUser.create();
+    RandomUser user = UserTestUtils.generateRandomUserInfo();
     temporaryUser.create(new UserRecord.CreateRequest()
-        .setUid(user.uid)
-        .setEmail(user.email)
+        .setUid(user.getUid())
+        .setEmail(user.getEmail())
         .setEmailVerified(false)
         .setPassword("password"));
-    String link = auth.generatePasswordResetLink(user.email, ActionCodeSettings.builder()
+    String link = auth.generatePasswordResetLink(user.getEmail(), ActionCodeSettings.builder()
         .setUrl(ACTION_LINK_CONTINUE_URL)
         .setHandleCodeInApp(false)
         .build());
     Map<String, String> linkParams = parseLinkParameters(link);
     assertEquals(ACTION_LINK_CONTINUE_URL, linkParams.get("continueUrl"));
-    String email = resetPassword(user.email, "password", "newpassword",
+    String email = resetPassword(user.getEmail(), "password", "newpassword",
         linkParams.get("oobCode"));
-    assertEquals(user.email, email);
+    assertEquals(user.getEmail(), email);
     // Password reset also verifies the user's email
-    assertTrue(auth.getUser(user.uid).isEmailVerified());
+    assertTrue(auth.getUser(user.getUid()).isEmailVerified());
   }
 
   @Test
   public void testGenerateEmailVerificationResetLink() throws Exception {
-    RandomUser user = RandomUser.create();
+    RandomUser user = UserTestUtils.generateRandomUserInfo();
     temporaryUser.create(new UserRecord.CreateRequest()
-        .setUid(user.uid)
-        .setEmail(user.email)
+        .setUid(user.getUid())
+        .setEmail(user.getEmail())
         .setEmailVerified(false)
         .setPassword("password"));
-    String link = auth.generateEmailVerificationLink(user.email, ActionCodeSettings.builder()
+    String link = auth.generateEmailVerificationLink(user.getEmail(), ActionCodeSettings.builder()
         .setUrl(ACTION_LINK_CONTINUE_URL)
         .setHandleCodeInApp(false)
         .build());
@@ -544,21 +542,21 @@ public class FirebaseAuthIT {
 
   @Test
   public void testGenerateSignInWithEmailLink() throws Exception {
-    RandomUser user = RandomUser.create();
+    RandomUser user = UserTestUtils.generateRandomUserInfo();
     temporaryUser.create(new UserRecord.CreateRequest()
-        .setUid(user.uid)
-        .setEmail(user.email)
+        .setUid(user.getUid())
+        .setEmail(user.getEmail())
         .setEmailVerified(false)
         .setPassword("password"));
-    String link = auth.generateSignInWithEmailLink(user.email, ActionCodeSettings.builder()
+    String link = auth.generateSignInWithEmailLink(user.getEmail(), ActionCodeSettings.builder()
         .setUrl(ACTION_LINK_CONTINUE_URL)
         .setHandleCodeInApp(false)
         .build());
     Map<String, String> linkParams = parseLinkParameters(link);
     assertEquals(ACTION_LINK_CONTINUE_URL, linkParams.get("continueUrl"));
-    String idToken = signInWithEmailLink(user.email, linkParams.get("oobCode"));
+    String idToken = signInWithEmailLink(user.getEmail(), linkParams.get("oobCode"));
     assertFalse(Strings.isNullOrEmpty(idToken));
-    assertTrue(auth.getUser(user.uid).isEmailVerified());
+    assertTrue(auth.getUser(user.getUid()).isEmailVerified());
   }
 
   @Test
@@ -812,15 +810,6 @@ public class FirebaseAuthIT {
     return result;
   }
 
-  private String randomPhoneNumber() {
-    Random random = new Random();
-    StringBuilder builder = new StringBuilder("+1");
-    for (int i = 0; i < 10; i++) {
-      builder.append(random.nextInt(10));
-    }
-    return builder.toString();
-  }
-
   private String signInWithCustomToken(String customToken) throws IOException {
     return signInWithCustomToken(customToken, null);
   }
@@ -910,23 +899,6 @@ public class FirebaseAuthIT {
     }
   }
 
-  private static class RandomUser {
-    private final String uid;
-    private final String email;
-
-    private RandomUser(String uid, String email) {
-      this.uid = uid;
-      this.email = email;
-    }
-
-    static RandomUser create() {
-      final String uid = UUID.randomUUID().toString().replaceAll("-", "");
-      final String email = ("test" + uid.substring(0, 12) + "@example."
-          + uid.substring(12) + ".com").toLowerCase();
-      return new RandomUser(uid, email);
-    }
-  }
-
   private boolean checkOidcProviderConfig(List<String> providerIds, OidcProviderConfig config) {
     if (providerIds.contains(config.getProviderId())) {
       assertEquals("CLIENT_ID", config.getClientId());
@@ -947,48 +919,5 @@ public class FirebaseAuthIT {
     }
     return false;
   }
-
-  private static void assertUserDoesNotExist(AbstractFirebaseAuth firebaseAuth, String uid)
-      throws Exception {
-    try {
-      firebaseAuth.getUserAsync(uid).get();
-      fail("No error thrown for getting a user which was expected to be absent.");
-    } catch (ExecutionException e) {
-      assertTrue(e.getCause() instanceof FirebaseAuthException);
-      assertEquals(FirebaseUserManager.USER_NOT_FOUND_ERROR,
-          ((FirebaseAuthException) e.getCause()).getErrorCode());
-    }
-  }
-
-  /**
-   * Creates temporary Firebase user accounts for testing, and deletes them at the end of each
-   * test case.
-   */
-  private static final class TemporaryUser extends ExternalResource {
-
-    private final List<String> users = new ArrayList<>();
-
-    public UserRecord create(UserRecord.CreateRequest request) throws FirebaseAuthException {
-      UserRecord user = auth.createUser(request);
-      registerUid(user.getUid());
-      return user;
-    }
-
-    public synchronized void registerUid(String uid) {
-      users.add(uid);
-    }
-
-    @Override
-    protected synchronized void after() {
-      for (String uid : users) {
-        try {
-          auth.deleteUser(uid);
-        } catch (Exception ignore) {
-          // Ignore
-        }
-      }
-
-      users.clear();
-    }
-  }
 }
+

--- a/src/test/java/com/google/firebase/auth/UserTestUtils.java
+++ b/src/test/java/com/google/firebase/auth/UserTestUtils.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.auth;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import org.junit.rules.ExternalResource;
+
+final class UserTestUtils {
+
+  static void assertUserDoesNotExist(AbstractFirebaseAuth firebaseAuth, String uid)
+      throws Exception {
+    try {
+      firebaseAuth.getUserAsync(uid).get();
+      fail("No error thrown for getting a user which was expected to be absent.");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof FirebaseAuthException);
+      assertEquals(FirebaseUserManager.USER_NOT_FOUND_ERROR,
+          ((FirebaseAuthException) e.getCause()).getErrorCode());
+    }
+  }
+
+  static RandomUser generateRandomUserInfo() {
+    String uid = UUID.randomUUID().toString().replaceAll("-", "");
+    String email = String.format(
+        "test%s@example.%s.com",
+        uid.substring(0, 12),
+        uid.substring(12)).toLowerCase();
+    return new RandomUser(uid, email, generateRandomPhoneNumber());
+  }
+
+  private static String generateRandomPhoneNumber() {
+    Random random = new Random();
+    StringBuilder builder = new StringBuilder("+1");
+    for (int i = 0; i < 10; i++) {
+      builder.append(random.nextInt(10));
+    }
+    return builder.toString();
+  }
+
+  static class RandomUser {
+    private final String uid;
+    private final String email;
+    private final String phoneNumber;
+
+    private RandomUser(String uid, String email, String phoneNumber) {
+      this.uid = uid;
+      this.email = email;
+      this.phoneNumber = phoneNumber;
+    }
+
+    String getUid() {
+      return uid;
+    }
+
+    String getEmail() {
+      return email;
+    }
+
+    String getPhoneNumber() {
+      return phoneNumber;
+    }
+  }
+
+  /**
+   * Creates temporary Firebase user accounts for testing, and deletes them at the end of each
+   * test case.
+   */
+  static final class TemporaryUser extends ExternalResource {
+
+    private final AbstractFirebaseAuth auth;
+    private final List<String> users = new ArrayList<>();
+
+    TemporaryUser(AbstractFirebaseAuth auth) {
+      this.auth = auth;
+    }
+
+    public UserRecord create(UserRecord.CreateRequest request) throws FirebaseAuthException {
+      UserRecord user = auth.createUser(request);
+      registerUid(user.getUid());
+      return user;
+    }
+
+    public synchronized void registerUid(String uid) {
+      users.add(uid);
+    }
+
+    @Override
+    protected synchronized void after() {
+      for (String uid : users) {
+        try {
+          auth.deleteUser(uid);
+        } catch (Exception ignore) {
+          // Ignore
+        }
+      }
+
+      users.clear();
+    }
+  }
+}
+


### PR DESCRIPTION
I've refactored the test utilities we use for users in order to reduce code duplication, and I've also made `TenantAwareFirebaseAuthIT` use `TemporaryUser`.