### PR TITLE
Bump libraries-bom from 20.9.0 to 25.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>20.9.0</version>
+                <version>25.2.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Updating BOM version to prevent https://github.com/googleapis/java-firestore/issues/822 from occurring when using Admin API instead of Firestore API directly. 20.9.0 uses an old version of Firestore which does not contain https://github.com/googleapis/java-firestore/pull/834. 