### PR TITLE
Update custom Doclet configuration for javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,16 +78,6 @@
 
     <profiles>
         <profile>
-            <!-- Disable Doclint on Java 8 and higher -->
-            <id>disable-java8-doclint</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <properties>
-                <additionalparam>-Xdoclint:none</additionalparam>
-            </properties>
-        </profile>
-        <profile>
             <id>devsite-apidocs</id>
             <activation>
                 <property>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
                             </additionalOptions>
                             <useStandardDocletOptions>false</useStandardDocletOptions>
                             <additionalJOption>-J-Xmx1024m</additionalJOption>
+                            <doclint>none</doclint>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -123,16 +123,16 @@
                                     <version>1.3</version>
                                 </additionalDependency>
                             </additionalDependencies>
-                            <additionalparam>
-                                -hdf book.path /docs/reference/_book.yaml
-                                -hdf project.path /_project.yaml
-                                -hdf devsite.path /docs/reference/admin/java/reference/
-                                -d ${project.build.directory}/apidocs
-                                -templatedir ${devsite.template}
-                                -toroot /docs/reference/admin/java/reference/
-                                -yaml _toc.yaml
-                                -warning 101
-                            </additionalparam>
+                            <additionalOptions>
+                                <additionalOption>-hdf book.path /docs/reference/_book.yaml</additionalOption>
+                                <additionalOption>-hdf project.path /_project.yaml</additionalOption>
+                                <additionalOption>-hdf devsite.path /docs/reference/admin/java/reference/</additionalOption>
+                                <additionalOption>-d ${project.build.directory}/apidocs</additionalOption>
+                                <additionalOption>-templatedir ${devsite.template}</additionalOption>
+                                <additionalOption>-toroot /docs/reference/admin/java/reference/</additionalOption>
+                                <additionalOption>-yaml _toc.yaml</additionalOption>
+                                <additionalOption>-warning 101</additionalOption>
+                            </additionalOptions>
                             <useStandardDocletOptions>false</useStandardDocletOptions>
                             <additionalJOption>-J-Xmx1024m</additionalJOption>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -334,9 +334,9 @@
                             <version>1.3</version>
                         </additionalDependency>
                     </additionalDependencies>
-                    <additionalparam>
-                        -warning 101
-                    </additionalparam>
+                    <additionalOptions>
+                        <additionalOption>-warning 101</additionalOption>
+                    </additionalOptions>
                     <useStandardDocletOptions>false</useStandardDocletOptions>
                     <additionalJOption>-J-Xmx1024m</additionalJOption>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,7 @@
                     </additionalOptions>
                     <useStandardDocletOptions>false</useStandardDocletOptions>
                     <additionalJOption>-J-Xmx1024m</additionalJOption>
+                    <doclint>none</doclint>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
- Starting with version 3.0 `javadoc` uses [updated parameter names](https://maven.apache.org/plugins/maven-javadoc-plugin/examples/alternate-doclet.html) in custom Doclet configurations, which affects our internal devsite scripts.
-  This PR updates the config to use the new parameters names.
- Tested and verified with the devsite script.
