### PR TITLE
fix: FirebaseOptions: move default initialization from Builder

### DIFF
--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -102,12 +102,12 @@ public final class FirebaseOptions {
       this.serviceAccountId = null;
     }
     this.storageBucket = builder.storageBucket;
-    this.httpTransport = checkNotNull(builder.httpTransport,
-        "FirebaseOptions must be initialized with a non-null HttpTransport.");
-    this.jsonFactory = checkNotNull(builder.jsonFactory,
-        "FirebaseOptions must be initialized with a non-null JsonFactory.");
-    this.threadManager = checkNotNull(builder.threadManager,
-        "FirebaseOptions must be initialized with a non-null ThreadManager.");
+    this.httpTransport = builder.httpTransport != null ? builder.httpTransport
+      : ApiClientUtils.getDefaultTransport();
+    this.jsonFactory = builder.jsonFactory != null ? builder.jsonFactory
+      : ApiClientUtils.getDefaultJsonFactory();
+    this.threadManager = builder.threadManager != null ? builder.threadManager
+      : FirebaseThreadManagers.DEFAULT_THREAD_MANAGER;
     checkArgument(builder.connectTimeout >= 0);
     this.connectTimeout = builder.connectTimeout;
     checkArgument(builder.readTimeout >= 0);
@@ -255,9 +255,9 @@ public final class FirebaseOptions {
     private String serviceAccountId;
     private Supplier<GoogleCredentials> credentialsSupplier;
     private FirestoreOptions firestoreOptions;
-    private HttpTransport httpTransport = ApiClientUtils.getDefaultTransport();
-    private JsonFactory jsonFactory = ApiClientUtils.getDefaultJsonFactory();
-    private ThreadManager threadManager = FirebaseThreadManagers.DEFAULT_THREAD_MANAGER;
+    private HttpTransport httpTransport;
+    private JsonFactory jsonFactory;
+    private ThreadManager threadManager;
     private int connectTimeout;
     private int readTimeout;
 

--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -421,7 +421,8 @@ public final class FirebaseOptions {
      * @return This <code>Builder</code> instance is returned so subsequent calls can be chained.
      */
     public Builder setHttpTransport(HttpTransport httpTransport) {
-      this.httpTransport = httpTransport;
+      this.httpTransport = checkNotNull(httpTransport,
+          "FirebaseOptions must be initialized with a non-null HttpTransport.");
       return this;
     }
 
@@ -433,7 +434,8 @@ public final class FirebaseOptions {
      * @return This <code>Builder</code> instance is returned so subsequent calls can be chained.
      */
     public Builder setJsonFactory(JsonFactory jsonFactory) {
-      this.jsonFactory = jsonFactory;
+      this.jsonFactory = checkNotNull(jsonFactory,
+            "FirebaseOptions must be initialized with a non-null JsonFactory.");
       return this;
     }
 
@@ -445,7 +447,8 @@ public final class FirebaseOptions {
      * @return This <code>Builder</code> instance is returned so subsequent calls can be chained.
      */
     public Builder setThreadManager(ThreadManager threadManager) {
-      this.threadManager = threadManager;
+      this.threadManager = checkNotNull(threadManager,
+            "FirebaseOptions must be initialized with a non-null ThreadManager.");
       return this;
     }
 

--- a/src/test/java/com/google/firebase/FirebaseOptionsTest.java
+++ b/src/test/java/com/google/firebase/FirebaseOptionsTest.java
@@ -169,6 +169,14 @@ public class FirebaseOptionsTest {
         .build();
   }
 
+  @Test(expected = NullPointerException.class)
+  public void createOptionsWithNullThreadManager() {
+    FirebaseOptions.builder()
+        .setCredentials(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
+        .setThreadManager(null)
+        .build();
+  }
+
   @Test
   public void checkToBuilderCreatesNewEquivalentInstance() {
     FirebaseOptions allValuesOptionsCopy = ALL_VALUES_OPTIONS.toBuilder().build();

--- a/src/test/java/com/google/firebase/FirebaseOptionsTest.java
+++ b/src/test/java/com/google/firebase/FirebaseOptionsTest.java
@@ -169,14 +169,6 @@ public class FirebaseOptionsTest {
         .build();
   }
 
-  @Test(expected = NullPointerException.class)
-  public void createOptionsWithNullThreadManager() {
-    FirebaseOptions.builder()
-        .setCredentials(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
-        .setThreadManager(null)
-        .build();
-  }
-
   @Test
   public void checkToBuilderCreatesNewEquivalentInstance() {
     FirebaseOptions allValuesOptionsCopy = ALL_VALUES_OPTIONS.toBuilder().build();


### PR DESCRIPTION
Use provided by Builder objects prior to init defaults.
Avoid `ClassNotFoundException` when JacksonFactory excluded
```
                FirebaseOptions.builder()
                    .setJsonFactory(Utils.getDefaultJsonFactory())
                    .build()
``````
        <dependency>
            <groupId>com.google.firebase</groupId>
            <artifactId>firebase-admin</artifactId>
            <exclusions>
                <exclusion>
                    <groupId>com.google.http-client</groupId>
                    <artifactId>google-http-client-jackson2</artifactId>
                </exclusion>
            </exclusions>
        </dependency>
```
