### PR TITLE
fix(auth): check if the user is disabled on checkRevoked=true for verifyIdToken and verifySessionCookie

### DIFF
--- a/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
@@ -256,11 +256,13 @@ public abstract class AbstractFirebaseAuth {
    * API call.
    *
    * @param idToken A Firebase ID token string to parse and verify.
-   * @param checkRevoked A boolean denoting whether to check if the tokens were revoked.
+   * @param checkRevoked A boolean denoting whether to check if the tokens were revoked or if
+   *                     the user is disabled.
    * @return A {@link FirebaseToken} representing the verified and decoded token.
    * @throws IllegalArgumentException If the token is null, empty, or if the {@link FirebaseApp}
    *     instance does not have a project ID associated with it.
-   * @throws FirebaseAuthException If an error occurs while parsing or validating the token.
+   * @throws FirebaseAuthException If an error occurs while parsing or validating the token, or if
+   *     the user is disabled.
    */
   public FirebaseToken verifyIdToken(@NonNull String idToken, boolean checkRevoked)
       throws FirebaseAuthException {
@@ -343,8 +345,11 @@ public abstract class AbstractFirebaseAuth {
    * checkRevoked} is true, throws a {@link FirebaseAuthException}.
    *
    * @param cookie A Firebase session cookie string to verify and parse.
-   * @param checkRevoked A boolean indicating whether to check if the cookie was explicitly revoked.
+   * @param checkRevoked A boolean indicating whether to check if the cookie was explicitly revoked
+   *                    or if the user is disabled.
    * @return A {@link FirebaseToken} representing the verified and decoded cookie.
+   * @throws FirebaseAuthException If an error occurs while parsing or validating the token, or if
+   *     the user is disabled.
    */
   public FirebaseToken verifySessionCookie(String cookie, boolean checkRevoked)
       throws FirebaseAuthException {

--- a/src/main/java/com/google/firebase/auth/AuthErrorCode.java
+++ b/src/main/java/com/google/firebase/auth/AuthErrorCode.java
@@ -108,4 +108,9 @@ public enum AuthErrorCode {
    * No user record found for the given identifier.
    */
   USER_NOT_FOUND,
+
+  /**
+   * The user record is disabled.
+   */
+  USER_DISABLED,
 }

--- a/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseAuthTest.java
@@ -29,7 +29,6 @@ import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonParser;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
-import com.google.api.client.util.ArrayMap;
 import com.google.api.core.ApiFuture;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -47,6 +46,7 @@ import com.google.firebase.testing.TestUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -629,8 +629,8 @@ public class FirebaseAuthTest {
     JsonParser parser = ApiClientUtils.getDefaultJsonFactory().createJsonParser(getUserResponse);
     GenericJson json =
         parser.parseAndClose(GenericJson.class);
-    ArrayMap<String, Object> users =
-        ((ArrayList<ArrayMap<String, Object>>) json.get("users")).get(0);
+    Map<String, Object> users =
+        ((ArrayList<Map<String, Object>>) json.get("users")).get(0);
     users.put("disabled", true);
 
     MockHttpTransport transport = new MockHttpTransport.Builder()


### PR DESCRIPTION
When `verifyIdToken` or `verifySessionCookie` is called with `checkResolved` set to `true` we also check if the user is disabled. If so, a `FirebaseAuthException` with the new AuthErrorCode `USER_DISABLED` is thrown.
