### PR TITLE
fix: Handling JSON serialization/response interception at ErrorHandlingHttpClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.7.9</version>
+                        <version>0.8.5</version>
                         <executions>
                             <execution>
                                 <id>pre-unit-test</id>
@@ -289,7 +289,7 @@
             <!-- Test Phase -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>2.22.0</version>
                 <configuration>
                     <skipTests>${skipUTs}</skipTests>
                 </configuration>

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -80,7 +80,7 @@ class FirebaseUserManager {
   private final JsonFactory jsonFactory;
   private final AuthHttpClient httpClient;
 
-  FirebaseUserManager(Builder builder) {
+  private FirebaseUserManager(Builder builder) {
     FirebaseApp app = checkNotNull(builder.app, "FirebaseApp must not be null");
     String projectId = ImplFirebaseTrampolines.getProjectId(app);
     checkArgument(!Strings.isNullOrEmpty(projectId),

--- a/src/main/java/com/google/firebase/auth/internal/AuthHttpClient.java
+++ b/src/main/java/com/google/firebase/auth/internal/AuthHttpClient.java
@@ -69,10 +69,6 @@ public final class AuthHttpClient {
       String method, GenericUrl url, @Nullable Object content) throws FirebaseAuthException {
     HttpRequestInfo request = HttpRequestInfo.buildJsonRequest(method, url, content)
         .addHeader(CLIENT_VERSION_HEADER, CLIENT_VERSION);
-    if (method.equals("PATCH")) {
-      request.addHeader("X-HTTP-Method-Override", "PATCH");
-    }
-
     return httpClient.send(request);
   }
 

--- a/src/main/java/com/google/firebase/iid/FirebaseInstanceId.java
+++ b/src/main/java/com/google/firebase/iid/FirebaseInstanceId.java
@@ -65,8 +65,6 @@ public class FirebaseInstanceId {
   private final String projectId;
   private final ErrorHandlingHttpClient<FirebaseInstanceIdException> httpClient;
 
-  private HttpResponseInterceptor interceptor;
-
   private FirebaseInstanceId(FirebaseApp app) {
     this(app, null);
   }
@@ -115,7 +113,7 @@ public class FirebaseInstanceId {
 
   @VisibleForTesting
   void setInterceptor(HttpResponseInterceptor interceptor) {
-    this.interceptor = interceptor;
+    httpClient.setInterceptor(interceptor);
   }
 
   /**
@@ -154,8 +152,7 @@ public class FirebaseInstanceId {
       protected Void execute() throws FirebaseInstanceIdException {
         String url = String.format(
             "%s/project/%s/instanceId/%s", IID_SERVICE_URL, projectId, instanceId);
-        HttpRequestInfo request = HttpRequestInfo.buildDeleteRequest(url)
-            .setResponseInterceptor(interceptor);
+        HttpRequestInfo request = HttpRequestInfo.buildDeleteRequest(url);
         httpClient.send(request);
         return null;
       }

--- a/src/test/java/com/google/firebase/messaging/InstanceIdClientImplTest.java
+++ b/src/test/java/com/google/firebase/messaging/InstanceIdClientImplTest.java
@@ -378,7 +378,6 @@ public class InstanceIdClientImplTest {
     try {
       InstanceIdClientImpl client = InstanceIdClientImpl.fromApp(app);
 
-      assertSame(options.getJsonFactory(), client.getJsonFactory());
       client.subscribeToTopic("test-topic", ImmutableList.of("id1", "id2"));
       fail("No error thrown for error response");
     } catch (FirebaseMessagingException e) {


### PR DESCRIPTION
* Exposing `setInterceptor()` method on `ErrorHandlingHttpClient`. By handling it here, individual services no longer have to have a reference for `HttpResponseInterceptor`.
* Added support for serializing JSON request payloads at the `HttpRequestInfo`. This means individual services no longer have to handle this or even have a reference to a `JsonFactory`.
* Removing some leftover http method override code in `AuthHttpClient` (this became redundant as of #459)
* Upgraded Surefire and Jacoco test coverage dependencies.