### PR TITLE
Fix the language of mvn for testing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <skipUTs>${skipTests}</skipUTs>
         <netty.version>4.1.59.Final</netty.version>
+        <argLine>-Duser.language=en</argLine>
     </properties>
 
     <scm>


### PR DESCRIPTION
I challenged firebase/firebase-admin-java@9862c552928be34c8907189cfb00929452d67d21(tag: v7.1.0)  tests on my local pc.
However, it failed as follows. 
```
[ERROR] Failures: 
[ERROR]   TemplateTest.testToJSONWithVersion:321 expected:<...NODE","updateTime":"[Tue, 08 Dec] 2020 15:49:51 UTC",...> but was:<...NODE","updateTime":"[火, 08 12] 2020 15:49:51 UTC",...>
[ERROR] Errors: 
[ERROR]   TemplateTest.testFromJSONWithVersion:250 » IllegalState Unable to parse update...
[ERROR]   VersionTest.testConstructorWithValidUTCUpdateTime:51 » IllegalState Unable to ...
[INFO] 
[ERROR] Tests run: 1554, Failures: 1, Errors: 2, Skipped: 2
```

I thought it was probably a problem with the language settings on my pc, so the language is fixed to `en`.
```
$ mvn --version
... omit ...
Default locale: ja_JP, platform encoding: UTF-8
... omit ...
```
With this fix, `mvn test` was successful on my pc.