### PR TITLE
fix: Cleaning up FirebaseApp state management

### DIFF
--- a/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/src/main/java/com/google/firebase/FirebaseApp.java
@@ -34,7 +34,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
-import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.firebase.internal.FirebaseAppStore;
 import com.google.firebase.internal.FirebaseScheduledExecutor;
@@ -293,6 +292,8 @@ public class FirebaseApp {
    */
   @Nullable
   String getProjectId() {
+    checkNotDeleted();
+
     // Try to get project ID from user-specified options.
     String projectId = options.getProjectId();
 
@@ -330,8 +331,10 @@ public class FirebaseApp {
   }
 
   /**
-   * Deletes the {@link FirebaseApp} and all its data. All calls to this {@link FirebaseApp}
-   * instance will throw once it has been called.
+   * Deletes this {@link FirebaseApp} object and releases any local state and managed resources
+   * associated with it. All calls to this {@link FirebaseApp} instance will throw once this method
+   * has been called. This also releases any managed resources allocated by other services
+   * (e.g. {@code FirebaseAuth}, {@code FirebaseDatabase}) attached to this object instance.
    *
    * <p>A no-op if delete was called before.
    */

--- a/src/main/java/com/google/firebase/ImplFirebaseTrampolines.java
+++ b/src/main/java/com/google/firebase/ImplFirebaseTrampolines.java
@@ -26,7 +26,6 @@ import com.google.firebase.internal.FirebaseService;
 import com.google.firebase.internal.NonNull;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -18,7 +18,6 @@ package com.google.firebase.auth;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.util.Clock;
@@ -47,7 +46,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This class is the entry point for all server-side Firebase Authentication actions.
@@ -64,7 +62,6 @@ public class FirebaseAuth {
   private static final String ERROR_CUSTOM_TOKEN = "ERROR_CUSTOM_TOKEN";
 
   private final Object lock = new Object();
-  private final AtomicBoolean destroyed = new AtomicBoolean(false);
 
   private final FirebaseApp firebaseApp;
   private final Supplier<FirebaseTokenFactory> tokenFactory;
@@ -139,7 +136,6 @@ public class FirebaseAuth {
 
   private CallableOperation<String, FirebaseAuthException> createSessionCookieOp(
       final String idToken, final SessionCookieOptions options) {
-    checkNotDestroyed();
     checkArgument(!Strings.isNullOrEmpty(idToken), "idToken must not be null or empty");
     checkNotNull(options, "options must not be null");
     final FirebaseUserManager userManager = getUserManager();
@@ -214,7 +210,6 @@ public class FirebaseAuth {
 
   private CallableOperation<FirebaseToken, FirebaseAuthException> verifySessionCookieOp(
       final String cookie, final boolean checkRevoked) {
-    checkNotDestroyed();
     checkArgument(!Strings.isNullOrEmpty(cookie), "Session cookie must not be null or empty");
     final FirebaseTokenVerifier sessionCookieVerifier = getSessionCookieVerifier(checkRevoked);
     return new CallableOperation<FirebaseToken, FirebaseAuthException>() {
@@ -328,7 +323,6 @@ public class FirebaseAuth {
 
   private CallableOperation<String, FirebaseAuthException> createCustomTokenOp(
       final String uid, final Map<String, Object> developerClaims) {
-    checkNotDestroyed();
     checkArgument(!Strings.isNullOrEmpty(uid), "uid must not be null or empty");
     final FirebaseTokenFactory tokenFactory = this.tokenFactory.get();
     return new CallableOperation<String, FirebaseAuthException>() {
@@ -422,7 +416,6 @@ public class FirebaseAuth {
 
   private CallableOperation<FirebaseToken, FirebaseAuthException> verifyIdTokenOp(
       final String token, final boolean checkRevoked) {
-    checkNotDestroyed();
     checkArgument(!Strings.isNullOrEmpty(token), "ID token must not be null or empty");
     final FirebaseTokenVerifier verifier = getIdTokenVerifier(checkRevoked);
     return new CallableOperation<FirebaseToken, FirebaseAuthException>() {
@@ -476,7 +469,6 @@ public class FirebaseAuth {
   }
 
   private CallableOperation<Void, FirebaseAuthException> revokeRefreshTokensOp(final String uid) {
-    checkNotDestroyed();
     checkArgument(!Strings.isNullOrEmpty(uid), "uid must not be null or empty");
     final FirebaseUserManager userManager = getUserManager();
     return new CallableOperation<Void, FirebaseAuthException>() {
@@ -516,7 +508,6 @@ public class FirebaseAuth {
   }
 
   private CallableOperation<UserRecord, FirebaseAuthException> getUserOp(final String uid) {
-    checkNotDestroyed();
     checkArgument(!Strings.isNullOrEmpty(uid), "uid must not be null or empty");
     final FirebaseUserManager userManager = getUserManager();
     return new CallableOperation<UserRecord, FirebaseAuthException>() {
@@ -554,7 +545,6 @@ public class FirebaseAuth {
 
   private CallableOperation<UserRecord, FirebaseAuthException> getUserByEmailOp(
       final String email) {
-    checkNotDestroyed();
     checkArgument(!Strings.isNullOrEmpty(email), "email must not be null or empty");
     final FirebaseUserManager userManager = getUserManager();
     return new CallableOperation<UserRecord, FirebaseAuthException>() {
@@ -592,7 +582,6 @@ public class FirebaseAuth {
 
   private CallableOperation<UserRecord, FirebaseAuthException> getUserByPhoneNumberOp(
       final String phoneNumber) {
-    checkNotDestroyed();
     checkArgument(!Strings.isNullOrEmpty(phoneNumber), "phone number must not be null or empty");
     final FirebaseUserManager userManager = getUserManager();
     return new CallableOperation<UserRecord, FirebaseAuthException>() {
@@ -647,7 +636,6 @@ public class FirebaseAuth {
 
   private CallableOperation<GetUsersResult, FirebaseAuthException> getUsersOp(
       @NonNull final Collection<UserIdentifier> identifiers) {
-    checkNotDestroyed();
     checkNotNull(identifiers, "identifiers must not be null");
     checkArgument(identifiers.size() <= FirebaseUserManager.MAX_GET_ACCOUNTS_BATCH_SIZE,
         "identifiers parameter must have <= " + FirebaseUserManager.MAX_GET_ACCOUNTS_BATCH_SIZE
@@ -736,7 +724,6 @@ public class FirebaseAuth {
 
   private CallableOperation<ListUsersPage, FirebaseAuthException> listUsersOp(
       @Nullable final String pageToken, final int maxResults) {
-    checkNotDestroyed();
     final FirebaseUserManager userManager = getUserManager();
     final PageFactory factory = new PageFactory(
         new DefaultUserSource(userManager, jsonFactory), maxResults, pageToken);
@@ -776,7 +763,6 @@ public class FirebaseAuth {
 
   private CallableOperation<UserRecord, FirebaseAuthException> createUserOp(
       final CreateRequest request) {
-    checkNotDestroyed();
     checkNotNull(request, "create request must not be null");
     final FirebaseUserManager userManager = getUserManager();
     return new CallableOperation<UserRecord, FirebaseAuthException>() {
@@ -816,7 +802,6 @@ public class FirebaseAuth {
 
   private CallableOperation<UserRecord, FirebaseAuthException> updateUserOp(
       final UpdateRequest request) {
-    checkNotDestroyed();
     checkNotNull(request, "update request must not be null");
     final FirebaseUserManager userManager = getUserManager();
     return new CallableOperation<UserRecord, FirebaseAuthException>() {
@@ -869,7 +854,6 @@ public class FirebaseAuth {
 
   private CallableOperation<Void, FirebaseAuthException> setCustomUserClaimsOp(
       final String uid, final Map<String, Object> claims) {
-    checkNotDestroyed();
     checkArgument(!Strings.isNullOrEmpty(uid), "uid must not be null or empty");
     final FirebaseUserManager userManager = getUserManager();
     return new CallableOperation<Void, FirebaseAuthException>() {
@@ -907,7 +891,6 @@ public class FirebaseAuth {
   }
 
   private CallableOperation<Void, FirebaseAuthException> deleteUserOp(final String uid) {
-    checkNotDestroyed();
     checkArgument(!Strings.isNullOrEmpty(uid), "uid must not be null or empty");
     final FirebaseUserManager userManager = getUserManager();
     return new CallableOperation<Void, FirebaseAuthException>() {
@@ -961,7 +944,6 @@ public class FirebaseAuth {
 
   private CallableOperation<DeleteUsersResult, FirebaseAuthException> deleteUsersOp(
       final List<String> uids) {
-    checkNotDestroyed();
     checkNotNull(uids, "uids must not be null");
     for (String uid : uids) {
       UserRecord.checkUid(uid);
@@ -1048,7 +1030,6 @@ public class FirebaseAuth {
 
   private CallableOperation<UserImportResult, FirebaseAuthException> importUsersOp(
       final List<ImportUserRecord> users, final UserImportOptions options) {
-    checkNotDestroyed();
     final UserImportRequest request = new UserImportRequest(users, options, jsonFactory);
     final FirebaseUserManager userManager = getUserManager();
     return new CallableOperation<UserImportResult, FirebaseAuthException>() {
@@ -1226,7 +1207,6 @@ public class FirebaseAuth {
 
   private CallableOperation<String, FirebaseAuthException> generateEmailActionLinkOp(
           final EmailLinkType type, final String email, final ActionCodeSettings settings) {
-    checkNotDestroyed();
     checkArgument(!Strings.isNullOrEmpty(email), "email must not be null or empty");
     if (type == EmailLinkType.EMAIL_SIGNIN) {
       checkNotNull(settings, "ActionCodeSettings must not be null when generating sign-in links");
@@ -1246,24 +1226,10 @@ public class FirebaseAuth {
       public T get() {
         checkNotNull(supplier);
         synchronized (lock) {
-          checkNotDestroyed();
           return supplier.get();
         }
       }
     });
-  }
-
-  private void checkNotDestroyed() {
-    synchronized (lock) {
-      checkState(!destroyed.get(), "FirebaseAuth instance is no longer alive. This happens when "
-          + "the parent FirebaseApp instance has been deleted.");
-    }
-  }
-
-  private void destroy() {
-    synchronized (lock) {
-      destroyed.set(true);
-    }
   }
 
   private static FirebaseAuth fromApp(final FirebaseApp app) {
@@ -1344,11 +1310,6 @@ public class FirebaseAuth {
 
     FirebaseAuthService(FirebaseApp app) {
       super(SERVICE_ID, FirebaseAuth.fromApp(app));
-    }
-
-    @Override
-    public void destroy() {
-      instance.destroy();
     }
   }
 }

--- a/src/main/java/com/google/firebase/cloud/StorageClient.java
+++ b/src/main/java/com/google/firebase/cloud/StorageClient.java
@@ -106,13 +106,6 @@ public class StorageClient {
     StorageClientService(StorageClient client) {
       super(SERVICE_ID, client);
     }
-
-    @Override
-    public void destroy() {
-      // NOTE: We don't explicitly tear down anything here, but public methods of StorageClient
-      // will now fail because calls to getOptions() and getToken() will hit FirebaseApp,
-      // which will throw once the app is deleted.
-    }
   }
 
 }

--- a/src/main/java/com/google/firebase/database/FirebaseDatabase.java
+++ b/src/main/java/com/google/firebase/database/FirebaseDatabase.java
@@ -358,6 +358,10 @@ public class FirebaseDatabase {
     return this.config;
   }
 
+  /**
+   * Tears down the WebSocket connections and background threads started by this {@code
+   * FirebaseDatabase} instance thus disconnecting from the remote database.
+   */
   void destroy() {
     synchronized (lock) {
       if (destroyed.get()) {

--- a/src/main/java/com/google/firebase/iid/FirebaseInstanceId.java
+++ b/src/main/java/com/google/firebase/iid/FirebaseInstanceId.java
@@ -191,12 +191,5 @@ public class FirebaseInstanceId {
     FirebaseInstanceIdService(FirebaseApp app) {
       super(SERVICE_ID, new FirebaseInstanceId(app));
     }
-
-    @Override
-    public void destroy() {
-      // NOTE: We don't explicitly tear down anything here, but public methods of StorageClient
-      // will now fail because calls to getOptions() and getToken() will hit FirebaseApp,
-      // which will throw once the app is deleted.
-    }
   }
 }

--- a/src/main/java/com/google/firebase/internal/FirebaseService.java
+++ b/src/main/java/com/google/firebase/internal/FirebaseService.java
@@ -28,7 +28,7 @@ import com.google.common.base.Strings;
  *
  * @param <T> Type of the service
  */
-public abstract class FirebaseService<T> {
+public class FirebaseService<T> {
 
   private final String id;
   protected final T instance;
@@ -62,5 +62,8 @@ public abstract class FirebaseService<T> {
    * Tear down this FirebaseService instance and the service object wrapped in it, cleaning up
    * any allocated resources in the process.
    */
-  public abstract void destroy();
+  public void destroy() {
+    // Child classes can override this method to implement any service-specific cleanup logic.
+  }
+
 }

--- a/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
@@ -407,13 +407,6 @@ public class FirebaseMessaging {
     FirebaseMessagingService(FirebaseApp app) {
       super(SERVICE_ID, FirebaseMessaging.fromApp(app));
     }
-
-    @Override
-    public void destroy() {
-      // NOTE: We don't explicitly tear down anything here, but public methods of FirebaseMessaging
-      // will now fail because calls to getOptions() and getToken() will hit FirebaseApp,
-      // which will throw once the app is deleted.
-    }
   }
 
   private static FirebaseMessaging fromApp(final FirebaseApp app) {

--- a/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagement.java
+++ b/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagement.java
@@ -36,6 +36,7 @@ import java.util.List;
  * modify, or retrieve information about the Android or iOS Apps in your Firebase project.
  */
 public class FirebaseProjectManagement {
+
   private static final String SERVICE_ID = FirebaseProjectManagement.class.getName();
 
   private static final Object GET_INSTANCE_LOCK = new Object();
@@ -285,11 +286,6 @@ public class FirebaseProjectManagement {
       FirebaseProjectManagement serviceInstance = getInstance();
       serviceInstance.setAndroidAppService(serviceImpl);
       serviceInstance.setIosAppService(serviceImpl);
-    }
-
-    @Override
-    public void destroy() {
-      serviceImpl.destroy();
     }
   }
 }

--- a/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImpl.java
+++ b/src/main/java/com/google/firebase/projectmanagement/FirebaseProjectManagementServiceImpl.java
@@ -92,14 +92,6 @@ class FirebaseProjectManagementServiceImpl implements AndroidAppService, IosAppS
     httpHelper.setInterceptor(interceptor);
   }
 
-  void destroy() {
-    // NOTE: We don't explicitly tear down anything here. Any instance of IosApp, AndroidApp, or
-    // FirebaseProjectManagement that depends on this instance will no longer be able to make RPC
-    // calls. All polling or waiting iOS or Android App creations will be interrupted, even though
-    // the initial creation RPC (if made successfully) is still processed normally (asynchronously)
-    // by the server.
-  }
-
   /* getAndroidApp */
 
   @Override

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
@@ -83,17 +83,37 @@ public class FirebaseAuthTest {
   }
 
   @Test
-  public void testInvokeAfterAppDelete() {
+  public void testInvokeAfterAppDelete() throws FirebaseAuthException {
     FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "testInvokeAfterAppDelete");
     FirebaseAuth auth = FirebaseAuth.getInstance(app);
-    assertNotNull(auth);
     app.delete();
 
+    String message = "FirebaseApp 'testInvokeAfterAppDelete' was deleted";
     try {
       FirebaseAuth.getInstance(app);
       fail("No error thrown when invoking auth after deleting app");
     } catch (IllegalStateException ex) {
-      String message = "FirebaseApp 'testInvokeAfterAppDelete' was deleted";
+      assertEquals(message, ex.getMessage());
+    }
+
+    try {
+      auth.createCustomToken("uid");
+      fail("No error thrown from token factory for deleted app");
+    } catch (IllegalStateException ex) {
+      assertEquals(message, ex.getMessage());
+    }
+
+    try {
+      auth.verifyIdToken("idToken");
+      fail("No error thrown from token verifier for deleted app");
+    } catch (IllegalStateException ex) {
+      assertEquals(message, ex.getMessage());
+    }
+
+    try {
+      auth.getUser("uid");
+      fail("No error thrown from user manager for deleted app");
+    } catch (IllegalStateException ex) {
       assertEquals(message, ex.getMessage());
     }
   }

--- a/src/test/java/com/google/firebase/iid/FirebaseInstanceIdTest.java
+++ b/src/test/java/com/google/firebase/iid/FirebaseInstanceIdTest.java
@@ -43,6 +43,11 @@ import org.junit.Test;
 
 public class FirebaseInstanceIdTest {
 
+  private static final FirebaseOptions APP_OPTIONS = new FirebaseOptions.Builder()
+      .setCredentials(new MockGoogleCredentials("test-token"))
+      .setProjectId("test-project")
+      .build();
+
   @After
   public void tearDown() {
     TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
@@ -63,12 +68,24 @@ public class FirebaseInstanceIdTest {
   }
 
   @Test
+  public void testInvokeAfterAppDelete() {
+    FirebaseApp app = FirebaseApp.initializeApp(APP_OPTIONS, "testInvokeAfterAppDelete");
+    FirebaseInstanceId instanceId = FirebaseInstanceId.getInstance(app);
+    assertNotNull(instanceId);
+    app.delete();
+
+    try {
+      FirebaseInstanceId.getInstance(app);
+      fail("No error thrown when invoking instanceId after deleting app");
+    } catch (IllegalStateException ex) {
+      String message = "FirebaseApp 'testInvokeAfterAppDelete' was deleted";
+      assertEquals(message, ex.getMessage());
+    }
+  }
+
+  @Test
   public void testInvalidInstanceId() {
-    FirebaseOptions options = new FirebaseOptions.Builder()
-        .setCredentials(new MockGoogleCredentials("test-token"))
-        .setProjectId("test-project")
-        .build();
-    FirebaseApp.initializeApp(options);
+    FirebaseApp.initializeApp(APP_OPTIONS);
 
     FirebaseInstanceId instanceId = FirebaseInstanceId.getInstance();
     TestResponseInterceptor interceptor = new TestResponseInterceptor();
@@ -96,9 +113,7 @@ public class FirebaseInstanceIdTest {
     MockHttpTransport transport = new MockHttpTransport.Builder()
         .setLowLevelHttpResponse(response)
         .build();
-    FirebaseOptions options = new FirebaseOptions.Builder()
-        .setCredentials(new MockGoogleCredentials("test-token"))
-        .setProjectId("test-project")
+    FirebaseOptions options = new FirebaseOptions.Builder(APP_OPTIONS)
         .setHttpTransport(transport)
         .build();
     FirebaseApp app = FirebaseApp.initializeApp(options);
@@ -154,9 +169,7 @@ public class FirebaseInstanceIdTest {
       MockHttpTransport transport = new MockHttpTransport.Builder()
           .setLowLevelHttpResponse(response)
           .build();
-      FirebaseOptions options = new FirebaseOptions.Builder()
-          .setCredentials(new MockGoogleCredentials("test-token"))
-          .setProjectId("test-project")
+      FirebaseOptions options = new FirebaseOptions.Builder(APP_OPTIONS)
           .setHttpTransport(transport)
           .build();
       final FirebaseApp app = FirebaseApp.initializeApp(options);


### PR DESCRIPTION
We have a mechanism in place to tear down any SDK state and managed resources upon calling `FirebaseApp.delete()`. However the way this is used and enforced across services is inconsistent at the moment:

* `FirebaseAuth` uses some complex and repetitive logic to throw errors from all methods after `delete()` has been called.
* Most other services (e.g. `FirebaseMessaging`) do not bother with this.

**In order to simplify the service implementations and make them consistent I'm proposing the following changes:**

1. `FirebaseAuth` doesn't have any state that requires explicit tear down. Therefore remove the existing repetitive logic for throwing errors after `delete()` is called. 
2. Make the `FirebaseService.destroy()` method non-abstract so that child classes are not forced to provide a no-op implementation. Child classes that do allocate managed resources (e.g. `FirebaseDatabase`) can still override it to tear down those resources.
3. Clarify the semantics of `FirebaseApp.delete()` in the API reference docs.

**This results in the following concrete behaviors after `FirebaseApp.delete()`:**

* Calling any of the `FirebaseXXXXX.getInstance()` methods will throw.
* Services with managed resources (`FirebaseDatabase` and `FirestoreClient`) will get cleaned up and become unusable.
* Some methods in services without managed resources will throw (notably all the async methods will throw since they rely on a thread pool attached to `FirebaseApp`).
* Some methods in services without managed resources will continue to work (this behavior exists today in some classes as mentioned above), but this is not a valid use of the SDK and developers should refrain from doing it.

**Potential future work:** If necessary we can implement a mechanism to block all rpc calls after `FirebaseApp.delete()` has been called. This is easy enough to enforce via the existing `FirebaseRequestInitializer`. But methods that do not make rpc calls (e.g. `FirebaseAuth.createCustomToken()`) will continue to work.