### PR TITLE
Remote Config Refactor Public and Response types

### DIFF
--- a/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImpl.java
+++ b/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImpl.java
@@ -96,7 +96,7 @@ final class FirebaseRemoteConfigClientImpl implements FirebaseRemoteConfigClient
             .addAllHeaders(COMMON_HEADERS);
     IncomingHttpResponse response = httpClient.send(request);
     TemplateResponse templateResponse = httpClient.parse(response, TemplateResponse.class);
-    RemoteConfigTemplate template = templateResponse.toRemoteConfigTemplate();
+    RemoteConfigTemplate template = new RemoteConfigTemplate(templateResponse);
     return template.setETag(getETag(response));
   }
 

--- a/src/main/java/com/google/firebase/remoteconfig/RemoteConfigParameter.java
+++ b/src/main/java/com/google/firebase/remoteconfig/RemoteConfigParameter.java
@@ -48,14 +48,14 @@ public final class RemoteConfigParameter {
     checkNotNull(parameterResponse);
     conditionalValues = new HashMap<>();
     if (parameterResponse.getConditionalValues() != null) {
-      for (Map.Entry<String, ParameterValueResponse> entry :
-              parameterResponse.getConditionalValues().entrySet()) {
+      for (Map.Entry<String, ParameterValueResponse> entry
+              : parameterResponse.getConditionalValues().entrySet()) {
         conditionalValues.put(entry.getKey(), fromParameterValueResponse(entry.getValue()));
       }
     }
     ParameterValueResponse responseDefaultValue = parameterResponse.getDefaultValue();
-    defaultValue = (responseDefaultValue == null) ? null :
-            fromParameterValueResponse(responseDefaultValue);
+    defaultValue = (responseDefaultValue == null) ? null
+            : fromParameterValueResponse(responseDefaultValue);
     description = parameterResponse.getDescription();
   }
 
@@ -136,8 +136,8 @@ public final class RemoteConfigParameter {
     for (Map.Entry<String, RemoteConfigParameterValue> entry : conditionalValues.entrySet()) {
       conditionalResponseValues.put(entry.getKey(), entry.getValue().toParameterValueResponse());
     }
-    ParameterValueResponse defaultValueResponse = (defaultValue == null) ? null :
-            defaultValue.toParameterValueResponse();
+    ParameterValueResponse defaultValueResponse = (defaultValue == null) ? null
+            : defaultValue.toParameterValueResponse();
     return new ParameterResponse()
             .setDefaultValue(defaultValueResponse)
             .setDescription(description)

--- a/src/main/java/com/google/firebase/remoteconfig/RemoteConfigParameter.java
+++ b/src/main/java/com/google/firebase/remoteconfig/RemoteConfigParameter.java
@@ -16,7 +16,6 @@
 
 package com.google.firebase.remoteconfig;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.firebase.internal.NonNull;
@@ -43,6 +42,21 @@ public final class RemoteConfigParameter {
    */
   public RemoteConfigParameter() {
     conditionalValues = new HashMap<>();
+  }
+
+  protected RemoteConfigParameter(@NonNull ParameterResponse parameterResponse) {
+    checkNotNull(parameterResponse);
+    conditionalValues = new HashMap<>();
+    if (parameterResponse.getConditionalValues() != null) {
+      for (Map.Entry<String, ParameterValueResponse> entry :
+              parameterResponse.getConditionalValues().entrySet()) {
+        conditionalValues.put(entry.getKey(), fromParameterValueResponse(entry.getValue()));
+      }
+    }
+    ParameterValueResponse responseDefaultValue = parameterResponse.getDefaultValue();
+    defaultValue = (responseDefaultValue == null) ? null :
+            fromParameterValueResponse(responseDefaultValue);
+    description = parameterResponse.getDescription();
   }
 
   /**
@@ -122,9 +136,21 @@ public final class RemoteConfigParameter {
     for (Map.Entry<String, RemoteConfigParameterValue> entry : conditionalValues.entrySet()) {
       conditionalResponseValues.put(entry.getKey(), entry.getValue().toParameterValueResponse());
     }
-    ParameterValueResponse parameterValueResponse = (defaultValue == null) ? null : defaultValue
-            .toParameterValueResponse();
-    return new ParameterResponse(parameterValueResponse, description,
-            conditionalResponseValues);
+    ParameterValueResponse defaultValueResponse = (defaultValue == null) ? null :
+            defaultValue.toParameterValueResponse();
+    return new ParameterResponse()
+            .setDefaultValue(defaultValueResponse)
+            .setDescription(description)
+            .setConditionalValues(conditionalResponseValues);
+  }
+
+  private RemoteConfigParameterValue fromParameterValueResponse(
+          @NonNull ParameterValueResponse parameterValueResponse) {
+    checkNotNull(parameterValueResponse);
+    if (parameterValueResponse.isInAppDefaultValue() != null
+            && parameterValueResponse.isInAppDefaultValue()) {
+      return RemoteConfigParameterValue.inAppDefault();
+    }
+    return RemoteConfigParameterValue.of(parameterValueResponse.getValue());
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/RemoteConfigParameter.java
+++ b/src/main/java/com/google/firebase/remoteconfig/RemoteConfigParameter.java
@@ -44,19 +44,20 @@ public final class RemoteConfigParameter {
     conditionalValues = new HashMap<>();
   }
 
-  protected RemoteConfigParameter(@NonNull ParameterResponse parameterResponse) {
+  RemoteConfigParameter(@NonNull ParameterResponse parameterResponse) {
     checkNotNull(parameterResponse);
-    conditionalValues = new HashMap<>();
+    this.conditionalValues = new HashMap<>();
     if (parameterResponse.getConditionalValues() != null) {
       for (Map.Entry<String, ParameterValueResponse> entry
               : parameterResponse.getConditionalValues().entrySet()) {
-        conditionalValues.put(entry.getKey(), fromParameterValueResponse(entry.getValue()));
+        this.conditionalValues.put(entry.getKey(),
+                RemoteConfigParameterValue.fromParameterValueResponse(entry.getValue()));
       }
     }
     ParameterValueResponse responseDefaultValue = parameterResponse.getDefaultValue();
-    defaultValue = (responseDefaultValue == null) ? null
-            : fromParameterValueResponse(responseDefaultValue);
-    description = parameterResponse.getDescription();
+    this.defaultValue = (responseDefaultValue == null) ? null
+            : RemoteConfigParameterValue.fromParameterValueResponse(responseDefaultValue);
+    this.description = parameterResponse.getDescription();
   }
 
   /**
@@ -142,15 +143,5 @@ public final class RemoteConfigParameter {
             .setDefaultValue(defaultValueResponse)
             .setDescription(description)
             .setConditionalValues(conditionalResponseValues);
-  }
-
-  private RemoteConfigParameterValue fromParameterValueResponse(
-          @NonNull ParameterValueResponse parameterValueResponse) {
-    checkNotNull(parameterValueResponse);
-    if (parameterValueResponse.isInAppDefaultValue() != null
-            && parameterValueResponse.isInAppDefaultValue()) {
-      return RemoteConfigParameterValue.inAppDefault();
-    }
-    return RemoteConfigParameterValue.of(parameterValueResponse.getValue());
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/RemoteConfigParameterValue.java
+++ b/src/main/java/com/google/firebase/remoteconfig/RemoteConfigParameterValue.java
@@ -16,6 +16,9 @@
 
 package com.google.firebase.remoteconfig;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.firebase.internal.NonNull;
 import com.google.firebase.remoteconfig.internal.TemplateResponse.ParameterValueResponse;
 
 /**
@@ -44,6 +47,15 @@ public abstract class RemoteConfigParameterValue {
 
   abstract ParameterValueResponse toParameterValueResponse();
 
+  static RemoteConfigParameterValue fromParameterValueResponse(
+          @NonNull ParameterValueResponse parameterValueResponse) {
+    checkNotNull(parameterValueResponse);
+    if (parameterValueResponse.isUseInAppDefault()) {
+      return RemoteConfigParameterValue.inAppDefault();
+    }
+    return RemoteConfigParameterValue.of(parameterValueResponse.getValue());
+  }
+
   /**
    * Represents an explicit Remote Config parameter value with a {@link String} value that the
    * parameter is set to.
@@ -68,8 +80,7 @@ public abstract class RemoteConfigParameterValue {
     @Override
     ParameterValueResponse toParameterValueResponse() {
       return new ParameterValueResponse()
-              .setValue(this.value)
-              .setInAppDefaultValue(null);
+              .setValue(this.value);
     }
   }
 
@@ -80,9 +91,7 @@ public abstract class RemoteConfigParameterValue {
 
     @Override
     ParameterValueResponse toParameterValueResponse() {
-      return new ParameterValueResponse()
-              .setInAppDefaultValue(true)
-              .setValue(null);
+      return new ParameterValueResponse().setUseInAppDefault(true);
     }
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/RemoteConfigParameterValue.java
+++ b/src/main/java/com/google/firebase/remoteconfig/RemoteConfigParameterValue.java
@@ -67,7 +67,9 @@ public abstract class RemoteConfigParameterValue {
 
     @Override
     ParameterValueResponse toParameterValueResponse() {
-      return ParameterValueResponse.ofValue(this.value);
+      return new ParameterValueResponse()
+              .setValue(this.value)
+              .setInAppDefaultValue(null);
     }
   }
 
@@ -78,7 +80,9 @@ public abstract class RemoteConfigParameterValue {
 
     @Override
     ParameterValueResponse toParameterValueResponse() {
-      return ParameterValueResponse.ofInAppDefaultValue();
+      return new ParameterValueResponse()
+              .setInAppDefaultValue(true)
+              .setValue(null);
     }
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/RemoteConfigTemplate.java
+++ b/src/main/java/com/google/firebase/remoteconfig/RemoteConfigTemplate.java
@@ -39,13 +39,13 @@ public final class RemoteConfigTemplate {
     parameters = new HashMap<>();
   }
 
-  protected RemoteConfigTemplate(@NonNull TemplateResponse templateResponse) {
+  RemoteConfigTemplate(@NonNull TemplateResponse templateResponse) {
     checkNotNull(templateResponse);
-    parameters = new HashMap<>();
+    this.parameters = new HashMap<>();
     if (templateResponse.getParameters() != null) {
       for (Map.Entry<String, TemplateResponse.ParameterResponse> entry
               : templateResponse.getParameters().entrySet()) {
-        parameters.put(entry.getKey(), new RemoteConfigParameter(entry.getValue()));
+        this.parameters.put(entry.getKey(), new RemoteConfigParameter(entry.getValue()));
       }
     }
   }

--- a/src/main/java/com/google/firebase/remoteconfig/RemoteConfigTemplate.java
+++ b/src/main/java/com/google/firebase/remoteconfig/RemoteConfigTemplate.java
@@ -39,6 +39,17 @@ public final class RemoteConfigTemplate {
     parameters = new HashMap<>();
   }
 
+  protected RemoteConfigTemplate(@NonNull TemplateResponse templateResponse) {
+    checkNotNull(templateResponse);
+    parameters = new HashMap<>();
+    if (templateResponse.getParameters() != null) {
+      for (Map.Entry<String, TemplateResponse.ParameterResponse> entry :
+              templateResponse.getParameters().entrySet()) {
+        parameters.put(entry.getKey(), new RemoteConfigParameter(entry.getValue()));
+      }
+    }
+  }
+
   /**
    * Gets the ETag of the template.
    *
@@ -83,6 +94,6 @@ public final class RemoteConfigTemplate {
     for (Map.Entry<String, RemoteConfigParameter> entry : parameters.entrySet()) {
       parameterResponses.put(entry.getKey(), entry.getValue().toParameterResponse());
     }
-    return new TemplateResponse(parameterResponses);
+    return new TemplateResponse().setParameters(parameterResponses);
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/RemoteConfigTemplate.java
+++ b/src/main/java/com/google/firebase/remoteconfig/RemoteConfigTemplate.java
@@ -43,8 +43,8 @@ public final class RemoteConfigTemplate {
     checkNotNull(templateResponse);
     parameters = new HashMap<>();
     if (templateResponse.getParameters() != null) {
-      for (Map.Entry<String, TemplateResponse.ParameterResponse> entry :
-              templateResponse.getParameters().entrySet()) {
+      for (Map.Entry<String, TemplateResponse.ParameterResponse> entry
+              : templateResponse.getParameters().entrySet()) {
         parameters.put(entry.getKey(), new RemoteConfigParameter(entry.getValue()));
       }
     }

--- a/src/main/java/com/google/firebase/remoteconfig/internal/TemplateResponse.java
+++ b/src/main/java/com/google/firebase/remoteconfig/internal/TemplateResponse.java
@@ -94,14 +94,18 @@ public final class TemplateResponse {
     private String value;
 
     @Key("useInAppDefault")
-    private Boolean inAppDefaultValue;
+    private Boolean useInAppDefault;
 
     public String getValue() {
       return value;
     }
 
-    public Boolean isInAppDefaultValue() {
-      return inAppDefaultValue;
+    public Boolean getUseInAppDefault() {
+      return this.useInAppDefault;
+    }
+
+    public boolean isUseInAppDefault() {
+      return Boolean.TRUE.equals(this.useInAppDefault);
     }
 
     public ParameterValueResponse setValue(String value) {
@@ -109,8 +113,8 @@ public final class TemplateResponse {
       return this;
     }
 
-    public ParameterValueResponse setInAppDefaultValue(Boolean inAppDefaultValue) {
-      this.inAppDefaultValue = inAppDefaultValue;
+    public ParameterValueResponse setUseInAppDefault(Boolean useInAppDefault) {
+      this.useInAppDefault = useInAppDefault;
       return this;
     }
   }

--- a/src/main/java/com/google/firebase/remoteconfig/internal/TemplateResponse.java
+++ b/src/main/java/com/google/firebase/remoteconfig/internal/TemplateResponse.java
@@ -16,18 +16,8 @@
 
 package com.google.firebase.remoteconfig.internal;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.api.client.util.Key;
-import com.google.firebase.database.annotations.Nullable;
-import com.google.firebase.internal.NonNull;
-import com.google.firebase.remoteconfig.RemoteConfigParameter;
-import com.google.firebase.remoteconfig.RemoteConfigParameterValue;
-import com.google.firebase.remoteconfig.RemoteConfigTemplate;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -39,21 +29,14 @@ public final class TemplateResponse {
   @Key("parameters")
   private Map<String, ParameterResponse> parameters;
 
-  public TemplateResponse() {
-    parameters = Collections.emptyMap();
+  public Map<String, ParameterResponse> getParameters() {
+    return parameters;
   }
 
-  public TemplateResponse(@NonNull Map<String, ParameterResponse> parameters) {
-    checkNotNull(parameters, "parameters must not be null.");
+  public TemplateResponse setParameters(
+          Map<String, ParameterResponse> parameters) {
     this.parameters = parameters;
-  }
-
-  public RemoteConfigTemplate toRemoteConfigTemplate() {
-    Map<String, RemoteConfigParameter> parameterPublicTypes = new HashMap<>();
-    for (Map.Entry<String, ParameterResponse> entry : parameters.entrySet()) {
-      parameterPublicTypes.put(entry.getKey(), entry.getValue().toRemoteConfigParameter());
-    }
-    return new RemoteConfigTemplate().setParameters(parameterPublicTypes);
+    return this;
   }
 
   /**
@@ -71,30 +54,33 @@ public final class TemplateResponse {
     @Key("conditionalValues")
     private Map<String, ParameterValueResponse> conditionalValues;
 
-    public ParameterResponse() {
-      conditionalValues = Collections.emptyMap();
+    public ParameterValueResponse getDefaultValue() {
+      return defaultValue;
     }
 
-    public ParameterResponse(@Nullable ParameterValueResponse defaultValue,
-                             @Nullable String description,
-                             @NonNull Map<String, ParameterValueResponse> conditionalValues) {
+    public String getDescription() {
+      return description;
+    }
+
+    public Map<String, ParameterValueResponse> getConditionalValues() {
+      return conditionalValues;
+    }
+
+    public ParameterResponse setDefaultValue(
+            ParameterValueResponse defaultValue) {
       this.defaultValue = defaultValue;
-      this.description = description;
-      this.conditionalValues = checkNotNull(conditionalValues);
+      return this;
     }
 
-    public RemoteConfigParameter toRemoteConfigParameter() {
-      Map<String, RemoteConfigParameterValue> conditionalPublicValues = new HashMap<>();
-      for (Map.Entry<String, ParameterValueResponse> entry : conditionalValues.entrySet()) {
-        conditionalPublicValues
-                .put(entry.getKey(), entry.getValue().toRemoteConfigParameterValue());
-      }
-      RemoteConfigParameterValue remoteConfigParameterValue =
-              (defaultValue == null) ? null : defaultValue.toRemoteConfigParameterValue();
-      return new RemoteConfigParameter()
-              .setDefaultValue(remoteConfigParameterValue)
-              .setDescription(description)
-              .setConditionalValues(conditionalPublicValues);
+    public ParameterResponse setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    public ParameterResponse setConditionalValues(
+            Map<String, ParameterValueResponse> conditionalValues) {
+      this.conditionalValues = conditionalValues;
+      return this;
     }
   }
 
@@ -110,27 +96,22 @@ public final class TemplateResponse {
     @Key("useInAppDefault")
     private Boolean inAppDefaultValue;
 
-    public ParameterValueResponse() {
+    public String getValue() {
+      return value;
     }
 
-    private ParameterValueResponse(String value, Boolean inAppDefaultValue) {
+    public Boolean isInAppDefaultValue() {
+      return inAppDefaultValue;
+    }
+
+    public ParameterValueResponse setValue(String value) {
       this.value = value;
+      return this;
+    }
+
+    public ParameterValueResponse setInAppDefaultValue(Boolean inAppDefaultValue) {
       this.inAppDefaultValue = inAppDefaultValue;
-    }
-
-    public static ParameterValueResponse ofValue(String value) {
-      return new ParameterValueResponse(value, null);
-    }
-
-    public static ParameterValueResponse ofInAppDefaultValue() {
-      return new ParameterValueResponse(null, true);
-    }
-
-    public RemoteConfigParameterValue toRemoteConfigParameterValue() {
-      if (this.inAppDefaultValue != null && this.inAppDefaultValue) {
-        return RemoteConfigParameterValue.inAppDefault();
-      }
-      return RemoteConfigParameterValue.of(this.value);
+      return this;
     }
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/internal/TemplateResponse.java
+++ b/src/main/java/com/google/firebase/remoteconfig/internal/TemplateResponse.java
@@ -100,10 +100,6 @@ public final class TemplateResponse {
       return value;
     }
 
-    public Boolean getUseInAppDefault() {
-      return this.useInAppDefault;
-    }
-
     public boolean isUseInAppDefault() {
       return Boolean.TRUE.equals(this.useInAppDefault);
     }
@@ -113,7 +109,7 @@ public final class TemplateResponse {
       return this;
     }
 
-    public ParameterValueResponse setUseInAppDefault(Boolean useInAppDefault) {
+    public ParameterValueResponse setUseInAppDefault(boolean useInAppDefault) {
       this.useInAppDefault = useInAppDefault;
       return this;
     }


### PR DESCRIPTION
- Refactor `public` and `response` types
- Change the `response` DTOs to simple java beans (with getters and setters)
- Add `protected` `ctors` to `public` types to initialize from the corresponding `response` types

Related to: #446 