### PR TITLE
fix(auth): adds missing EMAIL_NOT_FOUND error code

### DIFF
--- a/src/main/java/com/google/firebase/auth/AuthErrorCode.java
+++ b/src/main/java/com/google/firebase/auth/AuthErrorCode.java
@@ -37,6 +37,13 @@ public enum AuthErrorCode {
   EMAIL_ALREADY_EXISTS,
 
   /**
+   * No user record found for the given email, typically raised when
+   * generating a password reset link using an email for a user that
+   * is not already registered.
+   */
+  EMAIL_NOT_FOUND,
+
+  /**
    * The specified ID token is expired.
    */
   EXPIRED_ID_TOKEN,

--- a/src/main/java/com/google/firebase/auth/internal/AuthErrorHandler.java
+++ b/src/main/java/com/google/firebase/auth/internal/AuthErrorHandler.java
@@ -61,6 +61,12 @@ final class AuthErrorHandler extends AbstractHttpErrorHandler<FirebaseAuthExcept
                   "The user with the provided email already exists",
                   AuthErrorCode.EMAIL_ALREADY_EXISTS))
           .put(
+              "EMAIL_NOT_FOUND",
+              new AuthError(
+                  ErrorCode.NOT_FOUND,
+                  "No user record found for the given email",
+                  AuthErrorCode.EMAIL_NOT_FOUND))
+          .put(
               "INVALID_DYNAMIC_LINK_DOMAIN",
               new AuthError(
                   ErrorCode.INVALID_ARGUMENT,

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -1448,6 +1448,27 @@ public class FirebaseUserManagerTest {
   }
 
   @Test
+  public void testGeneratePasswordResetLinkWithEmailNotFoundError() {
+    TestResponseInterceptor interceptor =
+        initializeAppForUserManagementWithStatusCode(400,
+            "{\"error\": {\"message\": \"EMAIL_NOT_FOUND\"}}");
+    try {
+      FirebaseAuth.getInstance()
+            .generatePasswordResetLinkAsync("test@example.com").get();
+      fail("No error thrown for error response");
+    } catch (FirebaseAuthException e) {
+      assertEquals(ErrorCode.NOT_FOUND, e.getErrorCode());
+      assertEquals(
+          "No user record found for the given email (EMAIL_NOT_FOUND).",
+          e.getMessage());
+      assertTrue(e.getCause() instanceof HttpResponseException);
+      assertNotNull(e.getHttpResponse());
+      assertEquals(AuthErrorCode.EMAIL_NOT_FOUND, e.getAuthErrorCode());
+    }
+    checkUrl(interceptor, "POST", PROJECT_BASE_URL + "/accounts:sendOobCode");
+  }
+
+  @Test
   public void testGenerateEmailVerificationLinkNoEmail() throws Exception {
     initializeAppForUserManagement();
     try {


### PR DESCRIPTION
Catch EMAIL_NOT_FOUND when /accounts:sendOobCode is called for password reset on a user that does not exist.
