### PR TITLE
chore: Support for specifying query parameters in HttpRequestInfo

### DIFF
--- a/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
@@ -96,11 +96,7 @@ public abstract class AbstractFirebaseAuth {
             new Supplier<FirebaseUserManager>() {
               @Override
               public FirebaseUserManager get() {
-                return FirebaseUserManager
-                    .builder()
-                    .setFirebaseApp(app)
-                    .setTenantId(tenantId)
-                    .build();
+                return FirebaseUserManager.createUserManager(app, tenantId);
               }
             });
   }

--- a/src/main/java/com/google/firebase/auth/FirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseAuth.java
@@ -19,14 +19,12 @@ package com.google.firebase.auth;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.api.client.util.Clock;
 import com.google.api.core.ApiFuture;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.ImplFirebaseTrampolines;
-import com.google.firebase.auth.internal.FirebaseTokenFactory;
 import com.google.firebase.auth.multitenancy.TenantManager;
 import com.google.firebase.internal.CallableOperation;
 import com.google.firebase.internal.FirebaseService;
@@ -214,37 +212,7 @@ public final class FirebaseAuth extends AbstractFirebaseAuth {
   protected void doDestroy() { }
 
   private static FirebaseAuth fromApp(final FirebaseApp app) {
-    return new FirebaseAuth(
-        AbstractFirebaseAuth.builder()
-          .setFirebaseApp(app)
-          .setTokenFactory(
-              new Supplier<FirebaseTokenFactory>() {
-                @Override
-                public FirebaseTokenFactory get() {
-                  return FirebaseTokenUtils.createTokenFactory(app, Clock.SYSTEM);
-                }
-              })
-          .setIdTokenVerifier(
-              new Supplier<FirebaseTokenVerifier>() {
-                @Override
-                public FirebaseTokenVerifier get() {
-                  return FirebaseTokenUtils.createIdTokenVerifier(app, Clock.SYSTEM);
-                }
-              })
-          .setCookieVerifier(
-              new Supplier<FirebaseTokenVerifier>() {
-                @Override
-                public FirebaseTokenVerifier get() {
-                  return FirebaseTokenUtils.createSessionCookieVerifier(app, Clock.SYSTEM);
-                }
-            })
-          .setUserManager(
-              new Supplier<FirebaseUserManager>() {
-                @Override
-                public FirebaseUserManager get() {
-                  return FirebaseUserManager.builder().setFirebaseApp(app).build();
-                }
-              }));
+    return new FirebaseAuth(AbstractFirebaseAuth.builderFromAppAndTenantId(app, null));
   }
 
   private static class FirebaseAuthService extends FirebaseService<FirebaseAuth> {

--- a/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseUserManager.java
@@ -19,8 +19,6 @@ package com.google.firebase.auth;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.api.client.http.GenericUrl;
-import com.google.api.client.http.HttpMethods;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponseInterceptor;
 import com.google.api.client.json.GenericJson;
@@ -44,9 +42,9 @@ import com.google.firebase.auth.internal.ListOidcProviderConfigsResponse;
 import com.google.firebase.auth.internal.ListSamlProviderConfigsResponse;
 import com.google.firebase.auth.internal.UploadAccountResponse;
 import com.google.firebase.internal.ApiClientUtils;
+import com.google.firebase.internal.HttpRequestInfo;
 import com.google.firebase.internal.NonNull;
 import com.google.firebase.internal.Nullable;
-
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -60,7 +58,7 @@ import java.util.Set;
  * @see <a href="https://developers.google.com/identity/toolkit/web/reference/relyingparty">
  *   Google Identity Toolkit</a>
  */
-class FirebaseUserManager {
+final class FirebaseUserManager {
 
   static final int MAX_LIST_PROVIDER_CONFIGS_RESULTS = 100;
   static final int MAX_GET_ACCOUNTS_BATCH_SIZE = 100;
@@ -81,13 +79,12 @@ class FirebaseUserManager {
   private final AuthHttpClient httpClient;
 
   private FirebaseUserManager(Builder builder) {
-    FirebaseApp app = checkNotNull(builder.app, "FirebaseApp must not be null");
-    String projectId = ImplFirebaseTrampolines.getProjectId(app);
+    String projectId = builder.projectId;
     checkArgument(!Strings.isNullOrEmpty(projectId),
         "Project ID is required to access the auth service. Use a service account credential or "
             + "set the project ID explicitly via FirebaseOptions. Alternatively you can also "
             + "set the project ID via the GOOGLE_CLOUD_PROJECT environment variable.");
-    this.jsonFactory = app.getOptions().getJsonFactory();
+    this.jsonFactory = checkNotNull(builder.jsonFactory, "JsonFactory must not be null");
     final String idToolkitUrlV1 = String.format(ID_TOOLKIT_URL, "v1", projectId);
     final String idToolkitUrlV2 = String.format(ID_TOOLKIT_URL, "v2", projectId);
     final String tenantId = builder.tenantId;
@@ -100,9 +97,7 @@ class FirebaseUserManager {
       this.idpConfigMgtBaseUrl = idToolkitUrlV2 + "/tenants/" + tenantId;
     }
 
-    HttpRequestFactory requestFactory = builder.requestFactory == null
-        ? ApiClientUtils.newAuthorizedRequestFactory(app) : builder.requestFactory;
-    this.httpClient = new AuthHttpClient(jsonFactory, requestFactory);
+    this.httpClient = new AuthHttpClient(jsonFactory, builder.requestFactory);
   }
 
   @VisibleForTesting
@@ -182,9 +177,10 @@ class FirebaseUserManager {
       builder.put("nextPageToken", pageToken);
     }
 
-    GenericUrl url = new GenericUrl(userMgtBaseUrl + "/accounts:batchGet");
-    url.putAll(builder.build());
-    return httpClient.sendRequest(HttpMethods.GET, url, null, DownloadAccountResponse.class);
+    String url = userMgtBaseUrl + "/accounts:batchGet";
+    HttpRequestInfo requestInfo = HttpRequestInfo.buildGetRequest(url)
+        .addAllParameters(builder.build());
+    return httpClient.sendRequest(requestInfo, DownloadAccountResponse.class);
   }
 
   UserImportResult importUsers(UserImportRequest request) throws FirebaseAuthException {
@@ -218,8 +214,9 @@ class FirebaseUserManager {
 
   private UserRecord lookupUserAccount(
       Map<String, Object> payload, String identifier) throws FirebaseAuthException {
-    IncomingHttpResponse response = httpClient.sendRequest(
-        HttpMethods.POST, new GenericUrl(userMgtBaseUrl + "/accounts:lookup"), payload);
+    HttpRequestInfo requestInfo = HttpRequestInfo.buildJsonPostRequest(
+        userMgtBaseUrl + "/accounts:lookup", payload);
+    IncomingHttpResponse response = httpClient.sendRequest(requestInfo);
     GetAccountInfoResponse parsed = httpClient.parse(response, GetAccountInfoResponse.class);
     if (parsed.getUsers() == null || parsed.getUsers().isEmpty()) {
       throw new FirebaseAuthException(ErrorCode.NOT_FOUND,
@@ -234,44 +231,46 @@ class FirebaseUserManager {
 
   OidcProviderConfig createOidcProviderConfig(
       OidcProviderConfig.CreateRequest request) throws FirebaseAuthException {
-    GenericUrl url = new GenericUrl(idpConfigMgtBaseUrl + "/oauthIdpConfigs");
-    url.set("oauthIdpConfigId", request.getProviderId());
-    return httpClient.sendRequest("POST", url, request.getProperties(), OidcProviderConfig.class);
+    String url = idpConfigMgtBaseUrl + "/oauthIdpConfigs";
+    HttpRequestInfo requestInfo = HttpRequestInfo.buildJsonPostRequest(url, request.getProperties())
+        .addParameter("oauthIdpConfigId", request.getProviderId());
+    return httpClient.sendRequest(requestInfo, OidcProviderConfig.class);
   }
 
   SamlProviderConfig createSamlProviderConfig(
       SamlProviderConfig.CreateRequest request) throws FirebaseAuthException {
-    GenericUrl url = new GenericUrl(idpConfigMgtBaseUrl + "/inboundSamlConfigs");
-    url.set("inboundSamlConfigId", request.getProviderId());
-    return httpClient.sendRequest("POST", url, request.getProperties(), SamlProviderConfig.class);
+    String url = idpConfigMgtBaseUrl + "/inboundSamlConfigs";
+    HttpRequestInfo requestInfo = HttpRequestInfo.buildJsonPostRequest(url, request.getProperties())
+        .addParameter("inboundSamlConfigId", request.getProviderId());
+    return httpClient.sendRequest(requestInfo, SamlProviderConfig.class);
   }
 
   OidcProviderConfig updateOidcProviderConfig(OidcProviderConfig.UpdateRequest request)
       throws FirebaseAuthException {
     Map<String, Object> properties = request.getProperties();
-    GenericUrl url =
-        new GenericUrl(idpConfigMgtBaseUrl + getOidcUrlSuffix(request.getProviderId()));
-    url.put("updateMask", Joiner.on(",").join(AuthHttpClient.generateMask(properties)));
-    return httpClient.sendRequest("PATCH", url, properties, OidcProviderConfig.class);
+    String url = idpConfigMgtBaseUrl + getOidcUrlSuffix(request.getProviderId());
+    HttpRequestInfo requestInfo = HttpRequestInfo.buildJsonPatchRequest(url, properties)
+        .addParameter("updateMask", Joiner.on(",").join(AuthHttpClient.generateMask(properties)));
+    return httpClient.sendRequest(requestInfo, OidcProviderConfig.class);
   }
 
   SamlProviderConfig updateSamlProviderConfig(SamlProviderConfig.UpdateRequest request)
       throws FirebaseAuthException {
     Map<String, Object> properties = request.getProperties();
-    GenericUrl url =
-        new GenericUrl(idpConfigMgtBaseUrl + getSamlUrlSuffix(request.getProviderId()));
-    url.put("updateMask", Joiner.on(",").join(AuthHttpClient.generateMask(properties)));
-    return httpClient.sendRequest("PATCH", url, properties, SamlProviderConfig.class);
+    String url = idpConfigMgtBaseUrl + getSamlUrlSuffix(request.getProviderId());
+    HttpRequestInfo requestInfo = HttpRequestInfo.buildJsonPatchRequest(url, properties)
+        .addParameter("updateMask", Joiner.on(",").join(AuthHttpClient.generateMask(properties)));
+    return httpClient.sendRequest(requestInfo, SamlProviderConfig.class);
   }
 
   OidcProviderConfig getOidcProviderConfig(String providerId) throws FirebaseAuthException {
-    GenericUrl url = new GenericUrl(idpConfigMgtBaseUrl + getOidcUrlSuffix(providerId));
-    return httpClient.sendRequest("GET", url, null, OidcProviderConfig.class);
+    String url = idpConfigMgtBaseUrl + getOidcUrlSuffix(providerId);
+    return httpClient.sendRequest(HttpRequestInfo.buildGetRequest(url), OidcProviderConfig.class);
   }
 
   SamlProviderConfig getSamlProviderConfig(String providerId) throws FirebaseAuthException {
-    GenericUrl url = new GenericUrl(idpConfigMgtBaseUrl + getSamlUrlSuffix(providerId));
-    return httpClient.sendRequest("GET", url, null, SamlProviderConfig.class);
+    String url = idpConfigMgtBaseUrl + getSamlUrlSuffix(providerId);
+    return httpClient.sendRequest(HttpRequestInfo.buildGetRequest(url), SamlProviderConfig.class);
   }
 
   ListOidcProviderConfigsResponse listOidcProviderConfigs(int maxResults, String pageToken)
@@ -284,9 +283,10 @@ class FirebaseUserManager {
       builder.put("nextPageToken", pageToken);
     }
 
-    GenericUrl url = new GenericUrl(idpConfigMgtBaseUrl + "/oauthIdpConfigs");
-    url.putAll(builder.build());
-    return httpClient.sendRequest("GET", url, null, ListOidcProviderConfigsResponse.class);
+    String url = idpConfigMgtBaseUrl + "/oauthIdpConfigs";
+    HttpRequestInfo requestInfo = HttpRequestInfo.buildGetRequest(url)
+        .addAllParameters(builder.build());
+    return httpClient.sendRequest(requestInfo, ListOidcProviderConfigsResponse.class);
   }
 
   ListSamlProviderConfigsResponse listSamlProviderConfigs(int maxResults, String pageToken)
@@ -299,19 +299,20 @@ class FirebaseUserManager {
       builder.put("nextPageToken", pageToken);
     }
 
-    GenericUrl url = new GenericUrl(idpConfigMgtBaseUrl + "/inboundSamlConfigs");
-    url.putAll(builder.build());
-    return httpClient.sendRequest("GET", url, null, ListSamlProviderConfigsResponse.class);
+    String url = idpConfigMgtBaseUrl + "/inboundSamlConfigs";
+    HttpRequestInfo requestInfo = HttpRequestInfo.buildGetRequest(url)
+        .addAllParameters(builder.build());
+    return httpClient.sendRequest(requestInfo, ListSamlProviderConfigsResponse.class);
   }
 
   void deleteOidcProviderConfig(String providerId) throws FirebaseAuthException {
-    GenericUrl url = new GenericUrl(idpConfigMgtBaseUrl + getOidcUrlSuffix(providerId));
-    httpClient.sendRequest("DELETE", url, null, GenericJson.class);
+    String url = idpConfigMgtBaseUrl + getOidcUrlSuffix(providerId);
+    httpClient.sendRequest(HttpRequestInfo.buildDeleteRequest(url));
   }
 
   void deleteSamlProviderConfig(String providerId) throws FirebaseAuthException {
-    GenericUrl url = new GenericUrl(idpConfigMgtBaseUrl + getSamlUrlSuffix(providerId));
-    httpClient.sendRequest("DELETE", url, null, GenericJson.class);
+    String url = idpConfigMgtBaseUrl + getSamlUrlSuffix(providerId);
+    httpClient.sendRequest(HttpRequestInfo.buildDeleteRequest(url));
   }
 
   private static String getOidcUrlSuffix(String providerId) {
@@ -327,8 +328,8 @@ class FirebaseUserManager {
   private <T> T post(String path, Object content, Class<T> clazz) throws FirebaseAuthException {
     checkArgument(!Strings.isNullOrEmpty(path), "path must not be null or empty");
     checkNotNull(content, "content must not be null for POST requests");
-    GenericUrl url = new GenericUrl(userMgtBaseUrl + path);
-    return httpClient.sendRequest(HttpMethods.POST, url, content, clazz);
+    String url = userMgtBaseUrl + path;
+    return httpClient.sendRequest(HttpRequestInfo.buildJsonPostRequest(url, content), clazz);
   }
 
   static class UserImportRequest extends GenericJson {
@@ -371,18 +372,30 @@ class FirebaseUserManager {
     PASSWORD_RESET,
   }
 
+  static FirebaseUserManager createUserManager(FirebaseApp app, String tenantId) {
+    return FirebaseUserManager.builder()
+        .setProjectId(ImplFirebaseTrampolines.getProjectId(app))
+        .setTenantId(tenantId)
+        .setHttpRequestFactory(ApiClientUtils.newAuthorizedRequestFactory(app))
+        .setJsonFactory(app.getOptions().getJsonFactory())
+        .build();
+  }
+
   static Builder builder() {
     return new Builder();
   }
 
   static class Builder {
 
-    private FirebaseApp app;
+    private String projectId;
     private String tenantId;
     private HttpRequestFactory requestFactory;
+    private JsonFactory jsonFactory;
 
-    Builder setFirebaseApp(FirebaseApp app) {
-      this.app = app;
+    private Builder() { }
+
+    public Builder setProjectId(String projectId) {
+      this.projectId = projectId;
       return this;
     }
 
@@ -393,6 +406,11 @@ class FirebaseUserManager {
 
     Builder setHttpRequestFactory(HttpRequestFactory requestFactory) {
       this.requestFactory = requestFactory;
+      return this;
+    }
+
+    public Builder setJsonFactory(JsonFactory jsonFactory) {
+      this.jsonFactory = jsonFactory;
       return this;
     }
 

--- a/src/main/java/com/google/firebase/auth/internal/AuthHttpClient.java
+++ b/src/main/java/com/google/firebase/auth/internal/AuthHttpClient.java
@@ -16,7 +16,6 @@
 
 package com.google.firebase.auth.internal;
 
-import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponseInterceptor;
 import com.google.api.client.json.JsonFactory;
@@ -25,7 +24,6 @@ import com.google.firebase.IncomingHttpResponse;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.internal.ErrorHandlingHttpClient;
 import com.google.firebase.internal.HttpRequestInfo;
-import com.google.firebase.internal.Nullable;
 import com.google.firebase.internal.SdkUtils;
 import java.util.Map;
 import java.util.Set;
@@ -65,21 +63,14 @@ public final class AuthHttpClient {
     this.httpClient.setInterceptor(interceptor);
   }
 
-  public IncomingHttpResponse sendRequest(
-      String method, GenericUrl url, @Nullable Object content) throws FirebaseAuthException {
-    HttpRequestInfo request = HttpRequestInfo.buildJsonRequest(method, url, content)
-        .addHeader(CLIENT_VERSION_HEADER, CLIENT_VERSION);
-    return httpClient.send(request);
+  public <T> T sendRequest(HttpRequestInfo request, Class<T> clazz) throws FirebaseAuthException {
+    IncomingHttpResponse response = this.sendRequest(request);
+    return this.parse(response, clazz);
   }
 
-  public <T> T sendRequest(
-      String method,
-      GenericUrl url,
-      @Nullable Object content,
-      Class<T> clazz) throws FirebaseAuthException {
-
-    IncomingHttpResponse response = this.sendRequest(method, url, content);
-    return this.parse(response, clazz);
+  public IncomingHttpResponse sendRequest(HttpRequestInfo request) throws FirebaseAuthException {
+    request.addHeader(CLIENT_VERSION_HEADER, CLIENT_VERSION);
+    return httpClient.send(request);
   }
 
   public <T> T parse(IncomingHttpResponse response, Class<T> clazz) throws FirebaseAuthException {

--- a/src/main/java/com/google/firebase/internal/ErrorHandlingHttpClient.java
+++ b/src/main/java/com/google/firebase/internal/ErrorHandlingHttpClient.java
@@ -24,7 +24,6 @@ import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpResponseInterceptor;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.json.JsonParser;
 import com.google.common.io.CharStreams;
 import com.google.firebase.FirebaseException;
@@ -42,7 +41,6 @@ public final class ErrorHandlingHttpClient<T extends FirebaseException> {
   private final HttpRequestFactory requestFactory;
   private final JsonFactory jsonFactory;
   private final HttpErrorHandler<T> errorHandler;
-  private final JsonObjectParser jsonParser;
 
   private HttpResponseInterceptor interceptor;
 
@@ -53,7 +51,6 @@ public final class ErrorHandlingHttpClient<T extends FirebaseException> {
     this.requestFactory = checkNotNull(requestFactory, "requestFactory must not be null");
     this.jsonFactory = checkNotNull(jsonFactory, "jsonFactory must not be null");
     this.errorHandler = checkNotNull(errorHandler, "errorHandler must not be null");
-    this.jsonParser = new JsonObjectParser(jsonFactory);
   }
 
   public ErrorHandlingHttpClient<T> setInterceptor(HttpResponseInterceptor interceptor) {
@@ -138,7 +135,6 @@ public final class ErrorHandlingHttpClient<T extends FirebaseException> {
   private HttpRequest createHttpRequest(HttpRequestInfo requestInfo) throws T {
     try {
       return requestInfo.newHttpRequest(requestFactory, jsonFactory)
-          .setParser(jsonParser)
           .setResponseInterceptor(interceptor);
     } catch (IOException e) {
       // Handle request initialization errors (credential loading and other config errors)

--- a/src/main/java/com/google/firebase/internal/HttpRequestInfo.java
+++ b/src/main/java/com/google/firebase/internal/HttpRequestInfo.java
@@ -61,6 +61,16 @@ public final class HttpRequestInfo {
     return this;
   }
 
+  public HttpRequestInfo addParameter(String name, Object value) {
+    this.url.put(name, value);
+    return this;
+  }
+
+  public HttpRequestInfo addAllParameters(Map<String, Object> params) {
+    this.url.putAll(params);
+    return this;
+  }
+
   public static HttpRequestInfo buildGetRequest(String url) {
     return buildRequest(HttpMethods.GET, url, null);
   }
@@ -71,26 +81,20 @@ public final class HttpRequestInfo {
 
   public static HttpRequestInfo buildRequest(
       String method, String url, @Nullable HttpContent content) {
-    return buildRequest(method, new GenericUrl(url), content);
-  }
-
-  public static HttpRequestInfo buildRequest(
-      String method, GenericUrl url, @Nullable HttpContent content) {
-    return new HttpRequestInfo(method, url, content, null);
+    return new HttpRequestInfo(method, new GenericUrl(url), content, null);
   }
 
   public static HttpRequestInfo buildJsonPostRequest(String url, @Nullable Object content) {
     return buildJsonRequest(HttpMethods.POST, url, content);
   }
 
-  public static HttpRequestInfo buildJsonRequest(
-      String method, String url, @Nullable Object content) {
-    return buildJsonRequest(method, new GenericUrl(url), content);
+  public static HttpRequestInfo buildJsonPatchRequest(String url, @Nullable Object content) {
+    return buildJsonRequest(HttpMethods.PATCH, url, content);
   }
 
   public static HttpRequestInfo buildJsonRequest(
-      String method, GenericUrl url, @Nullable Object content) {
-    return new HttpRequestInfo(method, url, null, content);
+      String method, String url, @Nullable Object content) {
+    return new HttpRequestInfo(method, new GenericUrl(url), null, content);
   }
 
   HttpRequest newHttpRequest(

--- a/src/main/java/com/google/firebase/projectmanagement/HttpHelper.java
+++ b/src/main/java/com/google/firebase/projectmanagement/HttpHelper.java
@@ -94,7 +94,7 @@ final class HttpHelper {
         requestIdentifierDescription);
   }
 
-  <T> IncomingHttpResponse makeRequest(
+  private <T> IncomingHttpResponse makeRequest(
       HttpRequestInfo baseRequest,
       T parsedResponseInstance,
       String requestIdentifier,

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
@@ -499,7 +499,7 @@ public class FirebaseAuthTest {
   private FirebaseAuth getAuthForIdTokenVerification(
       FirebaseApp app,
       Supplier<? extends FirebaseTokenVerifier> tokenVerifierSupplier) {
-    FirebaseUserManager userManager = FirebaseUserManager.builder().setFirebaseApp(app).build();
+    FirebaseUserManager userManager = FirebaseUserManager.createUserManager(app, null);
     return new FirebaseAuth(
         AbstractFirebaseAuth.builder()
           .setFirebaseApp(app)
@@ -526,7 +526,7 @@ public class FirebaseAuthTest {
   private FirebaseAuth getAuthForSessionCookieVerification(
       FirebaseApp app,
       Supplier<? extends FirebaseTokenVerifier> tokenVerifierSupplier) {
-    FirebaseUserManager userManager = FirebaseUserManager.builder().setFirebaseApp(app).build();
+    FirebaseUserManager userManager = FirebaseUserManager.createUserManager(app, null);
     return new FirebaseAuth(
           AbstractFirebaseAuth.builder()
           .setFirebaseApp(app)

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -45,14 +45,12 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.auth.FirebaseUserManager.EmailLinkType;
-import com.google.firebase.auth.internal.AuthHttpClient;
 import com.google.firebase.auth.multitenancy.TenantAwareFirebaseAuth;
 import com.google.firebase.auth.multitenancy.TenantManager;
 import com.google.firebase.internal.SdkUtils;
 import com.google.firebase.testing.MultiRequestMockHttpTransport;
 import com.google.firebase.testing.TestResponseInterceptor;
 import com.google.firebase.testing.TestUtils;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -2683,7 +2681,6 @@ public class FirebaseUserManagerTest {
         .build();
     final FirebaseApp app = FirebaseApp.initializeApp(new FirebaseOptions.Builder()
         .setCredentials(credentials)
-        .setProjectId("test-project-id")
         .setHttpTransport(transport)
         .build());
     return new FirebaseAuth(
@@ -2694,8 +2691,9 @@ public class FirebaseUserManagerTest {
             public FirebaseUserManager get() {
               return FirebaseUserManager
                 .builder()
-                .setFirebaseApp(app)
+                .setProjectId("test-project-id")
                 .setHttpRequestFactory(transport.createRequestFactory())
+                .setJsonFactory(JSON_FACTORY)
                 .build();
             }
           }));


### PR DESCRIPTION
A collection of somewhat related cleanup and refactoring actions:

* Updated to `FirebaseUserManager.Builder` and introducing a new `createUserManager()` factory method so it looks similar to how other helper classes are initialized in the auth package.
* `HttpRequestInfo` now supports setting URL query parameters. Calling classes no need to use `GenericUrl`.
* `JsonObjectParser` attribute is removed from the `ErrorHandlingHttpClient`. It's not needed there due to the way we parse response payloads in the SDK.