### PR TITLE
fix(auth): Support verifying tenant ID tokens in FirebaseAuth

### DIFF
--- a/src/main/java/com/google/firebase/auth/FirebaseTokenVerifierImpl.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseTokenVerifierImpl.java
@@ -71,7 +71,7 @@ final class FirebaseTokenVerifierImpl implements FirebaseTokenVerifier {
     this.docUrl = builder.docUrl;
     this.invalidTokenErrorCode = checkNotNull(builder.invalidTokenErrorCode);
     this.expiredTokenErrorCode = checkNotNull(builder.expiredTokenErrorCode);
-    this.tenantId = Strings.nullToEmpty(builder.tenantId);
+    this.tenantId = builder.tenantId;
   }
 
   /**
@@ -323,8 +323,8 @@ final class FirebaseTokenVerifierImpl implements FirebaseTokenVerifier {
   }
 
   private void checkTenantId(final FirebaseToken firebaseToken) throws FirebaseAuthException {
-    String tokenTenantId = Strings.nullToEmpty(firebaseToken.getTenantId());
-    if (!this.tenantId.equals(tokenTenantId)) {
+    String tokenTenantId = firebaseToken.getTenantId();
+    if (this.tenantId != null && !this.tenantId.equals(tokenTenantId)) {
       String message = String.format(
           "The tenant ID ('%s') of the token did not match the expected value ('%s')",
           tokenTenantId,

--- a/src/main/java/com/google/firebase/auth/FirebaseTokenVerifierImpl.java
+++ b/src/main/java/com/google/firebase/auth/FirebaseTokenVerifierImpl.java
@@ -327,7 +327,7 @@ final class FirebaseTokenVerifierImpl implements FirebaseTokenVerifier {
     if (this.tenantId != null && !this.tenantId.equals(tokenTenantId)) {
       String message = String.format(
           "The tenant ID ('%s') of the token did not match the expected value ('%s')",
-          tokenTenantId,
+          Strings.nullToEmpty(tokenTenantId),
           tenantId);
       throw newException(message, AuthErrorCode.TENANT_ID_MISMATCH);
     }

--- a/src/test/java/com/google/firebase/FirebaseAppTest.java
+++ b/src/test/java/com/google/firebase/FirebaseAppTest.java
@@ -66,7 +66,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-/** 
+/**
  * Unit tests for {@link com.google.firebase.FirebaseApp}.
  */
 public class FirebaseAppTest {
@@ -472,8 +472,8 @@ public class FirebaseAppTest {
   public void testEmptyFirebaseConfigFile() {
     setFirebaseConfigEnvironmentVariable("firebase_config_empty.json");
     FirebaseApp.initializeApp();
-  }  
-  
+  }
+
   @Test
   public void testEmptyFirebaseConfigString() {
     setFirebaseConfigEnvironmentVariable("");
@@ -481,7 +481,7 @@ public class FirebaseAppTest {
     assertNull(firebaseApp.getOptions().getProjectId());
     assertNull(firebaseApp.getOptions().getStorageBucket());
     assertNull(firebaseApp.getOptions().getDatabaseUrl());
-    assertTrue(firebaseApp.getOptions().getDatabaseAuthVariableOverride().isEmpty()); 
+    assertTrue(firebaseApp.getOptions().getDatabaseAuthVariableOverride().isEmpty());
   }
 
   @Test
@@ -542,20 +542,20 @@ public class FirebaseAppTest {
 
   @Test
   public void testValidFirebaseConfigString() {
-    setFirebaseConfigEnvironmentVariable("{" 
-        + "\"databaseAuthVariableOverride\": {" 
-        +   "\"uid\":" 
-        +   "\"testuser\"" 
-        + "}," 
-        + "\"databaseUrl\": \"https://hipster-chat.firebaseio.mock\"," 
-        + "\"projectId\": \"hipster-chat-mock\"," 
-        + "\"storageBucket\": \"hipster-chat.appspot.mock\"" 
+    setFirebaseConfigEnvironmentVariable("{"
+        + "\"databaseAuthVariableOverride\": {"
+        +   "\"uid\":"
+        +   "\"testuser\""
+        + "},"
+        + "\"databaseUrl\": \"https://hipster-chat.firebaseio.mock\","
+        + "\"projectId\": \"hipster-chat-mock\","
+        + "\"storageBucket\": \"hipster-chat.appspot.mock\""
         + "}");
     FirebaseApp firebaseApp = FirebaseApp.initializeApp();
     assertEquals("hipster-chat-mock", firebaseApp.getOptions().getProjectId());
     assertEquals("hipster-chat.appspot.mock", firebaseApp.getOptions().getStorageBucket());
     assertEquals("https://hipster-chat.firebaseio.mock", firebaseApp.getOptions().getDatabaseUrl());
-    assertEquals("testuser", 
+    assertEquals("testuser",
         firebaseApp.getOptions().getDatabaseAuthVariableOverride().get("uid"));
   }
 

--- a/src/test/java/com/google/firebase/auth/FirebaseTokenVerifierImplTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseTokenVerifierImplTest.java
@@ -379,7 +379,7 @@ public class FirebaseTokenVerifierImplTest {
     } catch (FirebaseAuthException e) {
       assertEquals(AuthErrorCode.TENANT_ID_MISMATCH, e.getAuthErrorCode());
       assertEquals(
-          "The tenant ID ('null') of the token did not match the expected value ('TENANT_1')",
+          "The tenant ID ('') of the token did not match the expected value ('TENANT_1')",
           e.getMessage());
     }
   }
@@ -394,7 +394,7 @@ public class FirebaseTokenVerifierImplTest {
     } catch (FirebaseAuthException e) {
       assertEquals(AuthErrorCode.TENANT_ID_MISMATCH, e.getAuthErrorCode());
       assertEquals(
-          "The tenant ID ('null') of the token did not match the expected value ('TENANT_ID')",
+          "The tenant ID ('') of the token did not match the expected value ('TENANT_ID')",
           e.getMessage());
     }
   }

--- a/src/test/java/com/google/firebase/auth/FirebaseTokenVerifierImplTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseTokenVerifierImplTest.java
@@ -328,6 +328,17 @@ public class FirebaseTokenVerifierImplTest {
 
   @Test
   public void testVerifyTokenWithTenantId() throws FirebaseAuthException {
+    FirebaseTokenVerifierImpl verifier = fullyPopulatedBuilder().build();
+
+    FirebaseToken firebaseToken = verifier.verifyToken(createTokenWithTenantId("TENANT_1"));
+
+    assertEquals(TEST_TOKEN_ISSUER, firebaseToken.getIssuer());
+    assertEquals(TestTokenFactory.UID, firebaseToken.getUid());
+    assertEquals("TENANT_1", firebaseToken.getTenantId());
+  }
+
+  @Test
+  public void testVerifyTokenWithMatchingTenantId() throws FirebaseAuthException {
     FirebaseTokenVerifierImpl verifier = fullyPopulatedBuilder()
         .setTenantId("TENANT_1")
         .build();
@@ -341,15 +352,34 @@ public class FirebaseTokenVerifierImplTest {
 
   @Test
   public void testVerifyTokenDifferentTenantIds() {
-    try {
-      fullyPopulatedBuilder()
+    FirebaseTokenVerifierImpl verifier = fullyPopulatedBuilder()
         .setTenantId("TENANT_1")
-        .build()
-        .verifyToken(createTokenWithTenantId("TENANT_2"));
+        .build();
+    String token = createTokenWithTenantId("TENANT_2");
+
+    try {
+      verifier.verifyToken(token);
     } catch (FirebaseAuthException e) {
       assertEquals(AuthErrorCode.TENANT_ID_MISMATCH, e.getAuthErrorCode());
       assertEquals(
           "The tenant ID ('TENANT_2') of the token did not match the expected value ('TENANT_1')",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testVerifyTokenNoTenantId() {
+    FirebaseTokenVerifierImpl verifier = fullyPopulatedBuilder()
+        .setTenantId("TENANT_1")
+        .build();
+    String token = tokenFactory.createToken();
+
+    try {
+      verifier.verifyToken(token);
+    } catch (FirebaseAuthException e) {
+      assertEquals(AuthErrorCode.TENANT_ID_MISMATCH, e.getAuthErrorCode());
+      assertEquals(
+          "The tenant ID ('null') of the token did not match the expected value ('TENANT_1')",
           e.getMessage());
     }
   }
@@ -364,7 +394,7 @@ public class FirebaseTokenVerifierImplTest {
     } catch (FirebaseAuthException e) {
       assertEquals(AuthErrorCode.TENANT_ID_MISMATCH, e.getAuthErrorCode());
       assertEquals(
-          "The tenant ID ('') of the token did not match the expected value ('TENANT_ID')",
+          "The tenant ID ('null') of the token did not match the expected value ('TENANT_ID')",
           e.getMessage());
     }
   }

--- a/src/test/java/com/google/firebase/auth/multitenancy/TenantAwareFirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/multitenancy/TenantAwareFirebaseAuthIT.java
@@ -261,6 +261,11 @@ public class TenantAwareFirebaseAuthIT {
       assertEquals(AuthErrorCode.TENANT_ID_MISMATCH,
           ((FirebaseAuthException) e.getCause()).getAuthErrorCode());
     }
+
+    // Verifies with FirebaseAuth
+    FirebaseToken decoded = FirebaseAuth.getInstance().verifyIdToken(idToken);
+    assertEquals("user", decoded.getUid());
+    assertEquals(tenantId, decoded.getTenantId());
   }
 
   @Test


### PR DESCRIPTION
`FirebaseAuth` should be able to verify ID tokens regardless of the tenant ID.

Resolves #474 