### PR TITLE
Add Version information to RC template

### DIFF
--- a/src/main/java/com/google/firebase/remoteconfig/Template.java
+++ b/src/main/java/com/google/firebase/remoteconfig/Template.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a Remote Config template.
@@ -201,5 +202,26 @@ public final class Template {
             .setConditions(conditionResponses)
             .setParameterGroups(parameterGroupResponse)
             .setVersion(versionResponse);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Template template = (Template) o;
+    return Objects.equals(etag, template.etag)
+            && Objects.equals(parameters, template.parameters)
+            && Objects.equals(conditions, template.conditions)
+            && Objects.equals(parameterGroups, template.parameterGroups)
+            && Objects.equals(version, template.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(etag, parameters, conditions, parameterGroups, version);
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/Template.java
+++ b/src/main/java/com/google/firebase/remoteconfig/Template.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Represents a Remote Config template.
@@ -36,6 +35,7 @@ public final class Template {
   private Map<String, Parameter> parameters;
   private List<Condition> conditions;
   private Map<String, ParameterGroup> parameterGroups;
+  private Version version;
 
   /**
    * Creates a new {@link Template}.
@@ -68,6 +68,9 @@ public final class Template {
               : templateResponse.getParameterGroups().entrySet()) {
         this.parameterGroups.put(entry.getKey(), new ParameterGroup(entry.getValue()));
       }
+    }
+    if (templateResponse.getVersion() != null) {
+      this.version = new Version(templateResponse.getVersion());
     }
   }
 
@@ -112,6 +115,15 @@ public final class Template {
   }
 
   /**
+   * Gets the version information of the template.
+   *
+   * @return The version information of the template.
+   */
+  public Version getVersion() {
+    return version;
+  }
+
+  /**
    * Sets the map of parameters of the template.
    *
    * @param parameters A non-null map of parameter keys to their optional default values and
@@ -152,6 +164,18 @@ public final class Template {
     return this;
   }
 
+  /**
+   * Sets the version information of the template.
+   * Only the version's description field can be specified here.
+   *
+   * @param version A {@link Version} instance.
+   * @return This {@link Template} instance.
+   */
+  public Template setVersion(Version version) {
+    this.version = version;
+    return this;
+  }
+
   Template setETag(String etag) {
     this.etag = etag;
     return this;
@@ -170,29 +194,12 @@ public final class Template {
     for (Map.Entry<String, ParameterGroup> entry : this.parameterGroups.entrySet()) {
       parameterGroupResponse.put(entry.getKey(), entry.getValue().toParameterGroupResponse());
     }
+    TemplateResponse.VersionResponse versionResponse = (this.version == null) ? null
+            : this.version.toVersionResponse();
     return new TemplateResponse()
             .setParameters(parameterResponses)
             .setConditions(conditionResponses)
-            .setParameterGroups(parameterGroupResponse);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    Template template = (Template) o;
-    return Objects.equals(etag, template.etag)
-            && Objects.equals(parameters, template.parameters)
-            && Objects.equals(conditions, template.conditions)
-            && Objects.equals(parameterGroups, template.parameterGroups);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(etag, parameters, conditions, parameterGroups);
+            .setParameterGroups(parameterGroupResponse)
+            .setVersion(versionResponse);
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/User.java
+++ b/src/main/java/com/google/firebase/remoteconfig/User.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.remoteconfig;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.firebase.internal.NonNull;
+import com.google.firebase.internal.Nullable;
+import com.google.firebase.remoteconfig.internal.TemplateResponse.UserResponse;
+
+/**
+ * Represents a Remote Config user. Output only.
+ */
+public final class User {
+
+  private String email;
+  private String name;
+  private String imageUrl;
+
+  User(@NonNull UserResponse userResponse) {
+    checkNotNull(userResponse);
+    this.email = userResponse.getEmail();
+    this.name = userResponse.getName();
+    this.imageUrl = userResponse.getImageUrl();
+  }
+
+  /**
+   * Gets the email of the user.
+   *
+   * @return The email of the user or null.
+   */
+  @Nullable
+  public String getEmail() {
+    return email;
+  }
+
+  /**
+   * Gets the name of the user.
+   *
+   * @return The name of the user or null.
+   */
+  @Nullable
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Gets the image URL of the user.
+   *
+   * @return The image URL of the user or null.
+   */
+  @Nullable
+  public String getImageUrl() {
+    return imageUrl;
+  }
+}

--- a/src/main/java/com/google/firebase/remoteconfig/User.java
+++ b/src/main/java/com/google/firebase/remoteconfig/User.java
@@ -22,14 +22,16 @@ import com.google.firebase.internal.NonNull;
 import com.google.firebase.internal.Nullable;
 import com.google.firebase.remoteconfig.internal.TemplateResponse.UserResponse;
 
+import java.util.Objects;
+
 /**
  * Represents a Remote Config user. Output only.
  */
-public final class User {
+public class User {
 
-  private String email;
-  private String name;
-  private String imageUrl;
+  private final String email;
+  private final String name;
+  private final String imageUrl;
 
   User(@NonNull UserResponse userResponse) {
     checkNotNull(userResponse);
@@ -66,5 +68,24 @@ public final class User {
   @Nullable
   public String getImageUrl() {
     return imageUrl;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    User user = (User) o;
+    return Objects.equals(email, user.email)
+            && Objects.equals(name, user.name)
+            && Objects.equals(imageUrl, user.imageUrl);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(email, name, imageUrl);
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/Version.java
+++ b/src/main/java/com/google/firebase/remoteconfig/Version.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.remoteconfig;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Strings;
+import com.google.firebase.internal.NonNull;
+import com.google.firebase.internal.Nullable;
+import com.google.firebase.remoteconfig.internal.TemplateResponse;
+import com.google.firebase.remoteconfig.internal.TemplateResponse.VersionResponse;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+
+/**
+ * Represents a Remote Config template version.
+ * Output only, except for the version description. Contains metadata about a particular
+ * version of the Remote Config template. All fields are set at the time the specified Remote
+ * Config template is published. A version's description field may be specified when
+ * publishing a template.
+ */
+public final class Version {
+
+  private String versionNumber;
+  private long updateTime;
+  private String updateOrigin;
+  private String updateType;
+  private User updateUser;
+  private String description;
+  private String rollbackSource;
+  private boolean legacy;
+
+  /**
+   * Creates a new {@link Version} with a description.
+   */
+  public static Version withDescription(String description) {
+    return new Version().setDescription(description);
+  }
+
+  Version() {
+  }
+
+  Version(@NonNull VersionResponse versionResponse) {
+    checkNotNull(versionResponse);
+    this.versionNumber = versionResponse.getVersionNumber();
+    if (!Strings.isNullOrEmpty(versionResponse.getUpdateTime())) {
+      SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+      dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+      try {
+        this.updateTime = dateFormat.parse(versionResponse.getUpdateTime()).getTime();
+      } catch (ParseException e) {
+        this.updateTime = 0;
+      }
+    }
+    this.updateOrigin = versionResponse.getUpdateOrigin();
+    this.updateType = versionResponse.getUpdateType();
+    TemplateResponse.UserResponse userResponse = versionResponse.getUpdateUser();
+    this.updateUser = (userResponse != null) ? new User(userResponse) : null;
+    this.description = versionResponse.getDescription();
+    this.rollbackSource = versionResponse.getRollbackSource();
+    this.legacy = versionResponse.isLegacy();
+  }
+
+  /**
+   * Gets the version number of the template.
+   *
+   * @return The version number or null.
+   */
+  @Nullable
+  public String getVersionNumber() {
+    return versionNumber;
+  }
+
+  /**
+   * Gets the update time of the version. The timestamp of when this version of the Remote Config
+   * template was written to the Remote Config backend.
+   *
+   * @return The update time of the version or null.
+   */
+  @Nullable
+  public long getUpdateTime() {
+    return updateTime;
+  }
+
+  /**
+   * Gets the origin of the template update action.
+   *
+   * @return The origin of the template update action or null.
+   */
+  @Nullable
+  public String getUpdateOrigin() {
+    return updateOrigin;
+  }
+
+  /**
+   * Gets the type of the template update action.
+   *
+   * @return The type of the template update action or null.
+   */
+  @Nullable
+  public String getUpdateType() {
+    return updateType;
+  }
+
+  /**
+   * Gets the update user of the template.
+   * An aggregation of all metadata fields about the account that performed the update.
+   *
+   * @return The update user of the template or null.
+   */
+  @Nullable
+  public User getUpdateUser() {
+    return updateUser;
+  }
+
+  /**
+   * Gets the user-provided description of the corresponding Remote Config template.
+   *
+   * @return The description of the template or null.
+   */
+  @Nullable
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Gets the rollback source of the template.
+   *
+   * <p>The version number of the Remote Config template that has become the current version
+   * due to a rollback. Only present if this version is the result of a rollback.
+   *
+   * @return The rollback source of the template or null.
+   */
+  @Nullable
+  public String getRollbackSource() {
+    return rollbackSource;
+  }
+
+  /**
+   * Indicates whether this Remote Config template was published before version history was
+   * supported.
+   *
+   * @return true if the template was published before version history was supported,
+   *     and false otherwise.
+   */
+  public boolean isLegacy() {
+    return legacy;
+  }
+
+  /**
+   * Sets the user-provided description of the template.
+   *
+   * @param description The description of the template.
+   * @return This {@link Version}.
+   */
+  public Version setDescription(String description) {
+    this.description = description;
+    return this;
+  }
+
+  VersionResponse toVersionResponse() {
+    return new VersionResponse()
+            .setDescription(this.description);
+  }
+}

--- a/src/main/java/com/google/firebase/remoteconfig/Version.java
+++ b/src/main/java/com/google/firebase/remoteconfig/Version.java
@@ -68,12 +68,14 @@ public final class Version {
       // example: "2014-10-02T15:01:23.045123456Z"
       // SimpleDateFormat cannot handle nanoseconds, therefore we strip nanoseconds from the string.
       String updateTime = versionResponse.getUpdateTime();
-      int indexOfPeriod = !updateTime.contains(".") ? 0 : updateTime.indexOf(".");
-      String updateTimeWithoutNanoseconds = updateTime.substring(0, indexOfPeriod);
+      int indexOfPeriod = updateTime.indexOf(".");
+      if (indexOfPeriod != -1) {
+        updateTime = updateTime.substring(0, indexOfPeriod);
+      }
       SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
       dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
       try {
-        this.updateTime = dateFormat.parse(updateTimeWithoutNanoseconds).getTime();
+        this.updateTime = dateFormat.parse(updateTime).getTime();
       } catch (ParseException e) {
         throw new IllegalStateException("Unable to parse update time.", e);
       }

--- a/src/main/java/com/google/firebase/remoteconfig/internal/TemplateResponse.java
+++ b/src/main/java/com/google/firebase/remoteconfig/internal/TemplateResponse.java
@@ -36,6 +36,9 @@ public final class TemplateResponse {
   @Key("parameterGroups")
   private Map<String, ParameterGroupResponse> parameterGroups;
 
+  @Key("version")
+  private VersionResponse version;
+
   public Map<String, ParameterResponse> getParameters() {
     return parameters;
   }
@@ -46,6 +49,10 @@ public final class TemplateResponse {
 
   public Map<String, ParameterGroupResponse> getParameterGroups() {
     return parameterGroups;
+  }
+
+  public VersionResponse getVersion() {
+    return version;
   }
 
   public TemplateResponse setParameters(
@@ -63,6 +70,11 @@ public final class TemplateResponse {
   public TemplateResponse setParameterGroups(
           Map<String, ParameterGroupResponse> parameterGroups) {
     this.parameterGroups = parameterGroups;
+    return this;
+  }
+
+  public TemplateResponse setVersion(VersionResponse version) {
+    this.version = version;
     return this;
   }
 
@@ -214,6 +226,100 @@ public final class TemplateResponse {
     public ParameterGroupResponse setDescription(String description) {
       this.description = description;
       return this;
+    }
+  }
+
+  /**
+   * The Data Transfer Object for parsing Remote Config version responses from the
+   * Remote Config service.
+   **/
+  public static final class VersionResponse {
+    @Key("versionNumber")
+    private String versionNumber;
+
+    @Key("updateTime")
+    private String updateTime;
+
+    @Key("updateOrigin")
+    private String updateOrigin;
+
+    @Key("updateType")
+    private String updateType;
+
+    @Key("updateUser")
+    private UserResponse updateUser;
+
+    @Key("description")
+    private String description;
+
+    @Key("rollbackSource")
+    private String rollbackSource;
+
+    @Key("legacy")
+    private Boolean legacy;
+
+    public String getVersionNumber() {
+      return versionNumber;
+    }
+
+    public String getUpdateTime() {
+      return updateTime;
+    }
+
+    public String getUpdateOrigin() {
+      return updateOrigin;
+    }
+
+    public String getUpdateType() {
+      return updateType;
+    }
+
+    public UserResponse getUpdateUser() {
+      return updateUser;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public String getRollbackSource() {
+      return rollbackSource;
+    }
+
+    public boolean isLegacy() {
+      return Boolean.TRUE.equals(this.legacy);
+    }
+
+    public VersionResponse setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+  }
+
+  /**
+   * The Data Transfer Object for parsing Remote Config user responses from the
+   * Remote Config service.
+   **/
+  public static final class UserResponse {
+    @Key("email")
+    private String email;
+
+    @Key("name")
+    private String name;
+
+    @Key("imageUrl")
+    private String imageUrl;
+
+    public String getEmail() {
+      return email;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getImageUrl() {
+      return imageUrl;
     }
   }
 }

--- a/src/main/java/com/google/firebase/remoteconfig/internal/TemplateResponse.java
+++ b/src/main/java/com/google/firebase/remoteconfig/internal/TemplateResponse.java
@@ -294,6 +294,41 @@ public final class TemplateResponse {
       this.description = description;
       return this;
     }
+
+    public VersionResponse setVersionNumber(String versionNumber) {
+      this.versionNumber = versionNumber;
+      return this;
+    }
+
+    public VersionResponse setUpdateTime(String updateTime) {
+      this.updateTime = updateTime;
+      return this;
+    }
+
+    public VersionResponse setUpdateOrigin(String updateOrigin) {
+      this.updateOrigin = updateOrigin;
+      return this;
+    }
+
+    public VersionResponse setUpdateType(String updateType) {
+      this.updateType = updateType;
+      return this;
+    }
+
+    public VersionResponse setUpdateUser(UserResponse updateUser) {
+      this.updateUser = updateUser;
+      return this;
+    }
+
+    public VersionResponse setRollbackSource(String rollbackSource) {
+      this.rollbackSource = rollbackSource;
+      return this;
+    }
+
+    public VersionResponse setLegacy(Boolean legacy) {
+      this.legacy = legacy;
+      return this;
+    }
   }
 
   /**
@@ -320,6 +355,21 @@ public final class TemplateResponse {
 
     public String getImageUrl() {
       return imageUrl;
+    }
+
+    public UserResponse setEmail(String email) {
+      this.email = email;
+      return this;
+    }
+
+    public UserResponse setName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public UserResponse setImageUrl(String imageUrl) {
+      this.imageUrl = imageUrl;
+      return this;
     }
   }
 }

--- a/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImplTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImplTest.java
@@ -41,6 +41,7 @@ import com.google.firebase.FirebaseOptions;
 import com.google.firebase.OutgoingHttpRequest;
 import com.google.firebase.auth.MockGoogleCredentials;
 import com.google.firebase.internal.SdkUtils;
+import com.google.firebase.remoteconfig.internal.TemplateResponse;
 import com.google.firebase.testing.TestResponseInterceptor;
 import com.google.firebase.testing.TestUtils;
 
@@ -115,25 +116,28 @@ public class FirebaseRemoteConfigClientImplTest {
                     "device.os == 'android' && device.country in ['us', 'uk']")
                     .setTagColor(TagColor.UNSPECIFIED)
     );
+    final Version expectedVersion = new Version(new TemplateResponse.VersionResponse()
+            .setVersionNumber("17")
+            .setUpdateOrigin("ADMIN_SDK_NODE")
+            .setUpdateType("INCREMENTAL_UPDATE")
+            .setUpdateUser(new TemplateResponse.UserResponse()
+                    .setEmail("firebase-user@account.com")
+                    .setName("dev-admin")
+                    .setImageUrl("http://image.jpg"))
+            .setUpdateTime("2020-11-03T20:24:15.203Z")
+            .setDescription("promo config")
+    );
+
+    Template expectedTemplate = new Template()
+            .setETag(TEST_ETAG)
+            .setParameters(expectedParameters)
+            .setConditions(expectedConditions)
+            .setParameterGroups(expectedParameterGroups)
+            .setVersion(expectedVersion);
 
     assertEquals(TEST_ETAG, receivedTemplate.getETag());
-    assertEquals(expectedParameters, receivedTemplate.getParameters());
-    assertEquals(expectedParameterGroups, receivedTemplate.getParameterGroups());
-    assertEquals(expectedConditions, receivedTemplate.getConditions());
-
-    final Version receivedVersion = receivedTemplate.getVersion();
-    SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
-    dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-    final String updateTime = dateFormat.format(new Date(receivedVersion.getUpdateTime()));
-
-    assertEquals("17", receivedVersion.getVersionNumber());
-    assertEquals("ADMIN_SDK_NODE", receivedVersion.getUpdateOrigin());
-    assertEquals("INCREMENTAL_UPDATE", receivedVersion.getUpdateType());
-    assertEquals("firebase-user@account.com", receivedVersion.getUpdateUser().getEmail());
-    assertEquals("dev-admin", receivedVersion.getUpdateUser().getName());
-    assertEquals("http://image.jpg", receivedVersion.getUpdateUser().getImageUrl());
-    assertEquals("Wed, 30 Sep 2020 17:56:07 GMT", updateTime);
-    assertEquals("promo config", receivedVersion.getDescription());
+    assertEquals(expectedTemplate, receivedTemplate);
+    assertEquals(1604435055000L, receivedTemplate.getVersion().getUpdateTime());
     checkGetRequestHeader(interceptor.getLastRequest());
   }
 

--- a/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImplTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/FirebaseRemoteConfigClientImplTest.java
@@ -124,7 +124,7 @@ public class FirebaseRemoteConfigClientImplTest {
                     .setEmail("firebase-user@account.com")
                     .setName("dev-admin")
                     .setImageUrl("http://image.jpg"))
-            .setUpdateTime("2020-11-03T20:24:15.203Z")
+            .setUpdateTime("2020-11-03T20:24:15.045123456Z")
             .setDescription("promo config")
     );
 

--- a/src/test/java/com/google/firebase/remoteconfig/TemplateTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/TemplateTest.java
@@ -16,17 +16,9 @@
 
 package com.google.firebase.remoteconfig;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
-import java.util.List;
-import java.util.Map;
 
 import org.junit.Test;
 
@@ -66,71 +58,5 @@ public class TemplateTest {
   public void testSetNullParameterGroups() {
     Template template = new Template();
     template.setParameterGroups(null);
-  }
-
-  @Test
-  public void testEquality() {
-    final Template templateOne = new Template();
-    final Template templateTwo = new Template();
-
-    assertEquals(templateOne, templateTwo);
-
-    final List<Condition> conditions = ImmutableList.<Condition>of(
-            new Condition("ios_en", "exp ios")
-                    .setTagColor(TagColor.INDIGO),
-            new Condition("android_en", "exp android")
-    );
-    final Map<String, ParameterValue> conditionalValues = ImmutableMap.of(
-            "ios", ParameterValue.of("hello ios"),
-            "android", ParameterValue.of("hello android"),
-            "promo", ParameterValue.inAppDefault()
-    );
-    final Map<String, Parameter> parameters = ImmutableMap.of(
-            "greeting_header", new Parameter()
-                    .setDefaultValue(ParameterValue.inAppDefault())
-                    .setDescription("greeting header text")
-                    .setConditionalValues(conditionalValues),
-            "greeting_text", new Parameter()
-                    .setDefaultValue(ParameterValue.inAppDefault())
-                    .setDescription("greeting text")
-                    .setConditionalValues(conditionalValues)
-    );
-    final Template templateThree = new Template()
-            .setConditions(conditions)
-            .setParameters(parameters);
-    final Template templateFour = new Template()
-            .setConditions(conditions)
-            .setParameters(parameters);
-
-    assertEquals(templateThree, templateFour);
-
-    final Map<String, ParameterGroup> parameterGroups = ImmutableMap.of(
-            "greetings_group", new ParameterGroup()
-                    .setDescription("description")
-                    .setParameters(parameters)
-    );
-    final Template templateFive = new Template()
-            .setConditions(conditions)
-            .setParameters(parameters)
-            .setParameterGroups(parameterGroups);
-    final Template templateSix = new Template()
-            .setConditions(conditions)
-            .setParameters(parameters)
-            .setParameterGroups(parameterGroups);
-
-    assertEquals(templateFive, templateSix);
-
-    final Template templateSeven = new Template()
-            .setETag("etag-123456789097-20");
-    final Template templateEight = new Template()
-            .setETag("etag-123456789097-20");
-
-    assertEquals(templateSeven, templateEight);
-    assertNotEquals(templateOne, templateThree);
-    assertNotEquals(templateOne, templateFive);
-    assertNotEquals(templateOne, templateSeven);
-    assertNotEquals(templateThree, templateFive);
-    assertNotEquals(templateThree, templateSeven);
-    assertNotEquals(templateFive, templateSeven);
   }
 }

--- a/src/test/java/com/google/firebase/remoteconfig/TemplateTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/TemplateTest.java
@@ -32,6 +32,52 @@ import org.junit.Test;
 
 public class TemplateTest {
 
+  private static final List<Condition> CONDITIONS = ImmutableList.<Condition>of(
+          new Condition("ios_en", "exp ios")
+                  .setTagColor(TagColor.INDIGO),
+          new Condition("android_en", "exp android")
+  );
+
+  private static final Map<String, ParameterValue> CONDITIONAL_VALUES = ImmutableMap.of(
+          "ios", ParameterValue.of("hello ios"),
+          "android", ParameterValue.of("hello android"),
+          "promo", ParameterValue.inAppDefault()
+  );
+
+  private static final Map<String, Parameter> PARAMETERS = ImmutableMap.of(
+          "greeting_header", new Parameter()
+                  .setDefaultValue(ParameterValue.inAppDefault())
+                  .setDescription("greeting header text")
+                  .setConditionalValues(CONDITIONAL_VALUES),
+          "greeting_text", new Parameter()
+                  .setDefaultValue(ParameterValue.inAppDefault())
+                  .setDescription("greeting text")
+                  .setConditionalValues(CONDITIONAL_VALUES)
+  );
+
+  private static final Map<String, ParameterGroup> PARAMETER_GROUPS = ImmutableMap.of(
+          "greetings_group", new ParameterGroup()
+                  .setDescription("description")
+                  .setParameters(PARAMETERS)
+  );
+
+  private static final Template EMPTY_TEMPLATE = new Template();
+
+  private static final Template TEMPLATE_WITH_CONDITIONS_PARAMETERS = new Template()
+          .setConditions(CONDITIONS)
+          .setParameters(PARAMETERS);
+
+  private static final Template TEMPLATE_WITH_CONDITIONS_PARAMETERS_GROUPS = new Template()
+          .setConditions(CONDITIONS)
+          .setParameters(PARAMETERS)
+          .setParameterGroups(PARAMETER_GROUPS);
+
+  private static final Template TEMPLATE_WITH_ETAG = new Template()
+          .setETag("etag-123456789097-20");
+
+  private static final Template TEMPLATE_WITH_VERSION = new Template()
+          .setVersion(Version.withDescription("promo version"));
+
   @Test
   public void testConstructor() {
     Template template = new Template();
@@ -71,73 +117,40 @@ public class TemplateTest {
   @Test
   public void testEquality() {
     final Template templateOne = new Template();
-    final Template templateTwo = new Template();
 
-    assertEquals(templateOne, templateTwo);
+    assertEquals(EMPTY_TEMPLATE, templateOne);
 
-    final List<Condition> conditions = ImmutableList.<Condition>of(
-            new Condition("ios_en", "exp ios")
-                    .setTagColor(TagColor.INDIGO),
-            new Condition("android_en", "exp android")
-    );
-    final Map<String, ParameterValue> conditionalValues = ImmutableMap.of(
-            "ios", ParameterValue.of("hello ios"),
-            "android", ParameterValue.of("hello android"),
-            "promo", ParameterValue.inAppDefault()
-    );
-    final Map<String, Parameter> parameters = ImmutableMap.of(
-            "greeting_header", new Parameter()
-                    .setDefaultValue(ParameterValue.inAppDefault())
-                    .setDescription("greeting header text")
-                    .setConditionalValues(conditionalValues),
-            "greeting_text", new Parameter()
-                    .setDefaultValue(ParameterValue.inAppDefault())
-                    .setDescription("greeting text")
-                    .setConditionalValues(conditionalValues)
-    );
+    final Template templateTwo = new Template()
+            .setConditions(CONDITIONS)
+            .setParameters(PARAMETERS);
+
+    assertEquals(TEMPLATE_WITH_CONDITIONS_PARAMETERS, templateTwo);
+
     final Template templateThree = new Template()
-            .setConditions(conditions)
-            .setParameters(parameters);
+            .setConditions(CONDITIONS)
+            .setParameters(PARAMETERS)
+            .setParameterGroups(PARAMETER_GROUPS);
+
+    assertEquals(TEMPLATE_WITH_CONDITIONS_PARAMETERS_GROUPS, templateThree);
+
     final Template templateFour = new Template()
-            .setConditions(conditions)
-            .setParameters(parameters);
+            .setETag("etag-123456789097-20");
 
-    assertEquals(templateThree, templateFour);
+    assertEquals(TEMPLATE_WITH_ETAG, templateFour);
 
-    final Map<String, ParameterGroup> parameterGroups = ImmutableMap.of(
-            "greetings_group", new ParameterGroup()
-                    .setDescription("description")
-                    .setParameters(parameters)
-    );
     final Template templateFive = new Template()
-            .setConditions(conditions)
-            .setParameters(parameters)
-            .setParameterGroups(parameterGroups);
-    final Template templateSix = new Template()
-            .setConditions(conditions)
-            .setParameters(parameters)
-            .setParameterGroups(parameterGroups);
+            .setVersion(Version.withDescription("promo version"));
 
-    assertEquals(templateFive, templateSix);
-
-    final Template templateSeven = new Template()
-            .setETag("etag-123456789097-20");
-    final Template templateEight = new Template()
-            .setETag("etag-123456789097-20");
-
-    assertEquals(templateSeven, templateEight);
+    assertEquals(TEMPLATE_WITH_VERSION, templateFive);
+    assertNotEquals(templateOne, templateTwo);
     assertNotEquals(templateOne, templateThree);
+    assertNotEquals(templateOne, templateFour);
     assertNotEquals(templateOne, templateFive);
-    assertNotEquals(templateOne, templateSeven);
+    assertNotEquals(templateTwo, templateThree);
+    assertNotEquals(templateTwo, templateFour);
+    assertNotEquals(templateTwo, templateFive);
+    assertNotEquals(templateThree, templateFour);
     assertNotEquals(templateThree, templateFive);
-    assertNotEquals(templateThree, templateSeven);
-    assertNotEquals(templateFive, templateSeven);
-
-    final Template templateNine = new Template()
-            .setVersion(Version.withDescription("promo version"));
-    final Template templateTen = new Template()
-            .setVersion(Version.withDescription("promo version"));
-    assertEquals(templateNine, templateTen);
-    assertNotEquals(templateOne, templateNine);
+    assertNotEquals(templateFour, templateFive);
   }
 }

--- a/src/test/java/com/google/firebase/remoteconfig/TemplateTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/TemplateTest.java
@@ -16,9 +16,17 @@
 
 package com.google.firebase.remoteconfig;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -58,5 +66,78 @@ public class TemplateTest {
   public void testSetNullParameterGroups() {
     Template template = new Template();
     template.setParameterGroups(null);
+  }
+
+  @Test
+  public void testEquality() {
+    final Template templateOne = new Template();
+    final Template templateTwo = new Template();
+
+    assertEquals(templateOne, templateTwo);
+
+    final List<Condition> conditions = ImmutableList.<Condition>of(
+            new Condition("ios_en", "exp ios")
+                    .setTagColor(TagColor.INDIGO),
+            new Condition("android_en", "exp android")
+    );
+    final Map<String, ParameterValue> conditionalValues = ImmutableMap.of(
+            "ios", ParameterValue.of("hello ios"),
+            "android", ParameterValue.of("hello android"),
+            "promo", ParameterValue.inAppDefault()
+    );
+    final Map<String, Parameter> parameters = ImmutableMap.of(
+            "greeting_header", new Parameter()
+                    .setDefaultValue(ParameterValue.inAppDefault())
+                    .setDescription("greeting header text")
+                    .setConditionalValues(conditionalValues),
+            "greeting_text", new Parameter()
+                    .setDefaultValue(ParameterValue.inAppDefault())
+                    .setDescription("greeting text")
+                    .setConditionalValues(conditionalValues)
+    );
+    final Template templateThree = new Template()
+            .setConditions(conditions)
+            .setParameters(parameters);
+    final Template templateFour = new Template()
+            .setConditions(conditions)
+            .setParameters(parameters);
+
+    assertEquals(templateThree, templateFour);
+
+    final Map<String, ParameterGroup> parameterGroups = ImmutableMap.of(
+            "greetings_group", new ParameterGroup()
+                    .setDescription("description")
+                    .setParameters(parameters)
+    );
+    final Template templateFive = new Template()
+            .setConditions(conditions)
+            .setParameters(parameters)
+            .setParameterGroups(parameterGroups);
+    final Template templateSix = new Template()
+            .setConditions(conditions)
+            .setParameters(parameters)
+            .setParameterGroups(parameterGroups);
+
+    assertEquals(templateFive, templateSix);
+
+    final Template templateSeven = new Template()
+            .setETag("etag-123456789097-20");
+    final Template templateEight = new Template()
+            .setETag("etag-123456789097-20");
+
+    assertEquals(templateSeven, templateEight);
+    assertNotEquals(templateOne, templateThree);
+    assertNotEquals(templateOne, templateFive);
+    assertNotEquals(templateOne, templateSeven);
+    assertNotEquals(templateThree, templateFive);
+    assertNotEquals(templateThree, templateSeven);
+    assertNotEquals(templateFive, templateSeven);
+
+    final Template templateNine = new Template()
+            .setVersion(Version.withDescription("promo version"));
+    final Template templateTen = new Template()
+            .setVersion(Version.withDescription("promo version"));
+    assertEquals(templateNine, templateTen);
+    assertNotEquals(templateOne, templateNine);
   }
 }

--- a/src/test/java/com/google/firebase/remoteconfig/UserTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/UserTest.java
@@ -16,6 +16,10 @@
 
 package com.google.firebase.remoteconfig;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import com.google.firebase.remoteconfig.internal.TemplateResponse;
 import org.junit.Test;
 
 public class UserTest {
@@ -23,5 +27,36 @@ public class UserTest {
   @Test(expected = NullPointerException.class)
   public void testConstructorWithNullVersionResponse() {
     new User(null);
+  }
+
+  @Test
+  public void testEquality() {
+    final User userOne = new User(new TemplateResponse.UserResponse());
+    final User userTwo = new User(new TemplateResponse.UserResponse());
+
+    assertEquals(userOne, userTwo);
+
+    final User userThree = new User(new TemplateResponse.UserResponse()
+            .setName("admin-user")
+            .setEmail("admin@email.com")
+            .setImageUrl("http://admin.jpg"));
+    final User userFour = new User(new TemplateResponse.UserResponse()
+            .setName("admin-user")
+            .setEmail("admin@email.com")
+            .setImageUrl("http://admin.jpg"));
+
+    assertEquals(userThree, userFour);
+
+    final User userFive = new User(new TemplateResponse.UserResponse()
+            .setName("admin-user")
+            .setEmail("admin@email.com"));
+    final User userSix = new User(new TemplateResponse.UserResponse()
+            .setName("admin-user")
+            .setEmail("admin@email.com"));
+
+    assertEquals(userFive, userSix);
+    assertNotEquals(userOne, userThree);
+    assertNotEquals(userOne, userFive);
+    assertNotEquals(userThree, userFive);
   }
 }

--- a/src/test/java/com/google/firebase/remoteconfig/UserTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/UserTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.remoteconfig;
+
+import org.junit.Test;
+
+public class UserTest {
+
+  @Test(expected = NullPointerException.class)
+  public void testConstructorWithNullVersionResponse() {
+    new User(null);
+  }
+}

--- a/src/test/java/com/google/firebase/remoteconfig/VersionTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/VersionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.remoteconfig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class VersionTest {
+
+  @Test
+  public void testConstructor() {
+    final Version version = new Version();
+
+    assertNull(version.getVersionNumber());
+    assertEquals(0, version.getUpdateTime());
+    assertNull(version.getUpdateOrigin());
+    assertNull(version.getUpdateType());
+    assertNull(version.getUpdateUser());
+    assertNull(version.getDescription());
+    assertNull(version.getRollbackSource());
+    assertFalse(version.isLegacy());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testConstructorWithNullVersionResponse() {
+    new Version(null);
+  }
+
+  @Test
+  public void testWithDescription() {
+    final Version version = Version.withDescription("version description text");
+
+    assertEquals("version description text", version.getDescription());
+    assertNull(version.getVersionNumber());
+    assertEquals(0, version.getUpdateTime());
+    assertNull(version.getUpdateOrigin());
+    assertNull(version.getUpdateType());
+    assertNull(version.getUpdateUser());
+    assertNull(version.getRollbackSource());
+    assertFalse(version.isLegacy());
+  }
+}

--- a/src/test/java/com/google/firebase/remoteconfig/VersionTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/VersionTest.java
@@ -18,29 +18,24 @@ package com.google.firebase.remoteconfig;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
+import com.google.firebase.remoteconfig.internal.TemplateResponse;
+import com.google.firebase.remoteconfig.internal.TemplateResponse.VersionResponse;
 import org.junit.Test;
 
 public class VersionTest {
 
-  @Test
-  public void testConstructor() {
-    final Version version = new Version();
-
-    assertNull(version.getVersionNumber());
-    assertEquals(0, version.getUpdateTime());
-    assertNull(version.getUpdateOrigin());
-    assertNull(version.getUpdateType());
-    assertNull(version.getUpdateUser());
-    assertNull(version.getDescription());
-    assertNull(version.getRollbackSource());
-    assertFalse(version.isLegacy());
-  }
-
   @Test(expected = NullPointerException.class)
   public void testConstructorWithNullVersionResponse() {
     new Version(null);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testConstructorWithInvalidUpdateTime() {
+    new Version(new VersionResponse()
+            .setUpdateTime("sunday,26th"));
   }
 
   @Test
@@ -55,5 +50,42 @@ public class VersionTest {
     assertNull(version.getUpdateUser());
     assertNull(version.getRollbackSource());
     assertFalse(version.isLegacy());
+  }
+
+  @Test
+  public void testEquality() {
+    final Version versionOne = new Version(new VersionResponse());
+    final Version versionTwo = new Version(new VersionResponse());
+
+    assertEquals(versionOne, versionTwo);
+
+    final Version versionThree = Version.withDescription("abcd");
+    final Version versionFour = Version.withDescription("abcd");
+    final Version versionFive = new Version(new VersionResponse()).setDescription("abcd");
+
+    assertEquals(versionThree, versionFour);
+    assertEquals(versionThree, versionFive);
+
+    final Version versionSix = Version.withDescription("efgh");
+
+    assertNotEquals(versionThree, versionSix);
+    assertNotEquals(versionOne, versionSix);
+
+    final VersionResponse versionResponse = new VersionResponse()
+            .setVersionNumber("23")
+            .setUpdateTime("2014-10-02T15:01:23.045123456Z")
+            .setUpdateOrigin("ADMIN_SDK")
+            .setUpdateUser(new TemplateResponse.UserResponse()
+                    .setEmail("user@email.com")
+                    .setName("user-1234")
+                    .setImageUrl("http://user.jpg"))
+            .setUpdateType("INCREMENTAL_UPDATE");
+    final Version versionSeven = new Version(versionResponse);
+    final Version versionEight = new Version(versionResponse);
+
+    assertEquals(versionSeven, versionEight);
+    assertNotEquals(versionOne, versionSeven);
+    assertNotEquals(versionThree, versionSeven);
+    assertNotEquals(versionSix, versionSeven);
   }
 }

--- a/src/test/resources/getRemoteConfig.json
+++ b/src/test/resources/getRemoteConfig.json
@@ -46,8 +46,11 @@
     "updateOrigin": "ADMIN_SDK_NODE",
     "updateType": "INCREMENTAL_UPDATE",
     "updateUser": {
-      "email": "firebase-user@account.com"
+      "email": "firebase-user@account.com",
+      "name": "dev-admin",
+      "imageUrl": "http://image.jpg"
     },
-    "updateTime": "Wed, 30 Sep 2020 17:56:07 GMT"
+    "updateTime": "Wed, 30 Sep 2020 17:56:07 GMT",
+    "description": "promo config"
   }
 }

--- a/src/test/resources/getRemoteConfig.json
+++ b/src/test/resources/getRemoteConfig.json
@@ -50,7 +50,7 @@
       "name": "dev-admin",
       "imageUrl": "http://image.jpg"
     },
-    "updateTime": "2020-11-03T20:24:15.203Z",
+    "updateTime": "2020-11-03T20:24:15.045123456ZZ",
     "description": "promo config"
   }
 }

--- a/src/test/resources/getRemoteConfig.json
+++ b/src/test/resources/getRemoteConfig.json
@@ -50,7 +50,7 @@
       "name": "dev-admin",
       "imageUrl": "http://image.jpg"
     },
-    "updateTime": "Wed, 30 Sep 2020 17:56:07 GMT",
+    "updateTime": "2020-11-03T20:24:15.203Z",
     "description": "promo config"
   }
 }


### PR DESCRIPTION
- Add Version information to the Template
- Create new Version type
- Create new User type
- ~Note: Since Version and User types are output only, I did not implement `equal()` and `hashcode()` operations. Instead, unit tests are checking for each property in `Version` and `User` individually. I also removed the equality operations from `Template`, as well.~
- Based on PR review feedback, implement equality in all public types (including `Version` and `User`) to keep consistency.

Related to: #446 