### PR TITLE
change: Drop support for Java 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [7, 8, 11]
+        java-version: [8, 11, 17]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Java Versions
 
-We currently support Java 8 and higher. Firebase Admin Java SDK also runs on [Google App
+We currently support Java 8 and higher. The Firebase Admin Java SDK also runs on [Google App
 Engine](https://cloud.google.com/appengine/).
 
 The Firebase Admin Java SDK follows the [Oracle Java SE

--- a/README.md
+++ b/README.md
@@ -46,11 +46,21 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Java Versions
 
-We currently support Java 7 and higher. However, Java 7 support is deprecated.
-We strongly encourage you to use Java 8 or higher as we will drop support for
-Java 7 in the next major version. Firebase Admin Java SDK also runs on [Google App
+We currently support Java 8 and higher. Firebase Admin Java SDK also runs on [Google App
 Engine](https://cloud.google.com/appengine/).
 
+The Firebase Admin Java SDK follows the [Oracle Java SE
+support roadmap](https://www.oracle.com/java/technologies/java-se-support-roadmap.html) 
+(see the Oracle Java SE Product Releases section).
+
+### For new development
+
+In general, new feature development occurs with support for the lowest Java LTS version
+covered by Oracle's Premier Support (which typically lasts 5 years from initial General
+Availability). If the minimum required JVM for a given library is changed, it is
+accompanied by a [semver](https://semver.org/) major release.
+
+Java 11 and Java 17 are the best choices for new development.
 
 ## Documentation
 

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
             <!-- Compile Phase -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
@@ -352,7 +352,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -385,14 +385,14 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>20.9.0</version>
+                <version>25.4.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.api-client</groupId>
                 <artifactId>google-api-client-bom</artifactId>
-                <version>1.34.1</version>
+                <version>1.35.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -460,7 +460,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.28.2</version>
+            <version>4.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Updated the minimum support platform version to Java 8
- Updated the CIs to run on Java 8, 11, and 17
- Upgraded the dependencies that were blocked on Java 7, including `libraries-bom`
- Fixes #678, #660, #655

RELEASE NOTE: Dropped support for Java 7. Developers should use Java 8 or higher when deploying the Admin SDK.

RELEASE NOTE: Upgraded the dependency on `libraries-bom` to v25 and higher. This in turns upgrades the dependencies on `google-cloud-firestore` and `google-cloud-storage` to the latest versions.