### PR TITLE
fix: Fixing a series of javadoc warnings

### DIFF
--- a/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
@@ -801,7 +801,7 @@ public abstract class AbstractFirebaseAuth {
    * not guaranteed to correspond to the nth entry in the input parameters list.
    *
    * <p>A maximum of 100 identifiers may be specified. If more than 100 identifiers are
-   * supplied, this method throws an {@link IllegalArgumentException}.
+   * supplied, this method throws an {@code IllegalArgumentException}.
    *
    * @param identifiers The identifiers used to indicate which user records should be returned. Must
    *     have 100 or fewer entries.
@@ -823,7 +823,7 @@ public abstract class AbstractFirebaseAuth {
    * not guaranteed to correspond to the nth entry in the input parameters list.
    *
    * <p>A maximum of 100 identifiers may be specified. If more than 100 identifiers are
-   * supplied, this method throws an {@link IllegalArgumentException}.
+   * supplied, this method throws an {@code IllegalArgumentException}.
    *
    * @param identifiers The identifiers used to indicate which user records should be returned.
    *     Must have 100 or fewer entries.
@@ -877,7 +877,7 @@ public abstract class AbstractFirebaseAuth {
    * DeleteUsersResult.getSuccessCount() value.
    *
    * <p>A maximum of 1000 identifiers may be supplied. If more than 1000 identifiers are
-   * supplied, this method throws an {@link IllegalArgumentException}.
+   * supplied, this method throws an {@code IllegalArgumentException}.
    *
    * <p>This API has a rate limit of 1 QPS. Exceeding the limit may result in a quota exceeded
    * error. If you want to delete more than 1000 users, we suggest adding a delay to ensure you
@@ -886,7 +886,7 @@ public abstract class AbstractFirebaseAuth {
    * @param uids The uids of the users to be deleted. Must have <= 1000 entries.
    * @return The total number of successful/failed deletions, as well as the array of errors that
    *     correspond to the failed deletions.
-   * @throw IllegalArgumentException If any of the identifiers are invalid or if more than 1000
+   * @throws IllegalArgumentException If any of the identifiers are invalid or if more than 1000
    *     identifiers are specified.
    * @throws FirebaseAuthException If an error occurs while deleting users.
    */
@@ -902,7 +902,7 @@ public abstract class AbstractFirebaseAuth {
    *     deletions, as well as the array of errors that correspond to the failed deletions. If an
    *     error occurs while deleting the user account, the future throws a
    *     {@link FirebaseAuthException}.
-   * @throw IllegalArgumentException If any of the identifiers are invalid or if more than 1000
+   * @throws IllegalArgumentException If any of the identifiers are invalid or if more than 1000
    *     identifiers are specified.
    */
   public ApiFuture<DeleteUsersResult> deleteUsersAsync(List<String> uids) {

--- a/src/main/java/com/google/firebase/auth/ListProviderConfigsPage.java
+++ b/src/main/java/com/google/firebase/auth/ListProviderConfigsPage.java
@@ -88,7 +88,7 @@ public class ListProviderConfigsPage<T extends ProviderConfig> implements Page<T
   @Override
   public ListProviderConfigsPage<T> getNextPage() {
     if (hasNextPage()) {
-      Factory<T> factory = new Factory<T>(source, maxResults, currentBatch.getPageToken());
+      Factory<T> factory = new Factory<>(source, maxResults, currentBatch.getPageToken());
       try {
         return factory.create();
       } catch (FirebaseAuthException e) {
@@ -99,25 +99,25 @@ public class ListProviderConfigsPage<T extends ProviderConfig> implements Page<T
   }
 
   /**
-   * Returns an {@link Iterable} that facilitates transparently iterating over all the provider
+   * Returns an {@code Iterable} that facilitates transparently iterating over all the provider
    * configs in the current Firebase project, starting from this page.
    *
-   * <p>The {@link Iterator} instances produced by the returned {@link Iterable} never buffers more
+   * <p>The {@code Iterator} instances produced by the returned {@code Iterable} never buffers more
    * than one page of provider configs at a time. It is safe to abandon the iterators (i.e. break
    * the loops) at any time.
    *
-   * @return a new {@link Iterable} instance.
+   * @return a new {@code Iterable} instance.
    */
   @NonNull
   @Override
   public Iterable<T> iterateAll() {
-    return new ProviderConfigIterable<T>(this);
+    return new ProviderConfigIterable<>(this);
   }
 
   /**
-   * Returns an {@link Iterable} over the provider configs in this page.
+   * Returns an {@code Iterable} over the provider configs in this page.
    *
-   * @return a {@link Iterable} instance.
+   * @return a {@code Iterable} instance.
    */
   @NonNull
   @Override
@@ -136,7 +136,7 @@ public class ListProviderConfigsPage<T extends ProviderConfig> implements Page<T
     @Override
     @NonNull
     public Iterator<T> iterator() {
-      return new ProviderConfigIterator<T>(startingPage);
+      return new ProviderConfigIterator<>(startingPage);
     }
 
     /**
@@ -230,7 +230,7 @@ public class ListProviderConfigsPage<T extends ProviderConfig> implements Page<T
   }
 
   /**
-   * A simple factory class for {@link ProviderConfigsPage} instances.
+   * A simple factory class for {@link ListProviderConfigsPage} instances.
    *
    * <p>Performs argument validation before attempting to load any provider config data (which is
    * expensive, and hence may be performed asynchronously on a separate thread).
@@ -261,7 +261,7 @@ public class ListProviderConfigsPage<T extends ProviderConfig> implements Page<T
 
     ListProviderConfigsPage<T> create() throws FirebaseAuthException {
       ListProviderConfigsResponse<T> batch = source.fetch(maxResults, pageToken);
-      return new ListProviderConfigsPage<T>(batch, source, maxResults);
+      return new ListProviderConfigsPage<>(batch, source, maxResults);
     }
   }
 }

--- a/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
+++ b/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
@@ -132,7 +132,7 @@ public final class OidcProviderConfig extends ProviderConfig {
      * provider.
      *
      * <p>The returned object should be passed to
-     * {@link AbstractFirebaseAuth#updateOidcProviderConfig(CreateRequest)} to save the updated
+     * {@link AbstractFirebaseAuth#updateOidcProviderConfig(UpdateRequest)} to save the updated
      * config.
      *
      * @param providerId A non-null, non-empty provider ID string.

--- a/src/main/java/com/google/firebase/auth/multitenancy/ListTenantsPage.java
+++ b/src/main/java/com/google/firebase/auth/multitenancy/ListTenantsPage.java
@@ -96,14 +96,14 @@ public class ListTenantsPage implements Page<Tenant> {
   }
 
   /**
-   * Returns an {@link Iterable} that facilitates transparently iterating over all the tenants in
+   * Returns an {@code Iterable} that facilitates transparently iterating over all the tenants in
    * the current Firebase project, starting from this page.
    *
-   * <p>The {@link Iterator} instances produced by the returned {@link Iterable} never buffers more
+   * <p>The {@code Iterator} instances produced by the returned {@code Iterable} never buffers more
    * than one page of tenants at a time. It is safe to abandon the iterators (i.e. break the loops)
    * at any time.
    *
-   * @return a new {@link Iterable} instance.
+   * @return a new {@code Iterable} instance.
    */
   @NonNull
   @Override
@@ -112,9 +112,9 @@ public class ListTenantsPage implements Page<Tenant> {
   }
 
   /**
-   * Returns an {@link Iterable} over the tenants in this page.
+   * Returns an {@code Iterable} over the tenants in this page.
    *
-   * @return a {@link Iterable} instance.
+   * @return a {@code Iterable} instance.
    */
   @NonNull
   @Override
@@ -137,7 +137,7 @@ public class ListTenantsPage implements Page<Tenant> {
     }
 
     /**
-     * An {@link Iterator} that cycles through tenants, one at a time.
+     * An {@code Iterator} that cycles through tenants, one at a time.
      *
      * <p>It buffers the last retrieved batch of tenants in memory. The {@code maxResults} parameter
      * is an upper bound on the batch size.


### PR DESCRIPTION
Fixing the following javadoc warnings:

```
[WARNING] Javadoc Warnings
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java:798: warning 101: Unresolved link/see tag "IllegalArgumentException" in com.google.firebase.auth.AbstractFirebaseAuth
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java:820: warning 101: Unresolved link/see tag "IllegalArgumentException" in com.google.firebase.auth.AbstractFirebaseAuth
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java:873: warning 101: Unresolved link/see tag "IllegalArgumentException" in com.google.firebase.auth.AbstractFirebaseAuth
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java:889: warning 103: Unknown tag: @throw
[WARNING] ~hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java:905: warning 103: Unknown tag: @throw
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/ListProviderConfigsPage.java:104: warning 101: Unresolved link/see tag "Iterable" in com.google.firebase.auth.ListProviderConfigsPage
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/ListProviderConfigsPage.java:104: warning 101: Unresolved link/see tag "Iterator" in com.google.firebase.auth.ListProviderConfigsPage
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/ListProviderConfigsPage.java:107: warning 101: Unresolved link/see tag "Iterable" in com.google.firebase.auth.ListProviderConfigsPage
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/ListProviderConfigsPage.java:118: warning 101: Unresolved link/see tag "Iterable" in com.google.firebase.auth.ListProviderConfigsPage
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/ListProviderConfigsPage.java:120: warning 101: Unresolved link/see tag "Iterable" in com.google.firebase.auth.ListProviderConfigsPage
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/OidcProviderConfig.java:131: warning 101: Unresolved link/see tag "AbstractFirebaseAuth#updateOidcProviderConfig(CreateRequest)" in com.google.firebase.auth.OidcProviderConfig.UpdateRequest
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/multitenancy/ListTenantsPage.java:101: warning 101: Unresolved link/see tag "Iterable" in com.google.firebase.auth.multitenancy.ListTenantsPage
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/multitenancy/ListTenantsPage.java:101: warning 101: Unresolved link/see tag "Iterator" in com.google.firebase.auth.multitenancy.ListTenantsPage
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/multitenancy/ListTenantsPage.java:104: warning 101: Unresolved link/see tag "Iterable" in com.google.firebase.auth.multitenancy.ListTenantsPage
[WARNING] ~/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/multitenancy/ListTenantsPage.java:115: warning 101: Unresolved link/see tag "Iterable" in com.google.firebase.auth.multitenancy.ListTenantsPage
[WARNING] ~/hkj/Projects/firebase-admin-java/public/src/main/java/com/google/firebase/auth/multitenancy/ListTenantsPage.java:117: warning 101: Unresolved link/see tag "Iterable" in com.google.firebase.auth.multitenancy.ListTenantsPage
```

Specifically we cannot `{@link }` to classes that are not part of our codebase.