### PR TITLE
Remove RemoteConfig prefix from classes

### DIFF
--- a/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
+++ b/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfig.java
@@ -73,28 +73,28 @@ public final class FirebaseRemoteConfig {
   /**
    * Gets the current active version of the Remote Config template.
    *
-   * @return A {@link RemoteConfigTemplate}.
+   * @return A {@link Template}.
    * @throws FirebaseRemoteConfigException If an error occurs while getting the template.
    */
-  public RemoteConfigTemplate getTemplate() throws FirebaseRemoteConfigException {
+  public Template getTemplate() throws FirebaseRemoteConfigException {
     return getTemplateOp().call();
   }
 
   /**
    * Similar to {@link #getTemplate()} but performs the operation asynchronously.
    *
-   * @return An {@code ApiFuture} that completes with a {@link RemoteConfigTemplate} when
+   * @return An {@code ApiFuture} that completes with a {@link Template} when
    *      the template is available.
    */
-  public ApiFuture<RemoteConfigTemplate> getTemplateAsync() {
+  public ApiFuture<Template> getTemplateAsync() {
     return getTemplateOp().callAsync(app);
   }
 
-  private CallableOperation<RemoteConfigTemplate, FirebaseRemoteConfigException> getTemplateOp() {
+  private CallableOperation<Template, FirebaseRemoteConfigException> getTemplateOp() {
     final FirebaseRemoteConfigClient remoteConfigClient = getRemoteConfigClient();
-    return new CallableOperation<RemoteConfigTemplate, FirebaseRemoteConfigException>() {
+    return new CallableOperation<Template, FirebaseRemoteConfigException>() {
       @Override
-      protected RemoteConfigTemplate execute() throws FirebaseRemoteConfigException {
+      protected Template execute() throws FirebaseRemoteConfigException {
         return remoteConfigClient.getTemplate();
       }
     };

--- a/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClient.java
+++ b/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClient.java
@@ -24,8 +24,8 @@ interface FirebaseRemoteConfigClient {
   /**
    * Gets the current active version of the Remote Config template.
    *
-   * @return A {@link RemoteConfigTemplate}.
+   * @return A {@link Template}.
    * @throws FirebaseRemoteConfigException If an error occurs while getting the template.
    */
-  RemoteConfigTemplate getTemplate() throws FirebaseRemoteConfigException;
+  Template getTemplate() throws FirebaseRemoteConfigException;
 }

--- a/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImpl.java
+++ b/src/main/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImpl.java
@@ -91,12 +91,12 @@ final class FirebaseRemoteConfigClientImpl implements FirebaseRemoteConfigClient
   }
 
   @Override
-  public RemoteConfigTemplate getTemplate() throws FirebaseRemoteConfigException {
+  public Template getTemplate() throws FirebaseRemoteConfigException {
     HttpRequestInfo request = HttpRequestInfo.buildGetRequest(remoteConfigUrl)
             .addAllHeaders(COMMON_HEADERS);
     IncomingHttpResponse response = httpClient.send(request);
     TemplateResponse templateResponse = httpClient.parse(response, TemplateResponse.class);
-    RemoteConfigTemplate template = new RemoteConfigTemplate(templateResponse);
+    Template template = new Template(templateResponse);
     return template.setETag(getETag(response));
   }
 

--- a/src/main/java/com/google/firebase/remoteconfig/Parameter.java
+++ b/src/main/java/com/google/firebase/remoteconfig/Parameter.java
@@ -27,46 +27,46 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Represents a Remote Config parameter that can be included in a {@link RemoteConfigTemplate}.
+ * Represents a Remote Config parameter that can be included in a {@link Template}.
  * At minimum, a default value or a conditional value must be present for the
  * parameter to have any effect.
  */
-public final class RemoteConfigParameter {
+public final class Parameter {
 
-  private RemoteConfigParameterValue defaultValue;
+  private ParameterValue defaultValue;
   private String description;
-  private Map<String, RemoteConfigParameterValue> conditionalValues;
+  private Map<String, ParameterValue> conditionalValues;
 
   /**
-   * Creates a new {@link RemoteConfigParameter}.
+   * Creates a new {@link Parameter}.
    */
-  public RemoteConfigParameter() {
+  public Parameter() {
     conditionalValues = new HashMap<>();
   }
 
-  RemoteConfigParameter(@NonNull ParameterResponse parameterResponse) {
+  Parameter(@NonNull ParameterResponse parameterResponse) {
     checkNotNull(parameterResponse);
     this.conditionalValues = new HashMap<>();
     if (parameterResponse.getConditionalValues() != null) {
       for (Map.Entry<String, ParameterValueResponse> entry
               : parameterResponse.getConditionalValues().entrySet()) {
         this.conditionalValues.put(entry.getKey(),
-                RemoteConfigParameterValue.fromParameterValueResponse(entry.getValue()));
+                ParameterValue.fromParameterValueResponse(entry.getValue()));
       }
     }
     ParameterValueResponse responseDefaultValue = parameterResponse.getDefaultValue();
     this.defaultValue = (responseDefaultValue == null) ? null
-            : RemoteConfigParameterValue.fromParameterValueResponse(responseDefaultValue);
+            : ParameterValue.fromParameterValueResponse(responseDefaultValue);
     this.description = parameterResponse.getDescription();
   }
 
   /**
    * Gets the default value of the parameter.
    *
-   * @return A {@link RemoteConfigParameterValue} instance or null.
+   * @return A {@link ParameterValue} instance or null.
    */
   @Nullable
-  public RemoteConfigParameterValue getDefaultValue() {
+  public ParameterValue getDefaultValue() {
     return defaultValue;
   }
 
@@ -83,12 +83,12 @@ public final class RemoteConfigParameter {
   /**
    * Gets the conditional values of the parameter.
    * The condition name of the highest priority (the one listed first in the
-   * {@link RemoteConfigTemplate}'s conditions list) determines the value of this parameter.
+   * {@link Template}'s conditions list) determines the value of this parameter.
    *
    * @return A non-null map of conditional values.
    */
   @NonNull
-  public Map<String, RemoteConfigParameterValue> getConditionalValues() {
+  public Map<String, ParameterValue> getConditionalValues() {
     return conditionalValues;
   }
 
@@ -97,10 +97,10 @@ public final class RemoteConfigParameter {
    * This is the value to set the parameter to, when none of the named conditions
    * evaluate to true.
    *
-   * @param value An {@link RemoteConfigParameterValue} instance.
-   * @return This {@link RemoteConfigParameter}.
+   * @param value An {@link ParameterValue} instance.
+   * @return This {@link Parameter}.
    */
-  public RemoteConfigParameter setDefaultValue(@Nullable RemoteConfigParameterValue value) {
+  public Parameter setDefaultValue(@Nullable ParameterValue value) {
     defaultValue = value;
     return this;
   }
@@ -110,9 +110,9 @@ public final class RemoteConfigParameter {
    * Should not be over 100 characters and may contain any Unicode characters.
    *
    * @param description The description of the parameter.
-   * @return This {@link RemoteConfigParameter}.
+   * @return This {@link Parameter}.
    */
-  public RemoteConfigParameter setDescription(@Nullable String description) {
+  public Parameter setDescription(@Nullable String description) {
     this.description = description;
     return this;
   }
@@ -120,13 +120,13 @@ public final class RemoteConfigParameter {
   /**
    * Sets the conditional values of the parameter.
    * The condition name of the highest priority (the one listed first in the
-   * {@link RemoteConfigTemplate}'s conditions list) determines the value of this parameter.
+   * {@link Template}'s conditions list) determines the value of this parameter.
    *
    * @param conditionalValues A non-null map of conditional values.
-   * @return This {@link RemoteConfigParameter}.
+   * @return This {@link Parameter}.
    */
-  public RemoteConfigParameter setConditionalValues(
-          @NonNull Map<String, RemoteConfigParameterValue> conditionalValues) {
+  public Parameter setConditionalValues(
+          @NonNull Map<String, ParameterValue> conditionalValues) {
     checkNotNull(conditionalValues, "conditional values must not be null.");
     this.conditionalValues = conditionalValues;
     return this;
@@ -134,7 +134,7 @@ public final class RemoteConfigParameter {
 
   ParameterResponse toParameterResponse() {
     Map<String, ParameterValueResponse> conditionalResponseValues = new HashMap<>();
-    for (Map.Entry<String, RemoteConfigParameterValue> entry : conditionalValues.entrySet()) {
+    for (Map.Entry<String, ParameterValue> entry : conditionalValues.entrySet()) {
       conditionalResponseValues.put(entry.getKey(), entry.getValue().toParameterValueResponse());
     }
     ParameterValueResponse defaultValueResponse = (defaultValue == null) ? null

--- a/src/main/java/com/google/firebase/remoteconfig/ParameterValue.java
+++ b/src/main/java/com/google/firebase/remoteconfig/ParameterValue.java
@@ -22,24 +22,24 @@ import com.google.firebase.internal.NonNull;
 import com.google.firebase.remoteconfig.internal.TemplateResponse.ParameterValueResponse;
 
 /**
- * Represents a Remote Config parameter value that can be used in a {@link RemoteConfigTemplate}.
+ * Represents a Remote Config parameter value that can be used in a {@link Template}.
  */
-public abstract class RemoteConfigParameterValue {
+public abstract class ParameterValue {
 
   /**
-   * Creates a new {@link RemoteConfigParameterValue.Explicit} instance with the given value.
+   * Creates a new {@link ParameterValue.Explicit} instance with the given value.
    *
-   * @param value The value of the {@link RemoteConfigParameterValue.Explicit}.
-   * @return A {@link RemoteConfigParameterValue.Explicit} instance.
+   * @param value The value of the {@link ParameterValue.Explicit}.
+   * @return A {@link ParameterValue.Explicit} instance.
    */
   public static Explicit of(String value) {
     return new Explicit(value);
   }
 
   /**
-   * Creates a new {@link RemoteConfigParameterValue.InAppDefault} instance.
+   * Creates a new {@link ParameterValue.InAppDefault} instance.
    *
-   * @return A {@link RemoteConfigParameterValue.InAppDefault} instance.
+   * @return A {@link ParameterValue.InAppDefault} instance.
    */
   public static InAppDefault inAppDefault() {
     return new InAppDefault();
@@ -47,20 +47,20 @@ public abstract class RemoteConfigParameterValue {
 
   abstract ParameterValueResponse toParameterValueResponse();
 
-  static RemoteConfigParameterValue fromParameterValueResponse(
+  static ParameterValue fromParameterValueResponse(
           @NonNull ParameterValueResponse parameterValueResponse) {
     checkNotNull(parameterValueResponse);
     if (parameterValueResponse.isUseInAppDefault()) {
-      return RemoteConfigParameterValue.inAppDefault();
+      return ParameterValue.inAppDefault();
     }
-    return RemoteConfigParameterValue.of(parameterValueResponse.getValue());
+    return ParameterValue.of(parameterValueResponse.getValue());
   }
 
   /**
    * Represents an explicit Remote Config parameter value with a {@link String} value that the
    * parameter is set to.
    */
-  public static final class Explicit extends RemoteConfigParameterValue {
+  public static final class Explicit extends ParameterValue {
 
     private final String value;
 
@@ -69,7 +69,7 @@ public abstract class RemoteConfigParameterValue {
     }
 
     /**
-     * Gets the value of {@link RemoteConfigParameterValue.Explicit}.
+     * Gets the value of {@link ParameterValue.Explicit}.
      *
      * @return The {@link String} value.
      */
@@ -87,7 +87,7 @@ public abstract class RemoteConfigParameterValue {
   /**
    * Represents an in app default parameter value.
    */
-  public static final class InAppDefault extends RemoteConfigParameterValue {
+  public static final class InAppDefault extends ParameterValue {
 
     @Override
     ParameterValueResponse toParameterValueResponse() {

--- a/src/main/java/com/google/firebase/remoteconfig/Template.java
+++ b/src/main/java/com/google/firebase/remoteconfig/Template.java
@@ -27,25 +27,25 @@ import java.util.Map;
 /**
  * Represents a Remote Config template.
  */
-public final class RemoteConfigTemplate {
+public final class Template {
 
   private String etag;
-  private Map<String, RemoteConfigParameter> parameters;
+  private Map<String, Parameter> parameters;
 
   /**
-   * Creates a new {@link RemoteConfigTemplate}.
+   * Creates a new {@link Template}.
    */
-  public RemoteConfigTemplate() {
+  public Template() {
     parameters = new HashMap<>();
   }
 
-  RemoteConfigTemplate(@NonNull TemplateResponse templateResponse) {
+  Template(@NonNull TemplateResponse templateResponse) {
     checkNotNull(templateResponse);
     this.parameters = new HashMap<>();
     if (templateResponse.getParameters() != null) {
       for (Map.Entry<String, TemplateResponse.ParameterResponse> entry
               : templateResponse.getParameters().entrySet()) {
-        this.parameters.put(entry.getKey(), new RemoteConfigParameter(entry.getValue()));
+        this.parameters.put(entry.getKey(), new Parameter(entry.getValue()));
       }
     }
   }
@@ -66,7 +66,7 @@ public final class RemoteConfigTemplate {
    *     conditional values.
    */
   @NonNull
-  public Map<String, RemoteConfigParameter> getParameters() {
+  public Map<String, Parameter> getParameters() {
     return this.parameters;
   }
 
@@ -75,23 +75,23 @@ public final class RemoteConfigTemplate {
    *
    * @param parameters A non-null map of parameter keys to their optional default values and
    *                   optional conditional values.
-   * @return This {@link RemoteConfigTemplate} instance.
+   * @return This {@link Template} instance.
    */
-  public RemoteConfigTemplate setParameters(
-          @NonNull Map<String, RemoteConfigParameter> parameters) {
+  public Template setParameters(
+          @NonNull Map<String, Parameter> parameters) {
     checkNotNull(parameters, "parameters must not be null.");
     this.parameters = parameters;
     return this;
   }
 
-  RemoteConfigTemplate setETag(String etag) {
+  Template setETag(String etag) {
     this.etag = etag;
     return this;
   }
 
   TemplateResponse toTemplateResponse() {
     Map<String, TemplateResponse.ParameterResponse> parameterResponses = new HashMap<>();
-    for (Map.Entry<String, RemoteConfigParameter> entry : parameters.entrySet()) {
+    for (Map.Entry<String, Parameter> entry : parameters.entrySet()) {
       parameterResponses.put(entry.getKey(), entry.getValue().toParameterResponse());
     }
     return new TemplateResponse().setParameters(parameterResponses);

--- a/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImplTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImplTest.java
@@ -84,28 +84,28 @@ public class FirebaseRemoteConfigClientImplTest {
     response.addHeader("etag", TEST_ETAG);
     response.setContent(MOCK_TEMPLATE_RESPONSE);
 
-    RemoteConfigTemplate template = client.getTemplate();
+    Template template = client.getTemplate();
 
     assertEquals(TEST_ETAG, template.getETag());
-    Map<String, RemoteConfigParameter> parameters = template.getParameters();
+    Map<String, Parameter> parameters = template.getParameters();
     assertEquals(2, parameters.size());
     assertTrue(parameters.containsKey("welcome_message_text"));
-    RemoteConfigParameter welcomeMessageParameter = parameters.get("welcome_message_text");
+    Parameter welcomeMessageParameter = parameters.get("welcome_message_text");
     assertEquals("text for welcome message!", welcomeMessageParameter.getDescription());
-    RemoteConfigParameterValue.Explicit explicitDefaultValue =
-            (RemoteConfigParameterValue.Explicit) welcomeMessageParameter.getDefaultValue();
+    ParameterValue.Explicit explicitDefaultValue =
+            (ParameterValue.Explicit) welcomeMessageParameter.getDefaultValue();
     assertEquals("welcome to app", explicitDefaultValue.getValue());
-    Map<String, RemoteConfigParameterValue> conditionalValues = welcomeMessageParameter
+    Map<String, ParameterValue> conditionalValues = welcomeMessageParameter
             .getConditionalValues();
     assertEquals(1, conditionalValues.size());
     assertTrue(conditionalValues.containsKey("ios_en"));
-    RemoteConfigParameterValue.Explicit value =
-            (RemoteConfigParameterValue.Explicit) conditionalValues.get("ios_en");
+    ParameterValue.Explicit value =
+            (ParameterValue.Explicit) conditionalValues.get("ios_en");
     assertEquals("welcome to app en", value.getValue());
     assertTrue(parameters.containsKey("header_text"));
-    RemoteConfigParameter headerParameter = parameters.get("header_text");
+    Parameter headerParameter = parameters.get("header_text");
     assertTrue(
-            headerParameter.getDefaultValue() instanceof RemoteConfigParameterValue.InAppDefault);
+            headerParameter.getDefaultValue() instanceof ParameterValue.InAppDefault);
     checkGetRequestHeader(interceptor.getLastRequest());
   }
 
@@ -114,7 +114,7 @@ public class FirebaseRemoteConfigClientImplTest {
     response.addHeader("etag", TEST_ETAG);
     response.setContent("{}");
 
-    RemoteConfigTemplate template = client.getTemplate();
+    Template template = client.getTemplate();
 
     assertEquals(TEST_ETAG, template.getETag());
     assertEquals(0, template.getParameters().size());

--- a/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigTest.java
@@ -116,10 +116,10 @@ public class FirebaseRemoteConfigTest {
   @Test
   public void testGetTemplate() throws FirebaseRemoteConfigException {
     MockRemoteConfigClient client = MockRemoteConfigClient.fromTemplate(
-            new RemoteConfigTemplate().setETag(TEST_ETAG));
+            new Template().setETag(TEST_ETAG));
     FirebaseRemoteConfig remoteConfig = getRemoteConfig(client);
 
-    RemoteConfigTemplate template = remoteConfig.getTemplate();
+    Template template = remoteConfig.getTemplate();
 
     assertEquals(TEST_ETAG, template.getETag());
   }
@@ -139,10 +139,10 @@ public class FirebaseRemoteConfigTest {
   @Test
   public void testGetTemplateAsync() throws Exception {
     MockRemoteConfigClient client = MockRemoteConfigClient.fromTemplate(
-            new RemoteConfigTemplate().setETag(TEST_ETAG));
+            new Template().setETag(TEST_ETAG));
     FirebaseRemoteConfig remoteConfig = getRemoteConfig(client);
 
-    RemoteConfigTemplate template = remoteConfig.getTemplateAsync().get();
+    Template template = remoteConfig.getTemplateAsync().get();
 
     assertEquals(TEST_ETAG, template.getETag());
   }

--- a/src/test/java/com/google/firebase/remoteconfig/MockRemoteConfigClient.java
+++ b/src/test/java/com/google/firebase/remoteconfig/MockRemoteConfigClient.java
@@ -18,16 +18,16 @@ package com.google.firebase.remoteconfig;
 
 public class MockRemoteConfigClient implements FirebaseRemoteConfigClient{
 
-  private RemoteConfigTemplate resultTemplate;
+  private Template resultTemplate;
   private FirebaseRemoteConfigException exception;
 
-  private MockRemoteConfigClient(RemoteConfigTemplate resultTemplate,
+  private MockRemoteConfigClient(Template resultTemplate,
                                  FirebaseRemoteConfigException exception) {
     this.resultTemplate = resultTemplate;
     this.exception = exception;
   }
 
-  static MockRemoteConfigClient fromTemplate(RemoteConfigTemplate resultTemplate) {
+  static MockRemoteConfigClient fromTemplate(Template resultTemplate) {
     return new MockRemoteConfigClient(resultTemplate, null);
   }
 
@@ -36,7 +36,7 @@ public class MockRemoteConfigClient implements FirebaseRemoteConfigClient{
   }
 
   @Override
-  public RemoteConfigTemplate getTemplate() throws FirebaseRemoteConfigException {
+  public Template getTemplate() throws FirebaseRemoteConfigException {
     if (exception != null) {
       throw exception;
     }


### PR DESCRIPTION
- Based on the API review decision (go/admin-java-sdk-remote-config), Remove `RemoteConfig` prefix from classes

Related to: #446 