### PR TITLE
feat: Added new error codes for IdP management and multitenancy

### DIFF
--- a/src/main/java/com/google/firebase/auth/AuthErrorCode.java
+++ b/src/main/java/com/google/firebase/auth/AuthErrorCode.java
@@ -27,6 +27,11 @@ public enum AuthErrorCode {
   CERTIFICATE_FETCH_FAILED,
 
   /**
+   * No IdP configuration found for the given identifier.
+   */
+  CONFIGURATION_NOT_FOUND,
+
+  /**
    * A user already exists with the provided email.
    */
   EMAIL_ALREADY_EXISTS,
@@ -71,7 +76,15 @@ public enum AuthErrorCode {
    */
   REVOKED_SESSION_COOKIE,
 
+  /**
+   * Tenant ID in the JWT does not match.
+   */
   TENANT_ID_MISMATCH,
+
+  /**
+   * No tenant found for the given identifier.
+   */
+  TENANT_NOT_FOUND,
 
   /**
    * A user already exists with the provided UID.

--- a/src/main/java/com/google/firebase/auth/internal/AuthErrorHandler.java
+++ b/src/main/java/com/google/firebase/auth/internal/AuthErrorHandler.java
@@ -37,6 +37,12 @@ final class AuthErrorHandler extends AbstractHttpErrorHandler<FirebaseAuthExcept
   private static final Map<String, AuthError> ERROR_CODES =
       ImmutableMap.<String, AuthError>builder()
           .put(
+              "CONFIGURATION_NOT_FOUND",
+              new AuthError(
+                  ErrorCode.NOT_FOUND,
+                  "No IdP configuration found corresponding to the provided identifier",
+                  AuthErrorCode.CONFIGURATION_NOT_FOUND))
+          .put(
               "DUPLICATE_EMAIL",
               new AuthError(
                   ErrorCode.ALREADY_EXISTS,
@@ -67,6 +73,12 @@ final class AuthErrorHandler extends AbstractHttpErrorHandler<FirebaseAuthExcept
                   ErrorCode.ALREADY_EXISTS,
                   "The user with the provided phone number already exists",
                   AuthErrorCode.PHONE_NUMBER_ALREADY_EXISTS))
+          .put(
+              "TENANT_NOT_FOUND",
+              new AuthError(
+                  ErrorCode.NOT_FOUND,
+                  "No tenant found for the given identifier",
+                  AuthErrorCode.TENANT_NOT_FOUND))
           .put(
               "UNAUTHORIZED_DOMAIN",
               new AuthError(

--- a/src/main/java/com/google/firebase/auth/internal/AuthHttpClient.java
+++ b/src/main/java/com/google/firebase/auth/internal/AuthHttpClient.java
@@ -45,15 +45,15 @@ public final class AuthHttpClient {
 
   private static final String CLIENT_VERSION = "Java/Admin/" + SdkUtils.getVersion();
 
-  private final JsonFactory jsonFactory;
   private final ErrorHandlingHttpClient<FirebaseAuthException> httpClient;
+  private final JsonFactory jsonFactory;
 
   private HttpResponseInterceptor interceptor;
 
   public AuthHttpClient(JsonFactory jsonFactory, HttpRequestFactory requestFactory) {
-    this.jsonFactory = jsonFactory;
     AuthErrorHandler authErrorHandler = new AuthErrorHandler(jsonFactory);
     this.httpClient = new ErrorHandlingHttpClient<>(requestFactory, jsonFactory, authErrorHandler);
+    this.jsonFactory = jsonFactory;
   }
 
   public static Set<String> generateMask(Map<String, Object> properties) {

--- a/src/main/java/com/google/firebase/auth/multitenancy/FirebaseTenantClient.java
+++ b/src/main/java/com/google/firebase/auth/multitenancy/FirebaseTenantClient.java
@@ -46,15 +46,19 @@ final class FirebaseTenantClient {
   private final AuthHttpClient httpClient;
 
   FirebaseTenantClient(FirebaseApp app) {
-    checkNotNull(app, "FirebaseApp must not be null");
-    String projectId = ImplFirebaseTrampolines.getProjectId(app);
+    this(
+        ImplFirebaseTrampolines.getProjectId(checkNotNull(app)),
+        app.getOptions().getJsonFactory(),
+        ApiClientUtils.newAuthorizedRequestFactory(app));
+  }
+
+  FirebaseTenantClient(
+      String projectId, JsonFactory jsonFactory, HttpRequestFactory requestFactory) {
     checkArgument(!Strings.isNullOrEmpty(projectId),
         "Project ID is required to access the auth service. Use a service account credential or "
             + "set the project ID explicitly via FirebaseOptions. Alternatively you can also "
             + "set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.");
     this.tenantMgtBaseUrl = String.format(ID_TOOLKIT_URL, "v2", projectId);
-    JsonFactory jsonFactory = app.getOptions().getJsonFactory();
-    HttpRequestFactory requestFactory = ApiClientUtils.newAuthorizedRequestFactory(app);
     this.httpClient = new AuthHttpClient(jsonFactory, requestFactory);
   }
 

--- a/src/main/java/com/google/firebase/auth/multitenancy/TenantManager.java
+++ b/src/main/java/com/google/firebase/auth/multitenancy/TenantManager.java
@@ -54,8 +54,13 @@ public final class TenantManager {
    * @hide
    */
   public TenantManager(FirebaseApp firebaseApp) {
-    this.firebaseApp = firebaseApp;
-    this.tenantClient = new FirebaseTenantClient(firebaseApp);
+    this(firebaseApp, new FirebaseTenantClient(firebaseApp));
+  }
+
+  @VisibleForTesting
+  TenantManager(FirebaseApp firebaseApp, FirebaseTenantClient tenantClient) {
+    this.firebaseApp = checkNotNull(firebaseApp);
+    this.tenantClient = checkNotNull(tenantClient);
     this.tenantAwareAuths = new HashMap<>();
   }
 

--- a/src/test/java/com/google/firebase/auth/ProviderConfigTestUtils.java
+++ b/src/test/java/com/google/firebase/auth/ProviderConfigTestUtils.java
@@ -36,8 +36,9 @@ public class ProviderConfigTestUtils {
       fail("No error thrown for getting a deleted OIDC provider config.");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
-      assertEquals(ErrorCode.NOT_FOUND,
-          ((FirebaseAuthException) e.getCause()).getErrorCode());
+      FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
+      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCode());
+      assertEquals(AuthErrorCode.CONFIGURATION_NOT_FOUND, authException.getAuthErrorCode());
     }
   }
 
@@ -48,8 +49,9 @@ public class ProviderConfigTestUtils {
       fail("No error thrown for getting a deleted SAML provider config.");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
-      assertEquals(ErrorCode.NOT_FOUND,
-          ((FirebaseAuthException) e.getCause()).getErrorCode());
+      FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
+      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCode());
+      assertEquals(AuthErrorCode.CONFIGURATION_NOT_FOUND, authException.getAuthErrorCode());
     }
   }
 

--- a/src/test/java/com/google/firebase/auth/multitenancy/FirebaseTenantClientTest.java
+++ b/src/test/java/com/google/firebase/auth/multitenancy/FirebaseTenantClientTest.java
@@ -18,6 +18,7 @@ package com.google.firebase.auth.multitenancy;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -26,6 +27,7 @@ import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
@@ -37,6 +39,7 @@ import com.google.firebase.ErrorCode;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
+import com.google.firebase.auth.AuthErrorCode;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.auth.MockGoogleCredentials;
@@ -91,6 +94,11 @@ public class FirebaseTenantClientTest {
       fail("No error thrown for invalid response");
     } catch (FirebaseAuthException e) {
       assertEquals(ErrorCode.NOT_FOUND, e.getErrorCode());
+      assertEquals(
+          "No tenant found for the given identifier (TENANT_NOT_FOUND).", e.getMessage());
+      assertTrue(e.getCause() instanceof HttpResponseException);
+      assertNotNull(e.getHttpResponse());
+      assertEquals(AuthErrorCode.TENANT_NOT_FOUND, e.getAuthErrorCode());
     }
     checkUrl(interceptor, "GET", TENANTS_BASE_URL + "/UNKNOWN");
   }
@@ -183,16 +191,21 @@ public class FirebaseTenantClientTest {
 
   @Test
   public void testCreateTenantError() {
-    TestResponseInterceptor interceptor =
-        initializeAppForTenantManagementWithStatusCode(404,
-            "{\"error\": {\"message\": \"INTERNAL_ERROR\"}}");
+    String message = "{\"error\": {\"message\": \"INTERNAL_ERROR\"}}";
+    TenantManager tenantManager = getRetryDisabledTenantManager(new MockLowLevelHttpResponse()
+        .setStatusCode(500)
+        .setContent(message));
+
     try {
-      FirebaseAuth.getInstance().getTenantManager().createTenant(new Tenant.CreateRequest());
+      tenantManager.createTenant(new Tenant.CreateRequest());
       fail("No error thrown for invalid response");
     } catch (FirebaseAuthException e) {
-      assertEquals(ErrorCode.NOT_FOUND, e.getErrorCode());
+      assertEquals(ErrorCode.INTERNAL, e.getErrorCode());
+      assertEquals("Unexpected HTTP response with status: 500\n" + message, e.getMessage());
+      assertTrue(e.getCause() instanceof HttpResponseException);
+      assertNotNull(e.getHttpResponse());
+      assertNull(e.getAuthErrorCode());
     }
-    checkUrl(interceptor, "POST", TENANTS_BASE_URL);
   }
 
   @Test
@@ -252,18 +265,23 @@ public class FirebaseTenantClientTest {
 
   @Test
   public void testUpdateTenantError() {
-    TestResponseInterceptor interceptor =
-        initializeAppForTenantManagementWithStatusCode(404,
-            "{\"error\": {\"message\": \"INTERNAL_ERROR\"}}");
+    String message = "{\"error\": {\"message\": \"INTERNAL_ERROR\"}}";
+    TenantManager tenantManager = getRetryDisabledTenantManager(new MockLowLevelHttpResponse()
+        .setStatusCode(500)
+        .setContent(message));
     Tenant.UpdateRequest request =
         new Tenant.UpdateRequest("TENANT_1").setDisplayName("DISPLAY_NAME");
+
     try {
-      FirebaseAuth.getInstance().getTenantManager().updateTenant(request);
+      tenantManager.updateTenant(request);
       fail("No error thrown for invalid response");
     } catch (FirebaseAuthException e) {
-      assertEquals(ErrorCode.NOT_FOUND, e.getErrorCode());
+      assertEquals(ErrorCode.INTERNAL, e.getErrorCode());
+      assertEquals("Unexpected HTTP response with status: 500\n" + message, e.getMessage());
+      assertTrue(e.getCause() instanceof HttpResponseException);
+      assertNotNull(e.getHttpResponse());
+      assertNull(e.getAuthErrorCode());
     }
-    checkUrl(interceptor, "PATCH", TENANTS_BASE_URL + "/TENANT_1");
   }
 
   @Test
@@ -286,6 +304,10 @@ public class FirebaseTenantClientTest {
       fail("No error thrown for invalid response");
     } catch (FirebaseAuthException e) {
       assertEquals(ErrorCode.NOT_FOUND, e.getErrorCode());
+      assertEquals("No tenant found for the given identifier (TENANT_NOT_FOUND).", e.getMessage());
+      assertTrue(e.getCause() instanceof HttpResponseException);
+      assertNotNull(e.getHttpResponse());
+      assertEquals(AuthErrorCode.TENANT_NOT_FOUND, e.getAuthErrorCode());
     }
     checkUrl(interceptor, "DELETE", TENANTS_BASE_URL + "/UNKNOWN");
   }
@@ -319,7 +341,17 @@ public class FirebaseTenantClientTest {
   }
 
   private static TestResponseInterceptor initializeAppForTenantManagement(String... responses) {
-    initializeAppWithResponses(responses);
+    List<MockLowLevelHttpResponse> mocks = new ArrayList<>();
+    for (String response : responses) {
+      mocks.add(new MockLowLevelHttpResponse().setContent(response));
+    }
+    MockHttpTransport transport = new MultiRequestMockHttpTransport(mocks);
+    FirebaseApp.initializeApp(FirebaseOptions.builder()
+        .setCredentials(credentials)
+        .setHttpTransport(transport)
+        .setProjectId("test-project-id")
+        .build());
+
     TestResponseInterceptor interceptor = new TestResponseInterceptor();
     FirebaseAuth.getInstance().getTenantManager().setInterceptor(interceptor);
     return interceptor;
@@ -327,7 +359,7 @@ public class FirebaseTenantClientTest {
 
   private static TestResponseInterceptor initializeAppForTenantManagementWithStatusCode(
       int statusCode, String response) {
-    FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+    FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(credentials)
         .setHttpTransport(
             new MockHttpTransport.Builder()
@@ -341,17 +373,16 @@ public class FirebaseTenantClientTest {
     return interceptor;
   }
 
-  private static void initializeAppWithResponses(String... responses) {
-    List<MockLowLevelHttpResponse> mocks = new ArrayList<>();
-    for (String response : responses) {
-      mocks.add(new MockLowLevelHttpResponse().setContent(response));
-    }
-    MockHttpTransport transport = new MultiRequestMockHttpTransport(mocks);
-    FirebaseApp.initializeApp(new FirebaseOptions.Builder()
+  private static TenantManager getRetryDisabledTenantManager(MockLowLevelHttpResponse response) {
+    MockHttpTransport transport = new MockHttpTransport.Builder()
+        .setLowLevelHttpResponse(response)
+        .build();
+    FirebaseApp app = FirebaseApp.initializeApp(FirebaseOptions.builder()
         .setCredentials(credentials)
-        .setHttpTransport(transport)
-        .setProjectId("test-project-id")
         .build());
+    FirebaseTenantClient tenantClient = new FirebaseTenantClient(
+        "test-project-id", Utils.getDefaultJsonFactory(), transport.createRequestFactory());
+    return new TenantManager(app, tenantClient);
   }
 
   private static GenericJson parseRequestContent(TestResponseInterceptor interceptor)

--- a/src/test/java/com/google/firebase/auth/multitenancy/FirebaseTenantClientTest.java
+++ b/src/test/java/com/google/firebase/auth/multitenancy/FirebaseTenantClientTest.java
@@ -192,7 +192,7 @@ public class FirebaseTenantClientTest {
   @Test
   public void testCreateTenantError() {
     String message = "{\"error\": {\"message\": \"INTERNAL_ERROR\"}}";
-    TenantManager tenantManager = getRetryDisabledTenantManager(new MockLowLevelHttpResponse()
+    TenantManager tenantManager = createRetryDisabledTenantManager(new MockLowLevelHttpResponse()
         .setStatusCode(500)
         .setContent(message));
 
@@ -266,7 +266,7 @@ public class FirebaseTenantClientTest {
   @Test
   public void testUpdateTenantError() {
     String message = "{\"error\": {\"message\": \"INTERNAL_ERROR\"}}";
-    TenantManager tenantManager = getRetryDisabledTenantManager(new MockLowLevelHttpResponse()
+    TenantManager tenantManager = createRetryDisabledTenantManager(new MockLowLevelHttpResponse()
         .setStatusCode(500)
         .setContent(message));
     Tenant.UpdateRequest request =
@@ -373,7 +373,7 @@ public class FirebaseTenantClientTest {
     return interceptor;
   }
 
-  private static TenantManager getRetryDisabledTenantManager(MockLowLevelHttpResponse response) {
+  private static TenantManager createRetryDisabledTenantManager(MockLowLevelHttpResponse response) {
     MockHttpTransport transport = new MockHttpTransport.Builder()
         .setLowLevelHttpResponse(response)
         .build();

--- a/src/test/java/com/google/firebase/auth/multitenancy/TenantManagerIT.java
+++ b/src/test/java/com/google/firebase/auth/multitenancy/TenantManagerIT.java
@@ -28,6 +28,7 @@ import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.firebase.ErrorCode;
+import com.google.firebase.auth.AuthErrorCode;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.testing.IntegrationTestUtils;
@@ -81,8 +82,9 @@ public class TenantManagerIT {
       fail("No error thrown for getting a deleted tenant");
     } catch (ExecutionException e) {
       assertTrue(e.getCause() instanceof FirebaseAuthException);
-      assertEquals(ErrorCode.NOT_FOUND,
-          ((FirebaseAuthException) e.getCause()).getErrorCode());
+      FirebaseAuthException authException = (FirebaseAuthException) e.getCause();
+      assertEquals(ErrorCode.NOT_FOUND, authException.getErrorCode());
+      assertEquals(AuthErrorCode.TENANT_NOT_FOUND, authException.getAuthErrorCode());
     }
   }
 


### PR DESCRIPTION
* Added `CONFIGURATION_NOT_FOUND` error code. Also note that `TENANT_NOT_FOUND` error code was added while updating the v7 branch in #456.
* Made it possible to test `TenantManager` and `FirebaseTenantClient` with better mock responses.
* Updated error handling test cases to check for new error codes. I also updated some of the existing error handling tests to mock with more realistic errors (e.g. create operations do not usually fail with a NOT_FOUND error). 