### PR TITLE
Drop 500 from the retryable errorcode list

### DIFF
--- a/src/main/java/com/google/firebase/internal/ApiClientUtils.java
+++ b/src/main/java/com/google/firebase/internal/ApiClientUtils.java
@@ -34,7 +34,7 @@ public class ApiClientUtils {
 
   static final RetryConfig DEFAULT_RETRY_CONFIG = RetryConfig.builder()
       .setMaxRetries(4)
-      .setRetryStatusCodes(ImmutableList.of(500, 503))
+      .setRetryStatusCodes(ImmutableList.of(503))
       .setMaxIntervalMillis(60 * 1000)
       .build();
 

--- a/src/test/java/com/google/firebase/internal/ApiClientUtilsTest.java
+++ b/src/test/java/com/google/firebase/internal/ApiClientUtilsTest.java
@@ -66,7 +66,7 @@ public class ApiClientUtilsTest {
     assertEquals(4, retryConfig.getMaxRetries());
     assertEquals(60 * 1000, retryConfig.getMaxIntervalMillis());
     assertFalse(retryConfig.isRetryOnIOExceptions());
-    assertEquals(retryConfig.getRetryStatusCodes(), ImmutableList.of(500, 503));
+    assertEquals(retryConfig.getRetryStatusCodes(), ImmutableList.of(503));
   }
 
   @Test


### PR DESCRIPTION
[Google Cloud documentation](https://cloud.google.com/apis/design/errors#retrying_errors) has been updated to not consider 500 as a retryable error code. Update Admin SDK to align with that 