### PR TITLE
Document that Scrypt is used by default

### DIFF
--- a/src/main/java/com/google/firebase/auth/hash/Scrypt.java
+++ b/src/main/java/com/google/firebase/auth/hash/Scrypt.java
@@ -26,7 +26,7 @@ import java.util.Map;
  * Represents the Scrypt password hashing algorithm. This is the
  * <a href="https://github.com/firebase/scrypt">modified Scrypt algorithm</a> used by
  * Firebase Auth. See {@link StandardScrypt} for the standard Scrypt algorithm. Can be used as an
- * instance of {@link com.google.firebase.auth.UserImportHash} when importing users.
+ * instance of {@link com.google.firebase.auth.UserImportHash} when importing users. This is the default algorithm for passwords.
  */
 public final class Scrypt extends RepeatableHash {
 

--- a/src/main/java/com/google/firebase/auth/hash/package-info.java
+++ b/src/main/java/com/google/firebase/auth/hash/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.auth.hash;
+
+/**
+ * By default, passwords are stored as Scrypt hashes. The hashing algorithm used to store passwords can be changed to any supported algorithm by changing the project config via the API or by <href="https://firebase.google.com/docs/auth/admin/import-users">reimporting</href> existing users.
+ */


### PR DESCRIPTION
This PR is trying to add documentation that Scrypt is the default algorithm for storing passwords. Since those docs are generated from the comments, this PR updates the comments for the Scrypt package, and adds a new `package-info.java` to give a high-level summary.

I'm not sure if I need to add anything else for the new `package-info`; all of the [examples](https://github.com/firebase/firebase-admin-java/search?p=1&q=filename%3Apackage-info.java) I found in this repo were being used to hide content. Happy to make changes; let me know.