### PR TITLE
Revert "chore(deps): bump maven-javadoc-plugin from 3.2.0 to 3.3.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
                     <plugin>
                         <!-- Generate API docs using Doclava for the developer site -->
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.3.0</version>
+                        <version>3.2.0</version>
                         <executions>
                             <execution>
                                 <phase>site</phase>
@@ -310,7 +310,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Reverts firebase/firebase-admin-java#562

It appears that the `maven-javadoc-plugin 3.3.0` breaks the build flow in Java 1.7. Reverting this until we come up with a proper solution.
CI error: https://github.com/firebase/firebase-admin-java/runs/2784537466?check_suite_focus=true