### PR TITLE
Fix comment about max number of events

### DIFF
--- a/src/test/java/com/google/firebase/snippets/FirebaseMessagingSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseMessagingSnippets.java
@@ -151,7 +151,7 @@ public class FirebaseMessagingSnippets {
 
   public void sendMulticast() throws FirebaseMessagingException {
     // [START send_multicast]
-    // Create a list containing up to 100 registration tokens.
+    // Create a list containing up to 500 registration tokens.
     // These registration tokens come from the client FCM SDKs.
     List<String> registrationTokens = Arrays.asList(
         "YOUR_REGISTRATION_TOKEN_1",


### PR DESCRIPTION
Multicast message can send up to 500 messages, not 100

https://github.com/firebase/firebase-admin-java/blob/408b85f7d0072e8fb3b462aa2317843d683e7ad7/src/main/java/com/google/firebase/messaging/MulticastMessage.java#L46

