### PR TITLE
fix(auth): Set emulator credentials when using the Auth emulator

### DIFF
--- a/src/main/java/com/google/firebase/ImplFirebaseTrampolines.java
+++ b/src/main/java/com/google/firebase/ImplFirebaseTrampolines.java
@@ -22,6 +22,8 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.firestore.FirestoreOptions;
+import com.google.firebase.auth.internal.Utils;
+import com.google.firebase.internal.EmulatorCredentials;
 import com.google.firebase.internal.FirebaseService;
 import com.google.firebase.internal.NonNull;
 
@@ -41,6 +43,9 @@ public final class ImplFirebaseTrampolines {
   private ImplFirebaseTrampolines() {}
 
   public static GoogleCredentials getCredentials(@NonNull FirebaseApp app) {
+    if (Utils.isEmulatorMode()) {
+      return new EmulatorCredentials();
+    }
     return app.getOptions().getCredentials();
   }
 

--- a/src/main/java/com/google/firebase/database/FirebaseDatabase.java
+++ b/src/main/java/com/google/firebase/database/FirebaseDatabase.java
@@ -35,6 +35,7 @@ import com.google.firebase.database.util.EmulatorHelper;
 import com.google.firebase.database.utilities.ParsedUrl;
 import com.google.firebase.database.utilities.Utilities;
 import com.google.firebase.database.utilities.Validation;
+import com.google.firebase.internal.EmulatorCredentials;
 import com.google.firebase.internal.FirebaseService;
 
 import com.google.firebase.internal.SdkUtils;
@@ -404,28 +405,6 @@ public class FirebaseDatabase {
     @Override
     public void destroy() {
       instance.destroy();
-    }
-  }
-
-  private static class EmulatorCredentials extends GoogleCredentials {
-
-    EmulatorCredentials() {
-      super(newToken());
-    }
-
-    private static AccessToken newToken() {
-      return new AccessToken("owner",
-          new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1)));
-    }
-
-    @Override
-    public AccessToken refreshAccessToken() {
-      return newToken();
-    }
-
-    @Override
-    public Map<String, List<String>> getRequestMetadata() throws IOException {
-      return ImmutableMap.of();
     }
   }
 }

--- a/src/main/java/com/google/firebase/internal/EmulatorCredentials.java
+++ b/src/main/java/com/google/firebase/internal/EmulatorCredentials.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.internal;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A Mock Credentials implementation that can be used with the Emulator Suite
+ */
+public final class EmulatorCredentials extends GoogleCredentials {
+
+  public EmulatorCredentials() {
+    super(newToken());
+  }
+
+  private static AccessToken newToken() {
+    return new AccessToken("owner",
+            new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1)));
+  }
+
+  @Override
+  public AccessToken refreshAccessToken() {
+    return newToken();
+  }
+
+  @Override
+  public Map<String, List<String>> getRequestMetadata() throws IOException {
+    return ImmutableMap.of();
+  }
+}

--- a/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
+++ b/src/test/java/com/google/firebase/auth/FirebaseUserManagerTest.java
@@ -71,7 +71,12 @@ public class FirebaseUserManagerTest {
 
   private static final String TEST_TOKEN = "token";
 
+  private static final String TEST_EMULATOR_TOKEN = "owner";
+
   private static final GoogleCredentials credentials = new MockGoogleCredentials(TEST_TOKEN);
+
+  private static final GoogleCredentials emulator_credentials =
+          new MockGoogleCredentials(TEST_EMULATOR_TOKEN);
 
   private static final ActionCodeSettings ACTION_CODE_SETTINGS = ActionCodeSettings.builder()
           .setUrl("https://example.dynamic.link")
@@ -2916,7 +2921,7 @@ public class FirebaseUserManagerTest {
     }
     MockHttpTransport transport = new MultiRequestMockHttpTransport(mocks);
     FirebaseApp.initializeApp(FirebaseOptions.builder()
-        .setCredentials(credentials)
+        .setCredentials(isEmulatorMode() ? emulator_credentials : credentials)
         .setHttpTransport(transport)
         .setProjectId("test-project-id")
         .build());
@@ -3014,7 +3019,7 @@ public class FirebaseUserManagerTest {
 
   private static void checkRequestHeaders(TestResponseInterceptor interceptor) {
     HttpHeaders headers = interceptor.getResponse().getRequest().getHeaders();
-    String auth = "Bearer " + TEST_TOKEN;
+    String auth = "Bearer " + (isEmulatorMode() ? TEST_EMULATOR_TOKEN : TEST_TOKEN);
     assertEquals(auth, headers.getFirstHeaderStringValue("Authorization"));
 
     String clientVersion = "Java/Admin/" + SdkUtils.getVersion();
@@ -3025,6 +3030,12 @@ public class FirebaseUserManagerTest {
     HttpRequest request = interceptor.getResponse().getRequest();
     assertEquals(method, request.getRequestMethod());
     assertEquals(url, request.getUrl().toString().split("\\?")[0]);
+  }
+
+  private static boolean isEmulatorMode() {
+    return !Strings.isNullOrEmpty(
+            FirebaseProcessEnvironment.getenv("FIREBASE_AUTH_EMULATOR_HOST")
+    );
   }
 
   private interface UserManagerOp {


### PR DESCRIPTION
If `FIREBASE_AUTH_EMULATOR_HOST` env var is set the SDK shouldn't connect to Auth servers for OAuth2 handshake. This PR sets the emulator credentials when emulator mode is set.

b/220373445