### PR TITLE
chore: Setup a Dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This hopefully helps prevent dependencies falling behind. See #533 

More info on dependabot updates at https://docs.github.com/en/code-security/supply-chain-security/enabling-and-disabling-version-updates