### PR TITLE
[chore] Release 9.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.google.firebase</groupId>
     <artifactId>firebase-admin</artifactId>
-    <version>8.2.0</version>
+    <version>9.0.0</version>
     <packaging>jar</packaging>
 
     <name>firebase-admin</name>


### PR DESCRIPTION
Breaking change: Dropped support for Java 7. Developers should use Java 8 or higher when deploying the Admin SDK.

Breaking change: Upgraded the dependency on `libraries-bom` to v25 and higher. This in turns upgrades the dependencies on `google-cloud-firestore` and `google-cloud-storage` to the latest versions.