### PR TITLE
chore: Bump GCP BOM and pin `com.google.guava`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -420,6 +420,7 @@
         <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
+            <version>0.27.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
             <!-- Test Phase -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M6</version>
                 <configuration>
                     <skipTests>${skipUTs}</skipTests>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
             <!-- Test Phase -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M6</version>
+                <version>3.0.0</version>
                 <configuration>
                     <skipTests>${skipUTs}</skipTests>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
             <!-- Test Phase -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>2.22.2</version>
                 <configuration>
                     <skipTests>${skipUTs}</skipTests>
                 </configuration>
@@ -385,7 +385,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>25.3.0</version>
+                <version>21.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -435,7 +435,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <!-- for Java 7: -->
-            <version>31.1-android</version>
+            <version>30.1.1-android</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -383,6 +383,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.google.auth</groupId>
+                <artifactId>google-auth-library-oauth2-http</artifactId>
+                <version>0.26.0</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
                 <version>21.0.0</version>
@@ -416,11 +421,6 @@
         <dependency>
             <groupId>com.google.api</groupId>
             <artifactId>api-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.auth</groupId>
-            <artifactId>google-auth-library-oauth2-http</artifactId>
-            <version>0.27.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>20.9.0</version>
+                <version>25.3.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -434,6 +434,8 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <!-- for Java 7: -->
+            <version>31.1-android</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
             <!-- Test Phase -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <skipTests>${skipUTs}</skipTests>
                 </configuration>


### PR DESCRIPTION
- Test PR form pinning `com.google.guava` to a Java 7 supported version
