### PR TITLE
Fix javadoc error caused by having protected parameters public methods

### DIFF
--- a/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
@@ -1782,11 +1782,6 @@ public abstract class AbstractFirebaseAuth {
       return getThis();
     }
 
-    public T setTokenFactory(Supplier<FirebaseTokenFactory> tokenFactory) {
-      this.tokenFactory = tokenFactory;
-      return getThis();
-    }
-
     public T setIdTokenVerifier(Supplier<? extends FirebaseTokenVerifier> idTokenVerifier) {
       this.idTokenVerifier = idTokenVerifier;
       return getThis();
@@ -1797,8 +1792,13 @@ public abstract class AbstractFirebaseAuth {
       return getThis();
     }
 
-    public T setUserManager(Supplier<FirebaseUserManager> userManager) {
+    T setUserManager(Supplier<FirebaseUserManager> userManager) {
       this.userManager = userManager;
+      return getThis();
+    }
+
+    T setTokenFactory(Supplier<FirebaseTokenFactory> tokenFactory) {
+      this.tokenFactory = tokenFactory;
       return getThis();
     }
   }


### PR DESCRIPTION
`AbstractFirebaseAuth.Builder` has public methods `setTokenFactory` and `setUserManager` that accepts protected parameters, which cause `javadoc` errors.

This PR is based on: https://github.com/firebase/firebase-admin-java/pull/465/commits/b413c7ab64fcf2af657b55e578647559cf2bcd61