### PR TITLE
Update passwordHash and passwordSalt to be base64 decoded before user import

### DIFF
--- a/src/test/java/com/google/firebase/snippets/FirebaseAuthSnippets.java
+++ b/src/test/java/com/google/firebase/snippets/FirebaseAuthSnippets.java
@@ -569,8 +569,8 @@ public class FirebaseAuthSnippets {
       List<ImportUserRecord> users = Collections.singletonList(ImportUserRecord.builder()
           .setUid("some-uid")
           .setEmail("user@example.com")
-          .setPasswordHash("password-hash".getBytes())
-          .setPasswordSalt("salt".getBytes())
+          .setPasswordHash(BaseEncoding.base64().decode("password-hash"))
+          .setPasswordSalt(BaseEncoding.base64().decode("salt"))
           .build());
       UserImportOptions options = UserImportOptions.withHash(
           Scrypt.builder()


### PR DESCRIPTION
**Issue**: Using the [importWithScrypt()](https://github.com/firebase/firebase-admin-java/blob/master/src/test/java/com/google/firebase/snippets/FirebaseAuthSnippets.java#L566) code snippet in the [public doc](https://firebase.google.com/docs/auth/admin/import-users#import_users_with_firebase_scrypt_hashed_passwords) will successfully import the user, but we will be unable to sign in because the password is changed.

This may be similar to this issue in Firebase Admin Go: [https://github.com/firebase/firebase-admin-go/issues/479](https://www.google.com/url?q=https://github.com/firebase/firebase-admin-go/issues/479&sa=D&source=buganizer&usg=AOvVaw1NQR0Ya_HBNq6nQolmle6w) and the fixes in [https://github.com/firebase/firebase-admin-go/pull/480](https://www.google.com/url?q=https://github.com/firebase/firebase-admin-go/pull/480&sa=D&source=buganizer&usg=AOvVaw3HuLfgng7APuSd_ZPY1jTH) and [https://github.com/firebase/firebase-admin-python/pull/652](https://www.google.com/url?q=https://github.com/firebase/firebase-admin-python/pull/652&sa=D&source=buganizer&usg=AOvVaw3-Hc9nmXTIZ7npaMro5FAK)

After this change, we can successfully import a user and sign in with the original password.

**Note**: I use `BaseEncoding.base64()` instead of `BaseEncoding.base64Url()` because `BaseEncoding.base64Url().decode` will throw an `Unrecognized character: +` exception if the password hash contains '+'. 