### PR TITLE
fix(fcm): Gracefully handling non-json error responses

### DIFF
--- a/src/main/java/com/google/firebase/messaging/FirebaseMessagingClientImpl.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessagingClientImpl.java
@@ -307,7 +307,7 @@ final class FirebaseMessagingClientImpl implements FirebaseMessagingClient {
         try {
           return jsonFactory.createJsonParser(response)
               .parseAndClose(MessagingServiceErrorResponse.class);
-        } catch (IOException ignore) {
+        } catch (Exception ignore) {
           // Ignore any error that may occur while parsing the error response. The server
           // may have responded with a non-json payload.
         }

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
@@ -82,7 +82,7 @@ public class FirebaseMessagingClientImplTest {
       .setTopic("test-topic")
       .build();
   private static final List<Message> MESSAGE_LIST = ImmutableList.of(EMPTY_MESSAGE, EMPTY_MESSAGE);
-  
+
   private static final boolean DRY_RUN_ENABLED = true;
   private static final boolean DRY_RUN_DISABLED = false;
 
@@ -100,7 +100,7 @@ public class FirebaseMessagingClientImplTest {
   @Test
   public void testSend() throws Exception {
     Map<Message, Map<String, Object>> testMessages = buildTestMessages();
-    
+
     for (Map.Entry<Message, Map<String, Object>> entry : testMessages.entrySet()) {
       response.setContent(MOCK_RESPONSE);
       String resp = client.send(entry.getKey(), DRY_RUN_DISABLED);
@@ -200,14 +200,14 @@ public class FirebaseMessagingClientImplTest {
   @Test
   public void testSendErrorWithMalformedResponse() {
     for (int code : HTTP_ERRORS) {
-      response.setStatusCode(code).setContent("not json");
+      response.setStatusCode(code).setContent("[not json]");
 
       try {
         client.send(EMPTY_MESSAGE, DRY_RUN_DISABLED);
         fail("No error thrown for HTTP error");
       } catch (FirebaseMessagingException error) {
         checkExceptionFromHttpResponse(error, HTTP_2_ERROR.get(code), null,
-            "Unexpected HTTP response with status: " + code + "\nnot json");
+            "Unexpected HTTP response with status: " + code + "\n[not json]");
       }
       checkRequestHeader(interceptor.getLastRequest());
     }


### PR DESCRIPTION
FCM service seems to occasionally respond with non-json (HTML) error responses, and if these responses contain certain special characters (e.g. `[` or `]`), the SDK throws a cryptic JSON parse exception (see #506). 

The `MessagingErrorHandler` is supposed to catch all parse errors, but today it only handles IOExceptions thrown by the parser. But in the above case parser throws an IllegalArgumentException. This PR addresses this issue by updating the `MessagingErrorHandler` to catch *all* exceptions thrown by the parser. This makes sure the developer gets a `FirebaseMessagingException` with the original error response attached to it, when the above error condition occurs.

RELEASE NOTE: Improved support for handling certain non-JSON error responses sent by the FCM backend service.