### PR TITLE
feat: add process override sdk

### DIFF
--- a/src/main/java/com/google/firebase/FirebaseApp.java
+++ b/src/main/java/com/google/firebase/FirebaseApp.java
@@ -223,6 +223,7 @@ public class FirebaseApp {
           !instances.containsKey(normalizedName),
           "FirebaseApp name " + normalizedName + " already exists!");
 
+      overrideProcessEnvironment(options);
       FirebaseApp firebaseApp = new FirebaseApp(normalizedName, options, tokenRefresherFactory);
       instances.put(normalizedName, firebaseApp);
       return firebaseApp;
@@ -582,5 +583,9 @@ public class FirebaseApp {
     parser.parseAndClose(builder);
     builder.setCredentials(APPLICATION_DEFAULT_CREDENTIALS);
     return builder.build();
+  }
+
+  private static void overrideProcessEnvironment(FirebaseOptions options) {
+    options.getProcessEnvironmentOverride().forEach(FirebaseProcessEnvironment::setenv);
   }
 }

--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -85,13 +85,15 @@ public final class FirebaseOptions {
   private final JsonFactory jsonFactory;
   private final ThreadManager threadManager;
   private final FirestoreOptions firestoreOptions;
+  private final Map<String, String> processEnvironmentOverride;
 
-  private FirebaseOptions(@NonNull final FirebaseOptions.Builder builder) {
+  private FirebaseOptions(@NonNull final Builder builder) {
     this.databaseUrl = builder.databaseUrl;
     this.credentialsSupplier = checkNotNull(
         builder.credentialsSupplier, "FirebaseOptions must be initialized with setCredentials().");
     this.databaseAuthVariableOverride = builder.databaseAuthVariableOverride;
     this.projectId = builder.projectId;
+    this.processEnvironmentOverride = builder.processEnvironmentOverride;
     if (!Strings.isNullOrEmpty(builder.storageBucket)) {
       checkArgument(!builder.storageBucket.startsWith("gs://"),
           "StorageBucket must not include 'gs://' prefix.");
@@ -207,6 +209,15 @@ public final class FirebaseOptions {
     return readTimeout;
   }
 
+  /**
+   * Return the process environment override values used for setting the env in {@link com.google.firebase.internal.FirebaseProcessEnvironment}
+   *
+   * @return {@link Map} of environment variables used for overriding
+   */
+  public Map<String, String> getProcessEnvironmentOverride() {
+    return processEnvironmentOverride;
+  }
+
   @NonNull
   ThreadManager getThreadManager() {
     return threadManager;
@@ -260,6 +271,7 @@ public final class FirebaseOptions {
     private ThreadManager threadManager;
     private int connectTimeout;
     private int readTimeout;
+    private Map<String, String> processEnvironmentOverride;
 
     /**
      * Constructs an empty builder.
@@ -492,6 +504,17 @@ public final class FirebaseOptions {
      */
     public Builder setReadTimeout(int readTimeout) {
       this.readTimeout = readTimeout;
+      return this;
+    }
+
+    /**
+     * Sets the environment variable to override in {@link com.google.firebase.internal.FirebaseProcessEnvironment}
+     *
+     * @param processEnvironmentOverride {@link Map} of key, value for environment variables
+     * @return This <code>Builder</code> instance is returned so subsequent calls can be chained.
+     */
+    public Builder setProcessEnvironmentOverride(Map<String, String> processEnvironmentOverride) {
+      this.processEnvironmentOverride = processEnvironmentOverride;
       return this;
     }
 

--- a/src/test/java/com/google/firebase/FirebaseOptionsTest.java
+++ b/src/test/java/com/google/firebase/FirebaseOptionsTest.java
@@ -33,6 +33,8 @@ import com.google.cloud.firestore.FirestoreOptions;
 import com.google.firebase.testing.ServiceAccount;
 import com.google.firebase.testing.TestUtils;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 
@@ -76,6 +78,8 @@ public class FirebaseOptionsTest {
     GsonFactory jsonFactory = new GsonFactory();
     NetHttpTransport httpTransport = new NetHttpTransport();
     FirestoreOptions firestoreOptions = FirestoreOptions.newBuilder().build();
+    Map<String, String> processEnvOverride = new HashMap<>();
+    processEnvOverride.put("FIREBASE_AUTH_EMULATOR_HOST", "localhost:9092");
     FirebaseOptions firebaseOptions =
         FirebaseOptions.builder()
             .setDatabaseUrl(FIREBASE_DB_URL)
@@ -86,6 +90,7 @@ public class FirebaseOptionsTest {
             .setHttpTransport(httpTransport)
             .setThreadManager(MOCK_THREAD_MANAGER)
             .setConnectTimeout(30000)
+            .setProcessEnvironmentOverride(processEnvOverride)
             .setReadTimeout(60000)
             .setFirestoreOptions(firestoreOptions)
             .build();
@@ -98,6 +103,7 @@ public class FirebaseOptionsTest {
     assertEquals(30000, firebaseOptions.getConnectTimeout());
     assertEquals(60000, firebaseOptions.getReadTimeout());
     assertSame(firestoreOptions, firebaseOptions.getFirestoreOptions());
+    assertEquals("localhost:9092", firebaseOptions.getProcessEnvironmentOverride().get("FIREBASE_AUTH_EMULATOR_HOST"));
 
     GoogleCredentials credentials = firebaseOptions.getCredentials();
     assertNotNull(credentials);


### PR DESCRIPTION
Allow for emulator port and host override using `localCache` from `FirebaseProcessEnvironment`