### PR TITLE
feat: enables OIDC auth code flow

### DIFF
--- a/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
+++ b/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
@@ -79,6 +79,13 @@ public final class OidcProviderConfig extends ProviderConfig {
         "Invalid OIDC provider ID (must be prefixed with 'oidc.'): " + providerId);
   }
 
+  static Map<String, Boolean> ensureResponseType(Map<String,Object> properties) {
+    if (properties.get("responseType") == null) {
+      properties.put("responseType", new HashMap<String, Boolean>());
+    }
+    return (Map<String, Boolean>) properties.get("responseType");
+  }
+
   /**
    * A specification class for creating a new OIDC Auth provider.
    *
@@ -158,10 +165,7 @@ public final class OidcProviderConfig extends ProviderConfig {
      * @param enabled A boolean signifying whether the code response type is supported.
      */
     public CreateRequest setCodeResponseType(boolean enabled) {
-      if (properties.get("responseType") == null) {
-        properties.put("responseType", new HashMap<String, Boolean>());
-      }
-      Map<String, Boolean> map = (Map<String, Boolean>) properties.get("responseType");
+      Map<String, Boolean> map = ensureResponseType(properties);
       map.put("code", enabled);
       return this;
     }
@@ -175,11 +179,7 @@ public final class OidcProviderConfig extends ProviderConfig {
      * @param enabled A boolean signifying whether the ID token response type is supported.
      */
     public CreateRequest setIdTokenResponseType(boolean enabled) {
-      if (properties.get("responseType") == null) {
-        properties.put("responseType", new HashMap<String, Boolean>());
-      }
-
-      Map<String, Boolean> map = (Map<String, Boolean>) properties.get("responseType");
+      Map<String, Boolean> map = ensureResponseType(properties);
       map.put("idToken", enabled);
       return this;
     }
@@ -265,10 +265,7 @@ public final class OidcProviderConfig extends ProviderConfig {
      * @param enabled A boolean signifying whether the code response type is supported.
      */
     public UpdateRequest setCodeResponseType(boolean enabled) {
-      if (properties.get("responseType") == null) {
-        properties.put("responseType", new HashMap<String, Boolean>());
-      }
-      Map<String, Boolean> map = (Map<String, Boolean>) properties.get("responseType");
+      Map<String, Boolean> map = ensureResponseType(properties);
       map.put("code", enabled);
       return this;
     }
@@ -282,11 +279,7 @@ public final class OidcProviderConfig extends ProviderConfig {
      * @param enabled A boolean signifying whether the ID token response type is supported.
      */
     public UpdateRequest setIdTokenResponseType(boolean enabled) {
-      if (properties.get("responseType") == null) {
-        properties.put("responseType", new HashMap<String, Boolean>());
-      }
-
-      Map<String, Boolean> map = (Map<String, Boolean>) properties.get("responseType");
+      Map<String, Boolean> map = ensureResponseType(properties);
       map.put("idToken", enabled);
       return this;
     }

--- a/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
+++ b/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
@@ -18,8 +18,11 @@ package com.google.firebase.auth;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.api.client.json.GenericJson;
 import com.google.api.client.util.Key;
 import com.google.common.base.Strings;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Contains metadata associated with an OIDC Auth provider.
@@ -31,15 +34,29 @@ public final class OidcProviderConfig extends ProviderConfig {
   @Key("clientId")
   private String clientId;
 
+  @Key("clientSecret")
+  private String clientSecret;
+
   @Key("issuer")
   private String issuer;
+
+  @Key("responseType")
+  private GenericJson responseType;
 
   public String getClientId() {
     return clientId;
   }
 
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
   public String getIssuer() {
     return issuer;
+  }
+
+  public GenericJson getResponseType() {
+    return responseType;
   }
 
   /**
@@ -100,6 +117,19 @@ public final class OidcProviderConfig extends ProviderConfig {
     }
 
     /**
+     * Sets the client secret for the new provider. This is required for the code flow.
+     *
+     * @param clientSecret A non-null, non-empty client secret string.
+     * @throws IllegalArgumentException If the client secret is null or empty.
+     */
+    public CreateRequest setClientSecret(String clientSecret) {
+      checkArgument(!Strings.isNullOrEmpty(clientSecret),
+          "Client Secret must not be null or empty.");
+      properties.put("clientSecret", clientSecret);
+      return this;
+    }
+
+    /**
      * Sets the issuer for the new provider.
      *
      * @param issuer A non-null, non-empty issuer URL string.
@@ -110,6 +140,43 @@ public final class OidcProviderConfig extends ProviderConfig {
       checkArgument(!Strings.isNullOrEmpty(issuer), "Issuer must not be null or empty.");
       assertValidUrl(issuer);
       properties.put("issuer", issuer);
+      return this;
+    }
+
+    /**
+     * Sets whether to enable the code response flow for the new provider. By default, this is not
+     * enabled if no response type is specified.
+     *
+     * <p>A client secret must be set for this response type.
+     *
+     * <p>Having both the code and ID token response flows is currently not supported.
+     *
+     * @param enabled A boolean signifying whether the code response type is supported.
+     */
+    public CreateRequest setCodeResponseType(boolean enabled) {
+      if (properties.get("responseType") == null) {
+        properties.put("responseType", new HashMap<String, Boolean>());
+      }
+      Map<String, Boolean> map = (Map<String, Boolean>) properties.get("responseType");
+      map.put("code", enabled);
+      return this;
+    }
+
+    /**
+     * Sets whether to enable the ID token response flow for the new provider. By default, this is
+     * enabled if no response type is specified.
+     *
+     * <p>Having both the code and ID token response flows is currently not supported.
+     *
+     * @param enabled A boolean signifying whether the ID token response type is supported.
+     */
+    public CreateRequest setIdTokenResponseType(boolean enabled) {
+      if (properties.get("responseType") == null) {
+        properties.put("responseType", new HashMap<String, Boolean>());
+      }
+
+      Map<String, Boolean> map = (Map<String, Boolean>) properties.get("responseType");
+      map.put("idToken", enabled);
       return this;
     }
 
@@ -157,6 +224,19 @@ public final class OidcProviderConfig extends ProviderConfig {
     }
 
     /**
+     * Sets the client secret for the new provider. This is required for the code flow.
+     *
+     * @param clientSecret A non-null, non-empty client secret string.
+     * @throws IllegalArgumentException If the client secret is null or empty.
+     */
+    public UpdateRequest setClientSecret(String clientSecret) {
+      checkArgument(!Strings.isNullOrEmpty(clientSecret),
+          "Client Secret must not be null or empty.");
+      properties.put("clientSecret", clientSecret);
+      return this;
+    }
+
+    /**
      * Sets the issuer for the existing provider.
      *
      * @param issuer A non-null, non-empty issuer URL string.
@@ -167,6 +247,43 @@ public final class OidcProviderConfig extends ProviderConfig {
       checkArgument(!Strings.isNullOrEmpty(issuer), "Issuer must not be null or empty.");
       assertValidUrl(issuer);
       properties.put("issuer", issuer);
+      return this;
+    }
+
+    /**
+     * Sets whether to enable the code response flow for the new provider. By default, this is not
+     * enabled if no response type is specified.
+     *
+     * <p>A client secret must be set for this response type.
+     *
+     * <p>Having both the code and ID token response flows is currently not supported.
+     *
+     * @param enabled A boolean signifying whether the code response type is supported.
+     */
+    public UpdateRequest setCodeResponseType(boolean enabled) {
+      if (properties.get("responseType") == null) {
+        properties.put("responseType", new HashMap<String, Boolean>());
+      }
+      Map<String, Boolean> map = (Map<String, Boolean>) properties.get("responseType");
+      map.put("code", enabled);
+      return this;
+    }
+
+    /**
+     * Sets whether to enable the ID token response flow for the new provider. By default, this is
+     * enabled if no response type is specified.
+     *
+     * <p>Having both the code and ID token response flows is currently not supported.
+     *
+     * @param enabled A boolean signifying whether the ID token response type is supported.
+     */
+    public UpdateRequest setIdTokenResponseType(boolean enabled) {
+      if (properties.get("responseType") == null) {
+        properties.put("responseType", new HashMap<String, Boolean>());
+      }
+
+      Map<String, Boolean> map = (Map<String, Boolean>) properties.get("responseType");
+      map.put("idToken", enabled);
       return this;
     }
 

--- a/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
+++ b/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
@@ -55,8 +55,12 @@ public final class OidcProviderConfig extends ProviderConfig {
     return issuer;
   }
 
-  public GenericJson getResponseType() {
-    return responseType;
+  public boolean isCodeResponseType() {
+    return (responseType.containsKey("code") && (boolean) responseType.get("code"));
+  }
+
+  public boolean isIdTokenResponseType() {
+    return (responseType.containsKey("idToken") && (boolean) responseType.get("idToken"));
   }
 
   /**

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -714,9 +714,8 @@ public class FirebaseAuthIT {
     assertEquals("ClientId", config.getClientId());
     assertEquals("ClientSecret", config.getClientSecret());
     assertEquals("https://oidc.com/issuer", config.getIssuer());
-    GenericJson responseType = config.getResponseType();
-    assertTrue((boolean) responseType.get("code"));
-    assertNull(responseType.get("idToken"));
+    assertTrue(config.isCodeResponseType());
+    assertFalse(config.isIdTokenResponseType());
 
     // Get provider config
     config = auth.getOidcProviderConfigAsync(providerId).get();
@@ -726,9 +725,8 @@ public class FirebaseAuthIT {
     assertEquals("ClientId", config.getClientId());
     assertEquals("ClientSecret", config.getClientSecret());
     assertEquals("https://oidc.com/issuer", config.getIssuer());
-    responseType = config.getResponseType();
-    assertTrue((boolean) responseType.get("code"));
-    assertNull(responseType.get("idToken"));
+    assertTrue(config.isCodeResponseType());
+    assertFalse(config.isIdTokenResponseType());
 
     // Update provider config
     OidcProviderConfig.UpdateRequest updateRequest =
@@ -748,9 +746,8 @@ public class FirebaseAuthIT {
     assertEquals("NewClientId", config.getClientId());
     assertEquals("NewClientSecret", config.getClientSecret());
     assertEquals("https://oidc.com/new-issuer", config.getIssuer());
-    responseType = config.getResponseType();
-    assertTrue((boolean) responseType.get("idToken"));
-    assertNull(responseType.get("code"));
+    assertTrue(config.isIdTokenResponseType());
+    assertFalse(config.isCodeResponseType());
 
     // Delete provider config
     temporaryProviderConfig.deleteOidcProviderConfig(providerId);

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthIT.java
@@ -703,12 +703,20 @@ public class FirebaseAuthIT {
             .setDisplayName("DisplayName")
             .setEnabled(true)
             .setClientId("ClientId")
-            .setIssuer("https://oidc.com/issuer"));
+            .setClientSecret("ClientSecret")
+            .setIssuer("https://oidc.com/issuer")
+            .setCodeResponseType(true)
+            .setIdTokenResponseType(false));
+
     assertEquals(providerId, config.getProviderId());
     assertEquals("DisplayName", config.getDisplayName());
     assertTrue(config.isEnabled());
     assertEquals("ClientId", config.getClientId());
+    assertEquals("ClientSecret", config.getClientSecret());
     assertEquals("https://oidc.com/issuer", config.getIssuer());
+    GenericJson responseType = config.getResponseType();
+    assertTrue((boolean) responseType.get("code"));
+    assertNull(responseType.get("idToken"));
 
     // Get provider config
     config = auth.getOidcProviderConfigAsync(providerId).get();
@@ -716,7 +724,11 @@ public class FirebaseAuthIT {
     assertEquals("DisplayName", config.getDisplayName());
     assertTrue(config.isEnabled());
     assertEquals("ClientId", config.getClientId());
+    assertEquals("ClientSecret", config.getClientSecret());
     assertEquals("https://oidc.com/issuer", config.getIssuer());
+    responseType = config.getResponseType();
+    assertTrue((boolean) responseType.get("code"));
+    assertNull(responseType.get("idToken"));
 
     // Update provider config
     OidcProviderConfig.UpdateRequest updateRequest =
@@ -724,13 +736,21 @@ public class FirebaseAuthIT {
             .setDisplayName("NewDisplayName")
             .setEnabled(false)
             .setClientId("NewClientId")
-            .setIssuer("https://oidc.com/new-issuer");
+            .setClientSecret("NewClientSecret")
+            .setIssuer("https://oidc.com/new-issuer")
+            .setCodeResponseType(false)
+            .setIdTokenResponseType(true);
+
     config = auth.updateOidcProviderConfigAsync(updateRequest).get();
     assertEquals(providerId, config.getProviderId());
     assertEquals("NewDisplayName", config.getDisplayName());
     assertFalse(config.isEnabled());
     assertEquals("NewClientId", config.getClientId());
+    assertEquals("NewClientSecret", config.getClientSecret());
     assertEquals("https://oidc.com/new-issuer", config.getIssuer());
+    responseType = config.getResponseType();
+    assertTrue((boolean) responseType.get("idToken"));
+    assertNull(responseType.get("code"));
 
     // Delete provider config
     temporaryProviderConfig.deleteOidcProviderConfig(providerId);

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -2821,10 +2821,8 @@ public class FirebaseUserManagerTest {
     assertEquals("CLIENT_ID", config.getClientId());
     assertEquals("CLIENT_SECRET", config.getClientSecret());
     assertEquals("https://oidc.com/issuer", config.getIssuer());
-
-    GenericJson responseType = config.getResponseType();
-    assertTrue((boolean) responseType.get("code"));
-    assertFalse((boolean) responseType.get("idToken"));
+    assertTrue(config.isCodeResponseType());
+    assertFalse(config.isIdTokenResponseType());
   }
 
   private static void checkSamlProviderConfig(SamlProviderConfig config, String providerId) {

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -1490,7 +1490,10 @@ public class FirebaseUserManagerTest {
             .setDisplayName("DISPLAY_NAME")
             .setEnabled(true)
             .setClientId("CLIENT_ID")
-            .setIssuer("https://oidc.com/issuer");
+            .setClientSecret("CLIENT_SECRET")
+            .setIssuer("https://oidc.com/issuer")
+            .setCodeResponseType(true)
+            .setIdTokenResponseType(true);
 
     OidcProviderConfig config = FirebaseAuth.getInstance().createOidcProviderConfig(createRequest);
 
@@ -1501,7 +1504,13 @@ public class FirebaseUserManagerTest {
     assertEquals("DISPLAY_NAME", parsed.get("displayName"));
     assertTrue((boolean) parsed.get("enabled"));
     assertEquals("CLIENT_ID", parsed.get("clientId"));
+    assertEquals("CLIENT_SECRET", parsed.get("clientSecret"));
     assertEquals("https://oidc.com/issuer", parsed.get("issuer"));
+
+    Map<String, Boolean> responseType = (Map<String, Boolean>) parsed.get("responseType");
+    assertTrue(responseType.get("code"));
+    assertTrue(responseType.get("idToken"));
+
     GenericUrl url = interceptor.getResponse().getRequest().getUrl();
     assertEquals("oidc.provider-id", url.getFirst("oauthIdpConfigId"));
   }
@@ -1515,9 +1524,12 @@ public class FirebaseUserManagerTest {
             .setDisplayName("DISPLAY_NAME")
             .setEnabled(true)
             .setClientId("CLIENT_ID")
-            .setIssuer("https://oidc.com/issuer");
+            .setClientSecret("CLIENT_SECRET")
+            .setIssuer("https://oidc.com/issuer")
+            .setCodeResponseType(true)
+            .setIdTokenResponseType(true);
 
-    OidcProviderConfig config = 
+    OidcProviderConfig config =
         FirebaseAuth.getInstance().createOidcProviderConfigAsync(createRequest).get();
 
     checkOidcProviderConfig(config, "oidc.provider-id");
@@ -1527,7 +1539,13 @@ public class FirebaseUserManagerTest {
     assertEquals("DISPLAY_NAME", parsed.get("displayName"));
     assertTrue((boolean) parsed.get("enabled"));
     assertEquals("CLIENT_ID", parsed.get("clientId"));
+    assertEquals("CLIENT_SECRET", parsed.get("clientSecret"));
     assertEquals("https://oidc.com/issuer", parsed.get("issuer"));
+
+    Map<String, Boolean> responseType = (Map<String, Boolean>) parsed.get("responseType");
+    assertTrue(responseType.get("code"));
+    assertTrue(responseType.get("idToken"));
+
     GenericUrl url = interceptor.getResponse().getRequest().getUrl();
     assertEquals("oidc.provider-id", url.getFirst("oauthIdpConfigId"));
   }
@@ -1730,7 +1748,10 @@ public class FirebaseUserManagerTest {
             .setDisplayName("DISPLAY_NAME")
             .setEnabled(true)
             .setClientId("CLIENT_ID")
-            .setIssuer("https://oidc.com/issuer");
+            .setClientSecret("CLIENT_SECRET")
+            .setIssuer("https://oidc.com/issuer")
+            .setCodeResponseType(true)
+            .setIdTokenResponseType(true);
 
     OidcProviderConfig config = tenantAwareAuth.updateOidcProviderConfig(request);
 
@@ -1739,12 +1760,18 @@ public class FirebaseUserManagerTest {
     String expectedUrl = TENANTS_BASE_URL + "/TENANT_ID/oauthIdpConfigs/oidc.provider-id";
     checkUrl(interceptor, "PATCH", expectedUrl);
     GenericUrl url = interceptor.getResponse().getRequest().getUrl();
-    assertEquals("clientId,displayName,enabled,issuer", url.getFirst("updateMask"));
+    assertEquals("clientId,clientSecret,displayName,enabled,issuer,responseType.code,"
+        + "responseType.idToken", url.getFirst("updateMask"));
     GenericJson parsed = parseRequestContent(interceptor);
     assertEquals("DISPLAY_NAME", parsed.get("displayName"));
     assertTrue((boolean) parsed.get("enabled"));
     assertEquals("CLIENT_ID", parsed.get("clientId"));
+    assertEquals("CLIENT_SECRET", parsed.get("clientSecret"));
     assertEquals("https://oidc.com/issuer", parsed.get("issuer"));
+
+    Map<String, Boolean> responseType = (Map<String, Boolean>) parsed.get("responseType");
+    assertTrue(responseType.get("code"));
+    assertTrue(responseType.get("idToken"));
   }
 
   @Test
@@ -2792,7 +2819,12 @@ public class FirebaseUserManagerTest {
     assertEquals("DISPLAY_NAME", config.getDisplayName());
     assertTrue(config.isEnabled());
     assertEquals("CLIENT_ID", config.getClientId());
+    assertEquals("CLIENT_SECRET", config.getClientSecret());
     assertEquals("https://oidc.com/issuer", config.getIssuer());
+
+    GenericJson responseType = config.getResponseType();
+    assertTrue((boolean) responseType.get("code"));
+    assertFalse((boolean) responseType.get("idToken"));
   }
 
   private static void checkSamlProviderConfig(SamlProviderConfig config, String providerId) {
@@ -2824,5 +2856,4 @@ public class FirebaseUserManagerTest {
   private interface UserManagerOp {
     void call(FirebaseAuth auth) throws Exception;
   }
-
 }

--- a/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
+++ b/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
@@ -56,11 +56,8 @@ public class OidcProviderConfigTest {
     assertEquals("CLIENT_ID", config.getClientId());
     assertEquals("CLIENT_SECRET", config.getClientSecret());
     assertEquals("https://oidc.com/issuer", config.getIssuer());
-    assertNotNull(config.getResponseType());
-
-    GenericJson responseType = config.getResponseType();
-    assertTrue((boolean)responseType.get("code"));
-    assertFalse((boolean)responseType.get("idToken"));
+    assertTrue(config.isCodeResponseType());
+    assertFalse(config.isIdTokenResponseType());
   }
 
   @Test

--- a/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
+++ b/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
@@ -18,9 +18,11 @@ package com.google.firebase.auth;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.api.client.googleapis.util.Utils;
+import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
 import java.io.IOException;
 import java.util.Map;
@@ -36,7 +38,12 @@ public class OidcProviderConfigTest {
         + "  'displayName': 'DISPLAY_NAME',"
         + "  'enabled':      true,"
         + "  'clientId':    'CLIENT_ID',"
-        + "  'issuer':      'https://oidc.com/issuer'"
+        + "  'clientSecret':'CLIENT_SECRET',"
+        + "  'issuer':      'https://oidc.com/issuer',"
+        + "  'responseType': {"
+        + "    'code':  true,"
+        + "    'idToken': false"
+        + "   }"
         + "}").replace("'", "\"");
 
   @Test
@@ -47,7 +54,13 @@ public class OidcProviderConfigTest {
     assertEquals("DISPLAY_NAME", config.getDisplayName());
     assertTrue(config.isEnabled());
     assertEquals("CLIENT_ID", config.getClientId());
+    assertEquals("CLIENT_SECRET", config.getClientSecret());
     assertEquals("https://oidc.com/issuer", config.getIssuer());
+    assertNotNull(config.getResponseType());
+
+    GenericJson responseType = config.getResponseType();
+    assertTrue((boolean)responseType.get("code"));
+    assertFalse((boolean)responseType.get("idToken"));
   }
 
   @Test
@@ -58,15 +71,23 @@ public class OidcProviderConfigTest {
       .setDisplayName("DISPLAY_NAME")
       .setEnabled(false)
       .setClientId("CLIENT_ID")
-      .setIssuer("https://oidc.com/issuer");
+      .setClientSecret("CLIENT_SECRET")
+      .setIssuer("https://oidc.com/issuer")
+      .setCodeResponseType(true)
+      .setIdTokenResponseType(false);
 
     assertEquals("oidc.provider-id", createRequest.getProviderId());
     Map<String,Object> properties = createRequest.getProperties();
-    assertEquals(properties.size(), 4);
+    assertEquals(properties.size(), 6);
     assertEquals("DISPLAY_NAME", (String) properties.get("displayName"));
     assertFalse((boolean) properties.get("enabled"));
     assertEquals("CLIENT_ID", (String) properties.get("clientId"));
+    assertEquals("CLIENT_SECRET", properties.get("clientSecret"));
     assertEquals("https://oidc.com/issuer", (String) properties.get("issuer"));
+
+    Map<String, Boolean> responseType = (Map<String, Boolean>) properties.get("responseType");
+    assertTrue(responseType.get("code"));
+    assertFalse(responseType.get("idToken"));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -99,6 +120,16 @@ public class OidcProviderConfigTest {
     new OidcProviderConfig.CreateRequest().setIssuer("not a valid url");
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testCreateRequestMissingClientSecret() {
+    new OidcProviderConfig.CreateRequest().setClientSecret(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testCreateRequestEmptyClientSecret() {
+    new OidcProviderConfig.CreateRequest().setClientSecret("");
+  }
+
   @Test
   public void testUpdateRequestFromOidcProviderConfig() throws IOException {
     OidcProviderConfig config = jsonFactory.fromString(OIDC_JSON_STRING, OidcProviderConfig.class);
@@ -117,15 +148,23 @@ public class OidcProviderConfigTest {
       .setDisplayName("DISPLAY_NAME")
       .setEnabled(false)
       .setClientId("CLIENT_ID")
-      .setIssuer("https://oidc.com/issuer");
+      .setClientSecret("CLIENT_SECRET")
+      .setIssuer("https://oidc.com/issuer")
+      .setCodeResponseType(true)
+      .setIdTokenResponseType(false);
 
     assertEquals("oidc.provider-id", updateRequest.getProviderId());
     Map<String,Object> properties = updateRequest.getProperties();
-    assertEquals(properties.size(), 4);
+    assertEquals(properties.size(), 6);
     assertEquals("DISPLAY_NAME", (String) properties.get("displayName"));
     assertFalse((boolean) properties.get("enabled"));
     assertEquals("CLIENT_ID", (String) properties.get("clientId"));
+    assertEquals("CLIENT_SECRET", (String) properties.get("clientSecret"));
     assertEquals("https://oidc.com/issuer", (String) properties.get("issuer"));
+
+    Map<String, Boolean> responseType = (Map<String, Boolean>) properties.get("responseType");
+    assertTrue(responseType.get("code"));
+    assertFalse(responseType.get("idToken"));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -156,5 +195,15 @@ public class OidcProviderConfigTest {
   @Test(expected = IllegalArgumentException.class)
   public void testUpdateRequestInvalidIssuerUrl() {
     new OidcProviderConfig.UpdateRequest("oidc.provider-id").setIssuer("not a valid url");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testUpdateRequestMissingClientSecret() {
+    new OidcProviderConfig.UpdateRequest("oidc.provider-id").setClientSecret(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testUpdateRequestEmptyClientSecret() {
+    new OidcProviderConfig.UpdateRequest("oidc.provider-id").setClientSecret("");
   }
 }

--- a/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
+++ b/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.api.client.googleapis.util.Utils;
-import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
 import java.io.IOException;
 import java.util.HashMap;

--- a/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
+++ b/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
@@ -25,6 +25,7 @@ import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 
@@ -58,6 +59,31 @@ public class OidcProviderConfigTest {
     assertEquals("https://oidc.com/issuer", config.getIssuer());
     assertTrue(config.isCodeResponseType());
     assertFalse(config.isIdTokenResponseType());
+  }
+
+  @Test
+  public void testEnsureResponseType() {
+    Map<String, Object> properties = new HashMap<>();
+
+    Map<String, Boolean> responseType = OidcProviderConfig.ensureResponseType(properties);
+
+    assertNotNull(responseType);
+    assertEquals(responseType, properties.get("responseType"));
+  }
+
+  @Test
+  public void testEnsureResponseType_alreadyPresent() {
+    Map<String, Object> properties = new HashMap<>();
+    Map<String, Boolean> responseType = new HashMap<>();
+    responseType.put("code", true);
+    properties.put("responseType", responseType);
+
+    Map<String, Boolean> returnedResponseType = OidcProviderConfig.ensureResponseType(properties);
+
+    assertEquals(responseType, returnedResponseType);
+    assertTrue(returnedResponseType.get("code"));
+    assertEquals(returnedResponseType.size(), 1);
+    assertEquals(responseType, properties.get("responseType"));
   }
 
   @Test

--- a/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
+++ b/src/test/java/com/google/firebase/auth/OidcProviderConfigTest.java
@@ -72,7 +72,7 @@ public class OidcProviderConfigTest {
   }
 
   @Test
-  public void testEnsureResponseType_alreadyPresent() {
+  public void testEnsureResponseTypeAlreadyPresent() {
     Map<String, Object> properties = new HashMap<>();
     Map<String, Boolean> responseType = new HashMap<>();
     responseType.put("code", true);

--- a/src/test/java/com/google/firebase/auth/multitenancy/TenantAwareFirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/multitenancy/TenantAwareFirebaseAuthIT.java
@@ -289,9 +289,8 @@ public class TenantAwareFirebaseAuthIT {
     assertEquals("ClientId", config.getClientId());
     assertEquals("ClientSecret", config.getClientSecret());
     assertEquals("https://oidc.com/issuer", config.getIssuer());
-    GenericJson responseType = config.getResponseType();
-    assertTrue((boolean) responseType.get("code"));
-    assertNull(responseType.get("idToken"));
+    assertTrue(config.isCodeResponseType());
+    assertFalse(config.isIdTokenResponseType());
 
     // Get provider config
     config = tenantAwareAuth.getOidcProviderConfigAsync(providerId).get();
@@ -300,9 +299,8 @@ public class TenantAwareFirebaseAuthIT {
     assertEquals("ClientId", config.getClientId());
     assertEquals("ClientSecret", config.getClientSecret());
     assertEquals("https://oidc.com/issuer", config.getIssuer());
-    responseType = config.getResponseType();
-    assertTrue((boolean) responseType.get("code"));
-    assertNull(responseType.get("idToken"));
+    assertTrue(config.isCodeResponseType());
+    assertFalse(config.isIdTokenResponseType());
 
     // Update provider config
     OidcProviderConfig.UpdateRequest updateRequest =
@@ -322,9 +320,8 @@ public class TenantAwareFirebaseAuthIT {
     assertEquals("NewClientId", config.getClientId());
     assertEquals("NewClientSecret", config.getClientSecret());
     assertEquals("https://oidc.com/new-issuer", config.getIssuer());
-    responseType = config.getResponseType();
-    assertTrue((boolean) responseType.get("idToken"));
-    assertNull(responseType.get("code"));
+    assertFalse(config.isCodeResponseType());
+    assertTrue(config.isIdTokenResponseType());
 
     // Delete provider config
     temporaryProviderConfig.deleteOidcProviderConfig(providerId);

--- a/src/test/java/com/google/firebase/auth/multitenancy/TenantAwareFirebaseAuthIT.java
+++ b/src/test/java/com/google/firebase/auth/multitenancy/TenantAwareFirebaseAuthIT.java
@@ -279,18 +279,30 @@ public class TenantAwareFirebaseAuthIT {
               .setDisplayName("DisplayName")
               .setEnabled(true)
               .setClientId("ClientId")
-              .setIssuer("https://oidc.com/issuer"));
+              .setClientSecret("ClientSecret")
+              .setIssuer("https://oidc.com/issuer")
+              .setCodeResponseType(true)
+              .setIdTokenResponseType(false));
+
     assertEquals(providerId, config.getProviderId());
     assertEquals("DisplayName", config.getDisplayName());
     assertEquals("ClientId", config.getClientId());
+    assertEquals("ClientSecret", config.getClientSecret());
     assertEquals("https://oidc.com/issuer", config.getIssuer());
+    GenericJson responseType = config.getResponseType();
+    assertTrue((boolean) responseType.get("code"));
+    assertNull(responseType.get("idToken"));
 
     // Get provider config
     config = tenantAwareAuth.getOidcProviderConfigAsync(providerId).get();
     assertEquals(providerId, config.getProviderId());
     assertEquals("DisplayName", config.getDisplayName());
     assertEquals("ClientId", config.getClientId());
+    assertEquals("ClientSecret", config.getClientSecret());
     assertEquals("https://oidc.com/issuer", config.getIssuer());
+    responseType = config.getResponseType();
+    assertTrue((boolean) responseType.get("code"));
+    assertNull(responseType.get("idToken"));
 
     // Update provider config
     OidcProviderConfig.UpdateRequest updateRequest =
@@ -298,13 +310,21 @@ public class TenantAwareFirebaseAuthIT {
             .setDisplayName("NewDisplayName")
             .setEnabled(false)
             .setClientId("NewClientId")
-            .setIssuer("https://oidc.com/new-issuer");
+            .setClientSecret("NewClientSecret")
+            .setIssuer("https://oidc.com/new-issuer")
+            .setCodeResponseType(false)
+            .setIdTokenResponseType(true);
+
     config = tenantAwareAuth.updateOidcProviderConfigAsync(updateRequest).get();
     assertEquals(providerId, config.getProviderId());
     assertEquals("NewDisplayName", config.getDisplayName());
     assertFalse(config.isEnabled());
     assertEquals("NewClientId", config.getClientId());
+    assertEquals("NewClientSecret", config.getClientSecret());
     assertEquals("https://oidc.com/new-issuer", config.getIssuer());
+    responseType = config.getResponseType();
+    assertTrue((boolean) responseType.get("idToken"));
+    assertNull(responseType.get("code"));
 
     // Delete provider config
     temporaryProviderConfig.deleteOidcProviderConfig(providerId);

--- a/src/test/resources/listOidc.json
+++ b/src/test/resources/listOidc.json
@@ -4,12 +4,22 @@
     "displayName" : "DISPLAY_NAME",
     "enabled" : true,
     "clientId" : "CLIENT_ID",
-    "issuer" : "https://oidc.com/issuer"
+    "clientSecret" : "CLIENT_SECRET",
+    "issuer" : "https://oidc.com/issuer",
+    "responseType" : {
+      "code": true,
+      "idToken": false
+    }
   }, {
     "name": "projects/projectId/oauthIdpConfigs/oidc.provider-id2",
     "displayName" : "DISPLAY_NAME",
     "enabled" : true,
     "clientId" : "CLIENT_ID",
-    "issuer" : "https://oidc.com/issuer"
+    "clientSecret" : "CLIENT_SECRET",
+    "issuer" : "https://oidc.com/issuer",
+    "responseType" : {
+      "code": true,
+      "idToken": false
+    }
   } ]
 }

--- a/src/test/resources/oidc.json
+++ b/src/test/resources/oidc.json
@@ -3,5 +3,10 @@
   "displayName" : "DISPLAY_NAME",
   "enabled" : true,
   "clientId" : "CLIENT_ID",
-  "issuer" : "https://oidc.com/issuer"
+  "clientSecret" : "CLIENT_SECRET",
+  "issuer" : "https://oidc.com/issuer",
+  "responseType" : {
+    "code": true,
+    "idToken": false
+  }
 }


### PR DESCRIPTION
Provides an option for developers to specify the OAuth response type for their OIDC provider (either one of these can be set:):
- id_token
- code (if set, must also set the client secret)
