### PR TITLE
feat(fcm): Add FcmOptions on MulticastMessage

### DIFF
--- a/src/main/java/com/google/firebase/messaging/MulticastMessage.java
+++ b/src/main/java/com/google/firebase/messaging/MulticastMessage.java
@@ -51,6 +51,7 @@ public class MulticastMessage {
   private final AndroidConfig androidConfig;
   private final WebpushConfig webpushConfig;
   private final ApnsConfig apnsConfig;
+  private final FcmOptions fcmOptions;
 
   private MulticastMessage(Builder builder) {
     this.tokens = builder.tokens.build();
@@ -64,6 +65,7 @@ public class MulticastMessage {
     this.androidConfig = builder.androidConfig;
     this.webpushConfig = builder.webpushConfig;
     this.apnsConfig = builder.apnsConfig;
+    this.fcmOptions = builder.fcmOptions;
   }
 
   List<Message> getMessageList() {
@@ -71,7 +73,8 @@ public class MulticastMessage {
         .setNotification(this.notification)
         .setAndroidConfig(this.androidConfig)
         .setApnsConfig(this.apnsConfig)
-        .setWebpushConfig(this.webpushConfig);
+        .setWebpushConfig(this.webpushConfig)
+        .setFcmOptions(this.fcmOptions);
     if (this.data != null) {
       builder.putAllData(this.data);
     }
@@ -99,6 +102,7 @@ public class MulticastMessage {
     private AndroidConfig androidConfig;
     private WebpushConfig webpushConfig;
     private ApnsConfig apnsConfig;
+    private FcmOptions fcmOptions;
 
     private Builder() {}
 
@@ -167,6 +171,15 @@ public class MulticastMessage {
      */
     public Builder setApnsConfig(ApnsConfig apnsConfig) {
       this.apnsConfig = apnsConfig;
+      return this;
+    }
+
+    /**
+     * Sets the {@link FcmOptions}, which can be overridden by the platform-specific {@code
+     * fcm_options} fields.
+     */
+    public Builder setFcmOptions(FcmOptions fcmOptions) {
+      this.fcmOptions = fcmOptions;
       return this;
     }
 

--- a/src/test/java/com/google/firebase/messaging/MulticastMessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MulticastMessageTest.java
@@ -39,6 +39,7 @@ public class MulticastMessageTest {
       .putData("key", "value")
       .build();
   private static final Notification NOTIFICATION = new Notification("title", "body");
+  private static final FcmOptions FCM_OPTIONS = FcmOptions.withAnalyticsLabel("analytics_label");
 
   @Test
   public void testMulticastMessage() {
@@ -47,6 +48,7 @@ public class MulticastMessageTest {
         .setApnsConfig(APNS)
         .setWebpushConfig(WEBPUSH)
         .setNotification(NOTIFICATION)
+        .setFcmOptions(FCM_OPTIONS)
         .putData("key1", "value1")
         .putAllData(ImmutableMap.of("key2", "value2"))
         .addToken("token1")
@@ -96,6 +98,7 @@ public class MulticastMessageTest {
     assertSame(APNS, message.getApnsConfig());
     assertSame(WEBPUSH, message.getWebpushConfig());
     assertSame(NOTIFICATION, message.getNotification());
+    assertSame(FCM_OPTIONS, message.getFcmOptions());
     assertEquals(ImmutableMap.of("key1", "value1", "key2", "value2"), message.getData());
     assertEquals(expectedToken, message.getToken());
   }


### PR DESCRIPTION
`MulticastMessage` does not seem to support `FcmOptions`. This PR introduces `FcmOptions` in `MulticastMessage`s. 

The implementation follows the same approach with the NodeJS SDK. 

https://github.com/firebase/firebase-admin-node/blob/master/src/messaging/messaging.ts#L361

Resolves #440