### PR TITLE
Add Remote Config Parameter Group type

### DIFF
--- a/src/main/java/com/google/firebase/remoteconfig/Parameter.java
+++ b/src/main/java/com/google/firebase/remoteconfig/Parameter.java
@@ -25,6 +25,7 @@ import com.google.firebase.remoteconfig.internal.TemplateResponse.ParameterValue
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a Remote Config parameter that can be included in a {@link Template}.
@@ -73,7 +74,7 @@ public final class Parameter {
   /**
    * Gets the description of the parameter.
    *
-   * @return The {@link String} description of the parameter or null.
+   * @return The description of the parameter or null.
    */
   @Nullable
   public String getDescription() {
@@ -143,5 +144,24 @@ public final class Parameter {
             .setDefaultValue(defaultValueResponse)
             .setDescription(description)
             .setConditionalValues(conditionalResponseValues);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Parameter parameter = (Parameter) o;
+    return Objects.equals(defaultValue, parameter.defaultValue)
+            && Objects.equals(description, parameter.description)
+            && Objects.equals(conditionalValues, parameter.conditionalValues);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(defaultValue, description, conditionalValues);
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/ParameterGroup.java
+++ b/src/main/java/com/google/firebase/remoteconfig/ParameterGroup.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.remoteconfig;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.firebase.internal.NonNull;
+import com.google.firebase.internal.Nullable;
+import com.google.firebase.remoteconfig.internal.TemplateResponse;
+import com.google.firebase.remoteconfig.internal.TemplateResponse.ParameterGroupResponse;
+import com.google.firebase.remoteconfig.internal.TemplateResponse.ParameterResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a Remote Config parameter group that can be included in a {@link Template}.
+ * Grouping parameters is only for management purposes and does not affect client-side
+ * fetching of parameter values.
+ */
+public final class ParameterGroup {
+
+  private String description;
+  private Map<String, Parameter> parameters;
+
+  /**
+   * Creates a new {@link ParameterGroup}.
+   */
+  public ParameterGroup() {
+    parameters = new HashMap<>();
+  }
+
+  ParameterGroup(@NonNull ParameterGroupResponse parameterGroupResponse) {
+    checkNotNull(parameterGroupResponse);
+    this.parameters = new HashMap<>();
+    if (parameterGroupResponse.getParameters() != null) {
+      for (Map.Entry<String, TemplateResponse.ParameterResponse> entry
+              : parameterGroupResponse.getParameters().entrySet()) {
+        this.parameters.put(entry.getKey(), new Parameter(entry.getValue()));
+      }
+    }
+    this.description = parameterGroupResponse.getDescription();
+  }
+
+  /**
+   * Gets the description of the parameter group.
+   *
+   * @return The description of the parameter or null.
+   */
+  @Nullable
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Gets the map of parameters that belong to this group.
+   *
+   * @return A non-null map of parameter keys to their optional default values and optional
+   *     conditional values.
+   */
+  @NonNull
+  public Map<String, Parameter> getParameters() {
+    return parameters;
+  }
+
+  /**
+   * Sets the description of the parameter group.
+   * Should not be over 256 characters and may contain any Unicode characters.
+   *
+   * @param description The description of the parameter group.
+   * @return This {@link ParameterGroup}.
+   */
+  public ParameterGroup setDescription(@Nullable String description) {
+    this.description = description;
+    return this;
+  }
+
+  /**
+   * Sets the map of parameters that belong to this group.
+   *
+   * <p>A parameter only appears once per Remote Config template.
+   * An ungrouped parameter appears at the top level, whereas a
+   * parameter organized within a group appears within its group's map of parameters.
+   *
+   * @param parameters A non-null map of parameter keys to their optional default values and
+   *                   optional conditional values.
+   * @return This {@link ParameterGroup} instance.
+   */
+  public ParameterGroup setParameters(
+          @NonNull Map<String, Parameter> parameters) {
+    checkNotNull(parameters, "parameters must not be null.");
+    this.parameters = parameters;
+    return this;
+  }
+
+  ParameterGroupResponse toParameterGroupResponse() {
+    Map<String, ParameterResponse> parameterResponses = new HashMap<>();
+    for (Map.Entry<String, Parameter> entry : this.parameters.entrySet()) {
+      parameterResponses.put(entry.getKey(), entry.getValue().toParameterResponse());
+    }
+    return new ParameterGroupResponse()
+            .setDescription(this.description)
+            .setParameters(parameterResponses);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ParameterGroup that = (ParameterGroup) o;
+    return Objects.equals(description, that.description)
+            && Objects.equals(parameters, that.parameters);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(description, parameters);
+  }
+}

--- a/src/main/java/com/google/firebase/remoteconfig/ParameterValue.java
+++ b/src/main/java/com/google/firebase/remoteconfig/ParameterValue.java
@@ -21,6 +21,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.firebase.internal.NonNull;
 import com.google.firebase.remoteconfig.internal.TemplateResponse.ParameterValueResponse;
 
+import java.util.Objects;
+
 /**
  * Represents a Remote Config parameter value that can be used in a {@link Template}.
  */
@@ -57,7 +59,7 @@ public abstract class ParameterValue {
   }
 
   /**
-   * Represents an explicit Remote Config parameter value with a {@link String} value that the
+   * Represents an explicit Remote Config parameter value with a value that the
    * parameter is set to.
    */
   public static final class Explicit extends ParameterValue {
@@ -71,7 +73,7 @@ public abstract class ParameterValue {
     /**
      * Gets the value of {@link ParameterValue.Explicit}.
      *
-     * @return The {@link String} value.
+     * @return The value.
      */
     public String getValue() {
       return this.value;
@@ -81,6 +83,23 @@ public abstract class ParameterValue {
     ParameterValueResponse toParameterValueResponse() {
       return new ParameterValueResponse()
               .setValue(this.value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Explicit explicit = (Explicit) o;
+      return Objects.equals(value, explicit.value);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value);
     }
   }
 
@@ -92,6 +111,17 @@ public abstract class ParameterValue {
     @Override
     ParameterValueResponse toParameterValueResponse() {
       return new ParameterValueResponse().setUseInAppDefault(true);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      return true;
     }
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/Template.java
+++ b/src/main/java/com/google/firebase/remoteconfig/Template.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a Remote Config template.
@@ -145,7 +146,8 @@ public final class Template {
    * @return This {@link Template} instance.
    */
   public Template setParameterGroups(
-          Map<String, ParameterGroup> parameterGroups) {
+          @NonNull Map<String, ParameterGroup> parameterGroups) {
+    checkNotNull(parameterGroups, "parameter groups must not be null.");
     this.parameterGroups = parameterGroups;
     return this;
   }
@@ -172,5 +174,20 @@ public final class Template {
             .setParameters(parameterResponses)
             .setConditions(conditionResponses)
             .setParameterGroups(parameterGroupResponse);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Template template = (Template) o;
+    return Objects.equals(etag, template.etag)
+            && Objects.equals(parameters, template.parameters)
+            && Objects.equals(conditions, template.conditions)
+            && Objects.equals(parameterGroups, template.parameterGroups);
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/Template.java
+++ b/src/main/java/com/google/firebase/remoteconfig/Template.java
@@ -34,6 +34,7 @@ public final class Template {
   private String etag;
   private Map<String, Parameter> parameters;
   private List<Condition> conditions;
+  private Map<String, ParameterGroup> parameterGroups;
 
   /**
    * Creates a new {@link Template}.
@@ -41,12 +42,14 @@ public final class Template {
   public Template() {
     parameters = new HashMap<>();
     conditions = new ArrayList<>();
+    parameterGroups = new HashMap<>();
   }
 
   Template(@NonNull TemplateResponse templateResponse) {
     checkNotNull(templateResponse);
     this.parameters = new HashMap<>();
     this.conditions = new ArrayList<>();
+    this.parameterGroups = new HashMap<>();
     if (templateResponse.getParameters() != null) {
       for (Map.Entry<String, TemplateResponse.ParameterResponse> entry
               : templateResponse.getParameters().entrySet()) {
@@ -57,6 +60,12 @@ public final class Template {
       for (TemplateResponse.ConditionResponse conditionResponse
               : templateResponse.getConditions()) {
         this.conditions.add(new Condition(conditionResponse));
+      }
+    }
+    if (templateResponse.getParameterGroups() != null) {
+      for (Map.Entry<String, TemplateResponse.ParameterGroupResponse> entry
+              : templateResponse.getParameterGroups().entrySet()) {
+        this.parameterGroups.put(entry.getKey(), new ParameterGroup(entry.getValue()));
       }
     }
   }
@@ -84,11 +93,21 @@ public final class Template {
   /**
    * Gets the list of conditions of the template.
    *
-   * @return A non-null list of conditions
+   * @return A non-null list of conditions.
    */
   @NonNull
   public List<Condition> getConditions() {
     return conditions;
+  }
+
+  /**
+   * Gets the map of parameter groups of the template.
+   *
+   * @return A non-null map of parameter group names to their parameter group instances.
+   */
+  @NonNull
+  public Map<String, ParameterGroup> getParameterGroups() {
+    return parameterGroups;
   }
 
   /**
@@ -118,6 +137,19 @@ public final class Template {
     return this;
   }
 
+  /**
+   * Sets the map of parameter groups of the template.
+   *
+   * @param parameterGroups A non-null map of parameter group names to their
+   *                        parameter group instances.
+   * @return This {@link Template} instance.
+   */
+  public Template setParameterGroups(
+          Map<String, ParameterGroup> parameterGroups) {
+    this.parameterGroups = parameterGroups;
+    return this;
+  }
+
   Template setETag(String etag) {
     this.etag = etag;
     return this;
@@ -132,8 +164,13 @@ public final class Template {
     for (Condition condition : this.conditions) {
       conditionResponses.add(condition.toConditionResponse());
     }
+    Map<String, TemplateResponse.ParameterGroupResponse> parameterGroupResponse = new HashMap<>();
+    for (Map.Entry<String, ParameterGroup> entry : this.parameterGroups.entrySet()) {
+      parameterGroupResponse.put(entry.getKey(), entry.getValue().toParameterGroupResponse());
+    }
     return new TemplateResponse()
             .setParameters(parameterResponses)
-            .setConditions(conditionResponses);
+            .setConditions(conditionResponses)
+            .setParameterGroups(parameterGroupResponse);
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/Template.java
+++ b/src/main/java/com/google/firebase/remoteconfig/Template.java
@@ -190,4 +190,9 @@ public final class Template {
             && Objects.equals(conditions, template.conditions)
             && Objects.equals(parameterGroups, template.parameterGroups);
   }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(etag, parameters, conditions, parameterGroups);
+  }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/internal/TemplateResponse.java
+++ b/src/main/java/com/google/firebase/remoteconfig/internal/TemplateResponse.java
@@ -33,12 +33,19 @@ public final class TemplateResponse {
   @Key("conditions")
   private List<ConditionResponse> conditions;
 
+  @Key("parameterGroups")
+  private Map<String, ParameterGroupResponse> parameterGroups;
+
   public Map<String, ParameterResponse> getParameters() {
     return parameters;
   }
 
   public List<ConditionResponse> getConditions() {
     return conditions;
+  }
+
+  public Map<String, ParameterGroupResponse> getParameterGroups() {
+    return parameterGroups;
   }
 
   public TemplateResponse setParameters(
@@ -50,6 +57,12 @@ public final class TemplateResponse {
   public TemplateResponse setConditions(
           List<ConditionResponse> conditions) {
     this.conditions = conditions;
+    return this;
+  }
+
+  public TemplateResponse setParameterGroups(
+          Map<String, ParameterGroupResponse> parameterGroups) {
+    this.parameterGroups = parameterGroups;
     return this;
   }
 
@@ -168,6 +181,38 @@ public final class TemplateResponse {
 
     public ConditionResponse setTagColor(String tagColor) {
       this.tagColor = tagColor;
+      return this;
+    }
+  }
+
+  /**
+   * The Data Transfer Object for parsing Remote Config parameter groups responses from the
+   * Remote Config service.
+   **/
+  public static final class ParameterGroupResponse {
+
+    @Key("description")
+    private String description;
+
+    @Key("parameters")
+    private Map<String, ParameterResponse> parameters;
+
+    public Map<String, ParameterResponse> getParameters() {
+      return parameters;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public ParameterGroupResponse setParameters(
+            Map<String, ParameterResponse> parameters) {
+      this.parameters = parameters;
+      return this;
+    }
+
+    public ParameterGroupResponse setDescription(String description) {
+      this.description = description;
       return this;
     }
   }

--- a/src/test/java/com/google/firebase/remoteconfig/ConditionTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ConditionTest.java
@@ -26,27 +26,30 @@ public class ConditionTest {
 
   @Test
   public void testConstructor() {
-    Condition c1 = new Condition("ios_en_1", "expression1");
+    Condition c = new Condition("ios_en_1", "expression1");
 
-    assertEquals("ios_en_1", c1.getName());
-    assertEquals("expression1", c1.getExpression());
-    assertNull(c1.getTagColor());
+    assertEquals("ios_en_1", c.getName());
+    assertEquals("expression1", c.getExpression());
+    assertNull(c.getTagColor());
+  }
 
-    Condition c2 = new Condition("ios_en_2", "expression2", TagColor.BLUE);
+  @Test
+  public void testConstructorWithColor() {
+    Condition c = new Condition("ios_en_2", "expression2", TagColor.BLUE);
 
-    assertEquals("ios_en_2", c2.getName());
-    assertEquals("expression2", c2.getExpression());
-    assertEquals(TagColor.BLUE, c2.getTagColor());
+    assertEquals("ios_en_2", c.getName());
+    assertEquals("expression2", c.getExpression());
+    assertEquals(TagColor.BLUE, c.getTagColor());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testIllegalConstructor() {
-    Condition c = new Condition(null, null);
+    new Condition(null, null);
   }
 
   @Test(expected = NullPointerException.class)
   public void testConstructorWithNullConditionResponse() {
-    Condition c = new Condition(null);
+    new Condition(null);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/com/google/firebase/remoteconfig/ConditionTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ConditionTest.java
@@ -18,10 +18,58 @@ package com.google.firebase.remoteconfig;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
 public class ConditionTest {
+
+  @Test
+  public void testConstructor() {
+    Condition c1 = new Condition("ios_en_1", "expression1");
+    assertEquals("ios_en_1", c1.getName());
+    assertEquals("expression1", c1.getExpression());
+    assertNull(c1.getTagColor());
+
+    Condition c2 = new Condition("ios_en_2", "expression2", TagColor.BLUE);
+    assertEquals("ios_en_2", c2.getName());
+    assertEquals("expression2", c2.getExpression());
+    assertEquals(TagColor.BLUE, c2.getTagColor());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testIllegalConstructor() {
+    Condition c = new Condition(null, null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testConstructorWithNullConditionResponse() {
+    Condition c = new Condition(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSetNullName() {
+    Condition c = new Condition("ios", "exp");
+    c.setName(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSetEmptyName() {
+    Condition c = new Condition("ios", "exp");
+    c.setName("");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSetNullExpression() {
+    Condition c = new Condition("ios", "exp");
+    c.setExpression(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSetEmptyExpression() {
+    Condition c = new Condition("ios", "exp");
+    c.setExpression("");
+  }
 
   @Test
   public void testEquality() {

--- a/src/test/java/com/google/firebase/remoteconfig/ConditionTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ConditionTest.java
@@ -27,11 +27,13 @@ public class ConditionTest {
   @Test
   public void testConstructor() {
     Condition c1 = new Condition("ios_en_1", "expression1");
+
     assertEquals("ios_en_1", c1.getName());
     assertEquals("expression1", c1.getExpression());
     assertNull(c1.getTagColor());
 
     Condition c2 = new Condition("ios_en_2", "expression2", TagColor.BLUE);
+
     assertEquals("ios_en_2", c2.getName());
     assertEquals("expression2", c2.getExpression());
     assertEquals(TagColor.BLUE, c2.getTagColor());

--- a/src/test/java/com/google/firebase/remoteconfig/ConditionTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ConditionTest.java
@@ -26,20 +26,20 @@ public class ConditionTest {
 
   @Test
   public void testConstructor() {
-    Condition c = new Condition("ios_en_1", "expression1");
+    Condition condition = new Condition("ios_en_1", "expression1");
 
-    assertEquals("ios_en_1", c.getName());
-    assertEquals("expression1", c.getExpression());
-    assertNull(c.getTagColor());
+    assertEquals("ios_en_1", condition.getName());
+    assertEquals("expression1", condition.getExpression());
+    assertNull(condition.getTagColor());
   }
 
   @Test
   public void testConstructorWithColor() {
-    Condition c = new Condition("ios_en_2", "expression2", TagColor.BLUE);
+    Condition condition = new Condition("ios_en_2", "expression2", TagColor.BLUE);
 
-    assertEquals("ios_en_2", c.getName());
-    assertEquals("expression2", c.getExpression());
-    assertEquals(TagColor.BLUE, c.getTagColor());
+    assertEquals("ios_en_2", condition.getName());
+    assertEquals("expression2", condition.getExpression());
+    assertEquals(TagColor.BLUE, condition.getTagColor());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -54,26 +54,26 @@ public class ConditionTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testSetNullName() {
-    Condition c = new Condition("ios", "exp");
-    c.setName(null);
+    Condition condition = new Condition("ios", "exp");
+    condition.setName(null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testSetEmptyName() {
-    Condition c = new Condition("ios", "exp");
-    c.setName("");
+    Condition condition = new Condition("ios", "exp");
+    condition.setName("");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testSetNullExpression() {
-    Condition c = new Condition("ios", "exp");
-    c.setExpression(null);
+    Condition condition = new Condition("ios", "exp");
+    condition.setExpression(null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testSetEmptyExpression() {
-    Condition c = new Condition("ios", "exp");
-    c.setExpression("");
+    Condition condition = new Condition("ios", "exp");
+    condition.setExpression("");
   }
 
   @Test

--- a/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImplTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImplTest.java
@@ -45,7 +45,6 @@ import com.google.firebase.testing.TestResponseInterceptor;
 import com.google.firebase.testing.TestUtils;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImplTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImplTest.java
@@ -45,6 +45,7 @@ import com.google.firebase.testing.TestResponseInterceptor;
 import com.google.firebase.testing.TestUtils;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -122,6 +123,22 @@ public class FirebaseRemoteConfigClientImplTest {
     for (int i = 0; i < expectedConditions.size(); i++) {
       assertEquals(expectedConditions.get(i), actualConditions.get(i));
     }
+
+    // Check Parameter Groups
+    Map<String, ParameterGroup> parameterGroups = template.getParameterGroups();
+    assertEquals(1, parameterGroups.size());
+
+    Map<String, ParameterValue> cv = new HashMap<>();
+    cv.put("ios_en", ParameterValue.of("welcome to app en"));
+
+    Parameter p = new Parameter()
+            .setDefaultValue(ParameterValue.of("welcome to app"))
+            .setConditionalValues(cv)
+            .setDescription("text for welcome message!");
+    Parameter p1 = new Parameter()
+            .setDefaultValue(ParameterValue.inAppDefault());
+    assertEquals(p, welcomeMessageParameter);
+    assertEquals(p1, headerParameter);
   }
 
   @Test

--- a/src/test/java/com/google/firebase/remoteconfig/ParameterGroupTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ParameterGroupTest.java
@@ -32,11 +32,11 @@ public class ParameterGroupTest {
 
   @Test
   public void testConstructor() {
-    final ParameterGroup pg = new ParameterGroup();
+    final ParameterGroup parameterGroup = new ParameterGroup();
 
-    assertNotNull(pg.getParameters());
-    assertTrue(pg.getParameters().isEmpty());
-    assertNull(pg.getDescription());
+    assertNotNull(parameterGroup.getParameters());
+    assertTrue(parameterGroup.getParameters().isEmpty());
+    assertNull(parameterGroup.getDescription());
   }
 
   @Test(expected = NullPointerException.class)
@@ -46,23 +46,23 @@ public class ParameterGroupTest {
 
   @Test(expected = NullPointerException.class)
   public void testSetNullParameters() {
-    ParameterGroup pg = new ParameterGroup();
-    pg.setParameters(null);
+    ParameterGroup parameterGroup = new ParameterGroup();
+    parameterGroup.setParameters(null);
   }
 
   @Test
   public void testEquality() {
-    final ParameterGroup p1 = new ParameterGroup();
-    final ParameterGroup p2 = new ParameterGroup();
+    final ParameterGroup parameterGroupOne = new ParameterGroup();
+    final ParameterGroup parameterGroupTwo = new ParameterGroup();
 
-    assertEquals(p1, p2);
+    assertEquals(parameterGroupOne, parameterGroupTwo);
 
-    final ParameterGroup p3 = new ParameterGroup()
+    final ParameterGroup parameterGroupThree = new ParameterGroup()
             .setDescription("description");
-    final ParameterGroup p4 = new ParameterGroup()
+    final ParameterGroup parameterGroupFour = new ParameterGroup()
             .setDescription("description");
 
-    assertEquals(p3, p4);
+    assertEquals(parameterGroupThree, parameterGroupFour);
 
     final Map<String, Parameter> parameters = ImmutableMap.of(
             "header_text", new Parameter().setDefaultValue(ParameterValue.of("Welcome")),
@@ -72,16 +72,16 @@ public class ParameterGroupTest {
                             "ios", ParameterValue.of("ios header text")
                     ))
     );
-    final ParameterGroup p5 = new ParameterGroup()
+    final ParameterGroup parameterGroupFive = new ParameterGroup()
             .setDescription("description")
             .setParameters(parameters);
-    final ParameterGroup p6 = new ParameterGroup()
+    final ParameterGroup parameterGroupSix = new ParameterGroup()
             .setDescription("description")
             .setParameters(parameters);
 
-    assertEquals(p5, p6);
-    assertNotEquals(p1, p3);
-    assertNotEquals(p1, p5);
-    assertNotEquals(p3, p5);
+    assertEquals(parameterGroupFive, parameterGroupSix);
+    assertNotEquals(parameterGroupOne, parameterGroupThree);
+    assertNotEquals(parameterGroupOne, parameterGroupFive);
+    assertNotEquals(parameterGroupThree, parameterGroupFive);
   }
 }

--- a/src/test/java/com/google/firebase/remoteconfig/ParameterGroupTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ParameterGroupTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.remoteconfig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+public class ParameterGroupTest {
+
+  @Test
+  public void testConstructor() {
+    final ParameterGroup pg = new ParameterGroup();
+    assertNotNull(pg.getParameters());
+    assertEquals(0, pg.getParameters().size());
+    assertNull(pg.getDescription());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testConstructorWithNullParameterGroupResponse() {
+    ParameterGroup pg = new ParameterGroup(null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testSetNullParameters() {
+    ParameterGroup pg = new ParameterGroup();
+    pg.setParameters(null);
+  }
+
+  @Test
+  public void testEquality() {
+    final ParameterGroup p1 = new ParameterGroup();
+    final ParameterGroup p2 = new ParameterGroup();
+    assertEquals(p1, p2);
+
+    final ParameterGroup p3 = new ParameterGroup()
+            .setDescription("description");
+    final ParameterGroup p4 = new ParameterGroup()
+            .setDescription("description");
+    assertEquals(p3, p4);
+
+    final Map<String, Parameter> parameters = ImmutableMap.of(
+            "header_text", new Parameter().setDefaultValue(ParameterValue.of("Welcome")),
+            "promo", new Parameter()
+                    .setDefaultValue(ParameterValue.inAppDefault())
+                    .setConditionalValues(ImmutableMap.<String, ParameterValue>of(
+                            "ios", ParameterValue.of("ios header text")
+                    ))
+    );
+    final ParameterGroup p5 = new ParameterGroup()
+            .setDescription("description")
+            .setParameters(parameters);
+    final ParameterGroup p6 = new ParameterGroup()
+            .setDescription("description")
+            .setParameters(parameters);
+    assertEquals(p5, p6);
+    assertNotEquals(p1, p3);
+    assertNotEquals(p1, p5);
+    assertNotEquals(p3, p5);
+  }
+}

--- a/src/test/java/com/google/firebase/remoteconfig/ParameterGroupTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ParameterGroupTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -34,13 +35,13 @@ public class ParameterGroupTest {
     final ParameterGroup pg = new ParameterGroup();
 
     assertNotNull(pg.getParameters());
-    assertEquals(0, pg.getParameters().size());
+    assertTrue(pg.getParameters().isEmpty());
     assertNull(pg.getDescription());
   }
 
   @Test(expected = NullPointerException.class)
   public void testConstructorWithNullParameterGroupResponse() {
-    ParameterGroup pg = new ParameterGroup(null);
+    new ParameterGroup(null);
   }
 
   @Test(expected = NullPointerException.class)

--- a/src/test/java/com/google/firebase/remoteconfig/ParameterGroupTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ParameterGroupTest.java
@@ -32,6 +32,7 @@ public class ParameterGroupTest {
   @Test
   public void testConstructor() {
     final ParameterGroup pg = new ParameterGroup();
+
     assertNotNull(pg.getParameters());
     assertEquals(0, pg.getParameters().size());
     assertNull(pg.getDescription());
@@ -52,12 +53,14 @@ public class ParameterGroupTest {
   public void testEquality() {
     final ParameterGroup p1 = new ParameterGroup();
     final ParameterGroup p2 = new ParameterGroup();
+
     assertEquals(p1, p2);
 
     final ParameterGroup p3 = new ParameterGroup()
             .setDescription("description");
     final ParameterGroup p4 = new ParameterGroup()
             .setDescription("description");
+
     assertEquals(p3, p4);
 
     final Map<String, Parameter> parameters = ImmutableMap.of(
@@ -74,6 +77,7 @@ public class ParameterGroupTest {
     final ParameterGroup p6 = new ParameterGroup()
             .setDescription("description")
             .setParameters(parameters);
+
     assertEquals(p5, p6);
     assertNotEquals(p1, p3);
     assertNotEquals(p1, p5);

--- a/src/test/java/com/google/firebase/remoteconfig/ParameterTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ParameterTest.java
@@ -32,12 +32,12 @@ public class ParameterTest {
 
   @Test
   public void testConstructor() {
-    final Parameter p = new Parameter();
+    final Parameter parameter = new Parameter();
 
-    assertNotNull(p.getConditionalValues());
-    assertTrue(p.getConditionalValues().isEmpty());
-    assertNull(p.getDefaultValue());
-    assertNull(p.getDescription());
+    assertNotNull(parameter.getConditionalValues());
+    assertTrue(parameter.getConditionalValues().isEmpty());
+    assertNull(parameter.getDefaultValue());
+    assertNull(parameter.getDescription());
   }
 
   @Test(expected = NullPointerException.class)
@@ -47,46 +47,45 @@ public class ParameterTest {
 
   @Test(expected = NullPointerException.class)
   public void testSetNullConditionalValues() {
-    Parameter p = new Parameter();
-    p.setConditionalValues(null);
+    Parameter parameter = new Parameter();
+    parameter.setConditionalValues(null);
   }
 
   @Test
   public void testEquality() {
-    final Parameter p1 = new Parameter()
+    final Parameter parameterOne = new Parameter()
             .setDefaultValue(ParameterValue.of("hello"));
-    final Parameter p2 = new Parameter()
+    final Parameter parameterTwo = new Parameter()
             .setDefaultValue(ParameterValue.of("hello"));
 
-    assertEquals(p1, p2);
+    assertEquals(parameterOne, parameterTwo);
 
-    final Parameter p3 = new Parameter()
+    final Parameter parameterThree = new Parameter()
             .setDefaultValue(ParameterValue.inAppDefault())
             .setDescription("greeting text");
-    final Parameter p4 = new Parameter()
+    final Parameter parameterFour = new Parameter()
             .setDefaultValue(ParameterValue.inAppDefault())
             .setDescription("greeting text");
 
-    assertEquals(p3, p4);
+    assertEquals(parameterThree, parameterFour);
 
     final Map<String, ParameterValue> conditionalValues = ImmutableMap.of(
             "ios", ParameterValue.of("hello ios"),
             "android", ParameterValue.of("hello android"),
             "promo", ParameterValue.inAppDefault()
     );
-    final Parameter p5 = new Parameter()
+    final Parameter parameterFive = new Parameter()
             .setDefaultValue(ParameterValue.inAppDefault())
             .setDescription("greeting text")
             .setConditionalValues(conditionalValues);
-    final Parameter p6 = new Parameter()
+    final Parameter parameterSix = new Parameter()
             .setDefaultValue(ParameterValue.inAppDefault())
             .setDescription("greeting text")
             .setConditionalValues(conditionalValues);
 
-    assertEquals(p5, p6);
-    assertNotEquals(p1, p3);
-    assertNotEquals(p1, p5);
-    assertNotEquals(p3, p5);
+    assertEquals(parameterFive, parameterSix);
+    assertNotEquals(parameterOne, parameterThree);
+    assertNotEquals(parameterOne, parameterFive);
+    assertNotEquals(parameterThree, parameterFive);
   }
-
 }

--- a/src/test/java/com/google/firebase/remoteconfig/ParameterTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ParameterTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.remoteconfig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class ParameterTest {
+
+  @Test
+  public void testConstructor() {
+    final Parameter p = new Parameter();
+    assertNotNull(p.getConditionalValues());
+    assertEquals(0, p.getConditionalValues().size());
+    assertNull(p.getDefaultValue());
+    assertNull(p.getDescription());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testConstructorWithNullParameterResponse() {
+    Parameter p = new Parameter(null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testSetNullConditionalValues() {
+    Parameter p = new Parameter();
+    p.setConditionalValues(null);
+  }
+
+  @Test
+  public void testEquality() {
+    final Parameter p1 = new Parameter()
+            .setDefaultValue(ParameterValue.of("hello"));
+    final Parameter p2 = new Parameter()
+            .setDefaultValue(ParameterValue.of("hello"));
+    assertEquals(p1, p2);
+
+    final Parameter p3 = new Parameter()
+            .setDefaultValue(ParameterValue.inAppDefault())
+            .setDescription("greeting text");
+    final Parameter p4 = new Parameter()
+            .setDefaultValue(ParameterValue.inAppDefault())
+            .setDescription("greeting text");
+    assertEquals(p3, p4);
+
+    final Map<String, ParameterValue> conditionalValues = new HashMap();
+    conditionalValues.put("ios", ParameterValue.of("hello ios"));
+    conditionalValues.put("android", ParameterValue.of("hello android"));
+    conditionalValues.put("promo", ParameterValue.inAppDefault());
+    final Parameter p5 = new Parameter()
+            .setDefaultValue(ParameterValue.inAppDefault())
+            .setDescription("greeting text")
+            .setConditionalValues(conditionalValues);
+    final Parameter p6 = new Parameter()
+            .setDefaultValue(ParameterValue.inAppDefault())
+            .setDescription("greeting text")
+            .setConditionalValues(conditionalValues);
+    assertEquals(p5, p6);
+    assertNotEquals(p1, p3);
+    assertNotEquals(p1, p5);
+    assertNotEquals(p3, p5);
+  }
+
+}

--- a/src/test/java/com/google/firebase/remoteconfig/ParameterTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ParameterTest.java
@@ -21,7 +21,8 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import java.util.HashMap;
+import com.google.common.collect.ImmutableMap;
+
 import java.util.Map;
 
 import org.junit.Test;
@@ -64,10 +65,11 @@ public class ParameterTest {
             .setDescription("greeting text");
     assertEquals(p3, p4);
 
-    final Map<String, ParameterValue> conditionalValues = new HashMap();
-    conditionalValues.put("ios", ParameterValue.of("hello ios"));
-    conditionalValues.put("android", ParameterValue.of("hello android"));
-    conditionalValues.put("promo", ParameterValue.inAppDefault());
+    final Map<String, ParameterValue> conditionalValues = ImmutableMap.of(
+            "ios", ParameterValue.of("hello ios"),
+            "android", ParameterValue.of("hello android"),
+            "promo", ParameterValue.inAppDefault()
+    );
     final Parameter p5 = new Parameter()
             .setDefaultValue(ParameterValue.inAppDefault())
             .setDescription("greeting text")

--- a/src/test/java/com/google/firebase/remoteconfig/ParameterTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ParameterTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -32,15 +33,16 @@ public class ParameterTest {
   @Test
   public void testConstructor() {
     final Parameter p = new Parameter();
+
     assertNotNull(p.getConditionalValues());
-    assertEquals(0, p.getConditionalValues().size());
+    assertTrue(p.getConditionalValues().isEmpty());
     assertNull(p.getDefaultValue());
     assertNull(p.getDescription());
   }
 
   @Test(expected = NullPointerException.class)
   public void testConstructorWithNullParameterResponse() {
-    Parameter p = new Parameter(null);
+    new Parameter(null);
   }
 
   @Test(expected = NullPointerException.class)
@@ -55,6 +57,7 @@ public class ParameterTest {
             .setDefaultValue(ParameterValue.of("hello"));
     final Parameter p2 = new Parameter()
             .setDefaultValue(ParameterValue.of("hello"));
+
     assertEquals(p1, p2);
 
     final Parameter p3 = new Parameter()
@@ -63,6 +66,7 @@ public class ParameterTest {
     final Parameter p4 = new Parameter()
             .setDefaultValue(ParameterValue.inAppDefault())
             .setDescription("greeting text");
+
     assertEquals(p3, p4);
 
     final Map<String, ParameterValue> conditionalValues = ImmutableMap.of(
@@ -78,6 +82,7 @@ public class ParameterTest {
             .setDefaultValue(ParameterValue.inAppDefault())
             .setDescription("greeting text")
             .setConditionalValues(conditionalValues);
+
     assertEquals(p5, p6);
     assertNotEquals(p1, p3);
     assertNotEquals(p1, p5);

--- a/src/test/java/com/google/firebase/remoteconfig/ParameterValueTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ParameterValueTest.java
@@ -25,30 +25,30 @@ public class ParameterValueTest {
 
   @Test
   public void testCreateExplicitValue() {
-    final ParameterValue.Explicit pv = ParameterValue.of("title text");
+    final ParameterValue.Explicit parameterValue = ParameterValue.of("title text");
 
-    assertEquals("title text", pv.getValue());
+    assertEquals("title text", parameterValue.getValue());
   }
 
   @Test
   public void testCreateInAppDefault() {
-    final ParameterValue.InAppDefault pv = ParameterValue.inAppDefault();
+    final ParameterValue.InAppDefault parameterValue = ParameterValue.inAppDefault();
 
-    assertEquals(ParameterValue.InAppDefault.class, pv.getClass());
+    assertEquals(ParameterValue.InAppDefault.class, parameterValue.getClass());
   }
 
   @Test
   public void testEquality() {
-    ParameterValue.Explicit pv1 = ParameterValue.of("value");
-    ParameterValue.Explicit pv2 = ParameterValue.of("value");
-    ParameterValue.Explicit pv3 = ParameterValue.of("title");
+    ParameterValue.Explicit parameterValueOne = ParameterValue.of("value");
+    ParameterValue.Explicit parameterValueTwo = ParameterValue.of("value");
+    ParameterValue.Explicit parameterValueThree = ParameterValue.of("title");
 
-    assertEquals(pv1, pv2);
-    assertNotEquals(pv1, pv3);
+    assertEquals(parameterValueOne, parameterValueTwo);
+    assertNotEquals(parameterValueOne, parameterValueThree);
 
-    ParameterValue.InAppDefault pv4 = ParameterValue.inAppDefault();
-    ParameterValue.InAppDefault pv5 = ParameterValue.inAppDefault();
+    ParameterValue.InAppDefault parameterValueFour = ParameterValue.inAppDefault();
+    ParameterValue.InAppDefault parameterValueFive = ParameterValue.inAppDefault();
 
-    assertEquals(pv4, pv5);
+    assertEquals(parameterValueFour, parameterValueFive);
   }
 }

--- a/src/test/java/com/google/firebase/remoteconfig/ParameterValueTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ParameterValueTest.java
@@ -26,12 +26,14 @@ public class ParameterValueTest {
   @Test
   public void testCreateExplicitValue() {
     final ParameterValue.Explicit pv = ParameterValue.of("title text");
+
     assertEquals("title text", pv.getValue());
   }
 
   @Test
   public void testCreateInAppDefault() {
     final ParameterValue.InAppDefault pv = ParameterValue.inAppDefault();
+
     assertEquals(ParameterValue.InAppDefault.class, pv.getClass());
   }
 
@@ -40,11 +42,13 @@ public class ParameterValueTest {
     ParameterValue.Explicit pv1 = ParameterValue.of("value");
     ParameterValue.Explicit pv2 = ParameterValue.of("value");
     ParameterValue.Explicit pv3 = ParameterValue.of("title");
+
     assertEquals(pv1, pv2);
     assertNotEquals(pv1, pv3);
 
     ParameterValue.InAppDefault pv4 = ParameterValue.inAppDefault();
     ParameterValue.InAppDefault pv5 = ParameterValue.inAppDefault();
+
     assertEquals(pv4, pv5);
   }
 }

--- a/src/test/java/com/google/firebase/remoteconfig/ParameterValueTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ParameterValueTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.remoteconfig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+
+public class ParameterValueTest {
+
+  @Test
+  public void testCreateExplicitValue() {
+    final ParameterValue.Explicit pv = ParameterValue.of("title text");
+    assertEquals("title text", pv.getValue());
+  }
+
+  @Test
+  public void testCreateInAppDefault() {
+    final ParameterValue.InAppDefault pv = ParameterValue.inAppDefault();
+    assertEquals(ParameterValue.InAppDefault.class, pv.getClass());
+  }
+
+  @Test
+  public void testEquality() {
+    ParameterValue.Explicit pv1 = ParameterValue.of("value");
+    ParameterValue.Explicit pv2 = ParameterValue.of("value");
+    ParameterValue.Explicit pv3 = ParameterValue.of("title");
+    assertEquals(pv1, pv2);
+    assertNotEquals(pv1, pv3);
+
+    ParameterValue.InAppDefault pv4 = ParameterValue.inAppDefault();
+    ParameterValue.InAppDefault pv5 = ParameterValue.inAppDefault();
+    assertEquals(pv4, pv5);
+  }
+}

--- a/src/test/java/com/google/firebase/remoteconfig/TemplateTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/TemplateTest.java
@@ -34,15 +34,15 @@ public class TemplateTest {
 
   @Test
   public void testConstructor() {
-    Template t = new Template();
+    Template template = new Template();
 
-    assertNotNull(t.getParameters());
-    assertNotNull(t.getConditions());
-    assertNotNull(t.getParameterGroups());
-    assertTrue(t.getParameters().isEmpty());
-    assertTrue(t.getConditions().isEmpty());
-    assertTrue(t.getParameterGroups().isEmpty());
-    assertNull(t.getETag());
+    assertNotNull(template.getParameters());
+    assertNotNull(template.getConditions());
+    assertNotNull(template.getParameterGroups());
+    assertTrue(template.getParameters().isEmpty());
+    assertTrue(template.getConditions().isEmpty());
+    assertTrue(template.getParameterGroups().isEmpty());
+    assertNull(template.getETag());
   }
 
   @Test(expected = NullPointerException.class)
@@ -52,28 +52,28 @@ public class TemplateTest {
 
   @Test(expected = NullPointerException.class)
   public void testSetNullParameters() {
-    Template t = new Template();
-    t.setParameters(null);
+    Template template = new Template();
+    template.setParameters(null);
   }
 
   @Test(expected = NullPointerException.class)
   public void testSetNullConditions() {
-    Template t = new Template();
-    t.setConditions(null);
+    Template template = new Template();
+    template.setConditions(null);
   }
 
   @Test(expected = NullPointerException.class)
   public void testSetNullParameterGroups() {
-    Template t = new Template();
-    t.setParameterGroups(null);
+    Template template = new Template();
+    template.setParameterGroups(null);
   }
 
   @Test
   public void testEquality() {
-    final Template t1 = new Template();
-    final Template t2 = new Template();
+    final Template templateOne = new Template();
+    final Template templateTwo = new Template();
 
-    assertEquals(t1, t2);
+    assertEquals(templateOne, templateTwo);
 
     final List<Condition> conditions = ImmutableList.<Condition>of(
             new Condition("ios_en", "exp ios")
@@ -95,42 +95,42 @@ public class TemplateTest {
                     .setDescription("greeting text")
                     .setConditionalValues(conditionalValues)
     );
-    final Template t3 = new Template()
+    final Template templateThree = new Template()
             .setConditions(conditions)
             .setParameters(parameters);
-    final Template t4 = new Template()
+    final Template templateFour = new Template()
             .setConditions(conditions)
             .setParameters(parameters);
 
-    assertEquals(t3, t4);
+    assertEquals(templateThree, templateFour);
 
     final Map<String, ParameterGroup> parameterGroups = ImmutableMap.of(
             "greetings_group", new ParameterGroup()
                     .setDescription("description")
                     .setParameters(parameters)
     );
-    final Template t5 = new Template()
+    final Template templateFive = new Template()
             .setConditions(conditions)
             .setParameters(parameters)
             .setParameterGroups(parameterGroups);
-    final Template t6 = new Template()
+    final Template templateSix = new Template()
             .setConditions(conditions)
             .setParameters(parameters)
             .setParameterGroups(parameterGroups);
 
-    assertEquals(t5, t6);
+    assertEquals(templateFive, templateSix);
 
-    final Template t7 = new Template()
+    final Template templateSeven = new Template()
             .setETag("etag-123456789097-20");
-    final Template t8 = new Template()
+    final Template templateEight = new Template()
             .setETag("etag-123456789097-20");
 
-    assertEquals(t7, t8);
-    assertNotEquals(t1, t3);
-    assertNotEquals(t1, t5);
-    assertNotEquals(t1, t7);
-    assertNotEquals(t3, t5);
-    assertNotEquals(t3, t7);
-    assertNotEquals(t5, t7);
+    assertEquals(templateSeven, templateEight);
+    assertNotEquals(templateOne, templateThree);
+    assertNotEquals(templateOne, templateFive);
+    assertNotEquals(templateOne, templateSeven);
+    assertNotEquals(templateThree, templateFive);
+    assertNotEquals(templateThree, templateSeven);
+    assertNotEquals(templateFive, templateSeven);
   }
 }

--- a/src/test/java/com/google/firebase/remoteconfig/TemplateTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/TemplateTest.java
@@ -20,11 +20,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -39,15 +39,15 @@ public class TemplateTest {
     assertNotNull(t.getParameters());
     assertNotNull(t.getConditions());
     assertNotNull(t.getParameterGroups());
-    assertEquals(0, t.getParameters().size());
-    assertEquals(0, t.getConditions().size());
-    assertEquals(0, t.getParameterGroups().size());
+    assertTrue(t.getParameters().isEmpty());
+    assertTrue(t.getConditions().isEmpty());
+    assertTrue(t.getParameterGroups().isEmpty());
     assertNull(t.getETag());
   }
 
   @Test(expected = NullPointerException.class)
   public void testConstructorWithNullTemplateResponse() {
-    Template t = new Template(null);
+    new Template(null);
   }
 
   @Test(expected = NullPointerException.class)

--- a/src/test/java/com/google/firebase/remoteconfig/TemplateTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/TemplateTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.remoteconfig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class TemplateTest {
+
+  @Test
+  public void testConstructor() {
+    Template t = new Template();
+
+    assertNotNull(t.getParameters());
+    assertNotNull(t.getConditions());
+    assertNotNull(t.getParameterGroups());
+    assertEquals(0, t.getParameters().size());
+    assertEquals(0, t.getConditions().size());
+    assertEquals(0, t.getParameterGroups().size());
+    assertNull(t.getETag());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testConstructorWithNullTemplateResponse() {
+    Template t = new Template(null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testSetNullParameters() {
+    Template t = new Template();
+    t.setParameters(null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testSetNullConditions() {
+    Template t = new Template();
+    t.setConditions(null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testSetNullParameterGroups() {
+    Template t = new Template();
+    t.setParameterGroups(null);
+  }
+
+  @Test
+  public void testEquality() {
+    final Template t1 = new Template();
+    final Template t2 = new Template();
+
+    assertEquals(t1, t2);
+
+    final List<Condition> conditions = ImmutableList.<Condition>of(
+            new Condition("ios_en", "exp ios")
+                    .setTagColor(TagColor.INDIGO),
+            new Condition("android_en", "exp android")
+    );
+    final Map<String, ParameterValue> conditionalValues = ImmutableMap.of(
+            "ios", ParameterValue.of("hello ios"),
+            "android", ParameterValue.of("hello android"),
+            "promo", ParameterValue.inAppDefault()
+    );
+    final Map<String, Parameter> parameters = ImmutableMap.of(
+            "greeting_header", new Parameter()
+                    .setDefaultValue(ParameterValue.inAppDefault())
+                    .setDescription("greeting header text")
+                    .setConditionalValues(conditionalValues),
+            "greeting_text", new Parameter()
+                    .setDefaultValue(ParameterValue.inAppDefault())
+                    .setDescription("greeting text")
+                    .setConditionalValues(conditionalValues)
+    );
+    final Template t3 = new Template()
+            .setConditions(conditions)
+            .setParameters(parameters);
+    final Template t4 = new Template()
+            .setConditions(conditions)
+            .setParameters(parameters);
+
+    assertEquals(t3, t4);
+
+    final Map<String, ParameterGroup> parameterGroups = ImmutableMap.of(
+            "greetings_group", new ParameterGroup()
+                    .setDescription("description")
+                    .setParameters(parameters)
+    );
+    final Template t5 = new Template()
+            .setConditions(conditions)
+            .setParameters(parameters)
+            .setParameterGroups(parameterGroups);
+    final Template t6 = new Template()
+            .setConditions(conditions)
+            .setParameters(parameters)
+            .setParameterGroups(parameterGroups);
+
+    assertEquals(t5, t6);
+
+    final Template t7 = new Template()
+            .setETag("etag-123456789097-20");
+    final Template t8 = new Template()
+            .setETag("etag-123456789097-20");
+
+    assertEquals(t7, t8);
+    assertNotEquals(t1, t3);
+    assertNotEquals(t1, t5);
+    assertNotEquals(t1, t7);
+    assertNotEquals(t3, t5);
+    assertNotEquals(t3, t7);
+    assertNotEquals(t5, t7);
+  }
+}

--- a/src/test/resources/getRemoteConfig.json
+++ b/src/test/resources/getRemoteConfig.json
@@ -28,7 +28,19 @@
       }
     }
   },
-  "parameterGroups": {},
+  "parameterGroups": {
+    "new menu": {
+      "description": "New Menu",
+      "parameters": {
+        "pumpkin_spice_season": {
+          "defaultValue": {
+            "value": "true"
+          },
+          "description": "Whether it's currently pumpkin spice season."
+        }
+      }
+    }
+  },
   "version": {
     "versionNumber": "17",
     "updateOrigin": "ADMIN_SDK_NODE",


### PR DESCRIPTION
- Add Remote Config Parameter Group type
- Implement `equals()` in all public RC types
- Add unit tests for public RC types
- Refactor existing unit tests to use `equals()` when comparing templates

Related to: #446 