### PR TITLE
Fix a small bug in setCustomUserClaims() auth snippet

### DIFF
--- a/src/test/java/com/google/firebase/snippets/FirebaseAuthSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseAuthSnippets.java
@@ -151,13 +151,13 @@ public class FirebaseAuthSnippets {
     // [END update_user]
   }
 
-  public static void setCustomUserClaims(TenantAwareFirebaseAuth tenantAuth,
+  public static void setCustomUserClaims(
       String uid) throws FirebaseAuthException {
     // [START set_custom_user_claims]
     // Set admin privilege on the user corresponding to uid.
     Map<String, Object> claims = new HashMap<>();
     claims.put("admin", true);
-    tenantAuth.setCustomUserClaims(uid, claims);
+    FirebaseAuth.getInstance().setCustomUserClaims(uid, claims);
     // The new custom claims will propagate to the user's ID token the
     // next time a new one is issued.
     // [END set_custom_user_claims]
@@ -173,7 +173,7 @@ public class FirebaseAuthSnippets {
 
     // [START read_custom_user_claims]
     // Lookup the user associated with the specified uid.
-    UserRecord user = tenantAuth.getUser(uid);
+    UserRecord user = FirebaseAuth.getInstance().getUser(uid);
     System.out.println(user.getCustomClaims().get("admin"));
     // [END read_custom_user_claims]
   }
@@ -1148,6 +1148,33 @@ public class FirebaseAuthSnippets {
       //Allow access to requested admin resource.
     }
     // [END verify_custom_claims_tenant]
+  }
+
+  public static void setCustomUserClaimsTenant(TenantAwareFirebaseAuth tenantAuth,
+      String uid) throws FirebaseAuthException {
+    // [START set_custom_user_claims_tenant]
+    // Set admin privilege on the user corresponding to uid in a specific tenant.
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("admin", true);
+    tenantAuth.setCustomUserClaims(uid, claims);
+    // The new custom claims will propagate to the user's ID token the
+    // next time a new one is issued.
+    // [END set_custom_user_claims_tenant]
+
+    String idToken = "id_token";
+    // [START verify_custom_claims_tenant]
+    // Verify the ID token first.
+    FirebaseToken decoded = tenantAuth.verifyIdToken(idToken);
+    if (Boolean.TRUE.equals(decoded.getClaims().get("admin"))) {
+      // Allow access to requested admin resource.
+    }
+    // [END verify_custom_claims_tenant]
+
+    // [START read_custom_user_claims_tenant]
+    // Lookup the user associated with the specified uid in a specific tenant.
+    UserRecord user = tenantAuth.getUser(uid);
+    System.out.println(user.getCustomClaims().get("admin"));
+    // [END read_custom_user_claims_tenant]
   }
 
   public void generateEmailVerificationLinkTenant(

--- a/src/test/java/com/google/firebase/snippets/FirebaseAuthSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseAuthSnippets.java
@@ -151,13 +151,13 @@ public class FirebaseAuthSnippets {
     // [END update_user]
   }
 
-  public static void setCustomUserClaims(
+  public static void setCustomUserClaims(TenantAwareFirebaseAuth tenantAuth,
       String uid) throws FirebaseAuthException {
     // [START set_custom_user_claims]
     // Set admin privilege on the user corresponding to uid.
     Map<String, Object> claims = new HashMap<>();
     claims.put("admin", true);
-    FirebaseAuth.getInstance().setCustomUserClaims(uid, claims);
+    tenantAuth.setCustomUserClaims(uid, claims);
     // The new custom claims will propagate to the user's ID token the
     // next time a new one is issued.
     // [END set_custom_user_claims]
@@ -173,7 +173,7 @@ public class FirebaseAuthSnippets {
 
     // [START read_custom_user_claims]
     // Lookup the user associated with the specified uid.
-    UserRecord user = FirebaseAuth.getInstance().getUser(uid);
+    UserRecord user = tenantAuth.getUser(uid);
     System.out.println(user.getCustomClaims().get("admin"));
     // [END read_custom_user_claims]
   }


### PR DESCRIPTION
I was testing the code snippets in FirebaseAuthSnippets.java, which would be used this doc https://cloud.google.com/identity-platform/docs/multi-tenancy-managing-tenants#controlling_access_with_custom_claims. When testing the setCustomUserClaims(), I got an USER_NOT_FOUND error. 
"No user record found for the given identifier (USER_NOT_FOUND)."

I believe this error happens because `FirebaseAuth.getInstance()` doesn’t specify which tenant we are setting.
Therefore, using TenantAwareAuth instance for the corresponding tenant `tenantAuth` instead of `FirebaseAuth.getInstance()` fixes the issue.