### PR TITLE
feat(fcm): Implement `sendEach`, `sendEachAsync`, `sendEachForMulticast` and `sendEachForMulticastAsync`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -482,5 +482,11 @@
             <version>2.1.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingTest.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingTest.java
@@ -16,6 +16,9 @@
 
 package com.google.firebase.messaging;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -23,17 +26,24 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import autovalue.shaded.org.jetbrains.annotations.Nullable;
 import com.google.api.client.json.GenericJson;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.firebase.ErrorCode;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.auth.MockGoogleCredentials;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
+
 import org.junit.After;
 import org.junit.Test;
 
@@ -45,6 +55,9 @@ public class FirebaseMessagingTest {
       .build();
   private static final Message EMPTY_MESSAGE = Message.builder()
       .setTopic("test-topic")
+      .build();
+  private static final Message EMPTY_MESSAGE_2 = Message.builder()
+      .setTopic("test-topic2")
       .build();
   private static final MulticastMessage TEST_MULTICAST_MESSAGE = MulticastMessage.builder()
       .addToken("test-fcm-token1")
@@ -259,6 +272,277 @@ public class FirebaseMessagingTest {
     }
 
     assertSame(EMPTY_MESSAGE, client.lastMessage);
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachWithNull() throws  FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId(null);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    try {
+      messaging.sendEach(null);
+      fail("No error thrown for null message list");
+    } catch (NullPointerException expected) {
+      // expected
+    }
+
+    assertNull(client.lastMessage);
+  }
+
+  @Test
+  public void testSendEachWithEmptyList() throws FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId(null);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    try {
+      messaging.sendEach(ImmutableList.<Message>of());
+      fail("No error thrown for empty message list");
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+
+    assertNull(client.lastMessage);
+  }
+
+  @Test
+  public void testSendEachWithTooManyMessages() throws FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId(null);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+    ImmutableList.Builder<Message> listBuilder = ImmutableList.builder();
+    for (int i = 0; i < 501; i++) {
+      listBuilder.add(Message.builder().setTopic("topic").build());
+    }
+
+    try {
+      messaging.sendEach(listBuilder.build(), false);
+      fail("No error thrown for too many messages in the list");
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+
+    assertNull(client.lastMessage);
+  }
+
+  @Test
+  public void testSendEach() throws FirebaseMessagingException {
+    ImmutableList<Message> messages = ImmutableList.of(EMPTY_MESSAGE, EMPTY_MESSAGE_2);
+    ImmutableList<String> messageIds = ImmutableList.of("test1", "test2");
+    Map<Message, SendResponse> messageMap = new HashMap<>();
+    for (int i = 0; i < 2; i++) {
+      messageMap.put(messages.get(i), SendResponse.fromMessageId(messageIds.get(i)));
+    }
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageMap(messageMap);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEach(messages);
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals(messageIds.get(i), response.getResponses().get(i).getMessageId());
+    }
+    assertThat(client.lastMessage, anyOf(is(EMPTY_MESSAGE), is(EMPTY_MESSAGE_2)));
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachDryRun() throws FirebaseMessagingException {
+    ImmutableList<Message> messages = ImmutableList.of(EMPTY_MESSAGE, EMPTY_MESSAGE_2);
+    ImmutableList<String> messageIds = ImmutableList.of("test1", "test2");
+    Map<Message, SendResponse> messageMap = new HashMap<>();
+    for (int i = 0; i < 2; i++) {
+      messageMap.put(messages.get(i), SendResponse.fromMessageId(messageIds.get(i)));
+    }
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageMap(messageMap);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEach(messages, true);
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals(messageIds.get(i), response.getResponses().get(i).getMessageId());
+    }
+    assertThat(client.lastMessage, anyOf(is(EMPTY_MESSAGE), is(EMPTY_MESSAGE_2)));
+    assertTrue(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachFailure() throws FirebaseMessagingException {
+    ImmutableList<Message> messages = ImmutableList.of(EMPTY_MESSAGE, EMPTY_MESSAGE_2);
+    Map<Message, SendResponse> messageMap = new HashMap<>();
+    messageMap.put(messages.get(0), SendResponse.fromMessageId("test"));
+    messageMap.put(messages.get(1), SendResponse.fromException(TEST_EXCEPTION));
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageMap(messageMap);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response =  messaging.sendEach(messages);
+
+    assertEquals(1, response.getFailureCount());
+    assertEquals(1, response.getSuccessCount());
+    assertEquals("test", response.getResponses().get(0).getMessageId());
+    assertEquals(TEST_EXCEPTION, response.getResponses().get(1).getException());
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachAsync() throws Exception {
+    ImmutableList<Message> messages = ImmutableList.of(EMPTY_MESSAGE, EMPTY_MESSAGE_2);
+    ImmutableList<String> messageIds = ImmutableList.of("test1", "test2");
+    Map<Message, SendResponse> messageMap = new HashMap<>();
+    for (int i = 0; i < 2; i++) {
+      messageMap.put(messages.get(i), SendResponse.fromMessageId(messageIds.get(i)));
+    }
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageMap(messageMap);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEachAsync(messages).get();
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals(messageIds.get(i), response.getResponses().get(i).getMessageId());
+    }
+    assertThat(client.lastMessage, anyOf(is(EMPTY_MESSAGE), is(EMPTY_MESSAGE_2)));
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachAsyncDryRun() throws Exception {
+    ImmutableList<Message> messages = ImmutableList.of(EMPTY_MESSAGE, EMPTY_MESSAGE_2);
+    ImmutableList<String> messageIds = ImmutableList.of("test1", "test2");
+    Map<Message, SendResponse> messageMap = new HashMap<>();
+    for (int i = 0; i < 2; i++) {
+      messageMap.put(messages.get(i), SendResponse.fromMessageId(messageIds.get(i)));
+    }
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageMap(messageMap);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEachAsync(messages, true).get();
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals(messageIds.get(i), response.getResponses().get(i).getMessageId());
+    }
+    assertThat(client.lastMessage, anyOf(is(EMPTY_MESSAGE), is(EMPTY_MESSAGE_2)));
+    assertTrue(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachAsyncFailure() throws Exception {
+    ImmutableList<Message> messages = ImmutableList.of(EMPTY_MESSAGE, EMPTY_MESSAGE_2);
+    Map<Message, SendResponse> messageMap = new HashMap<>();
+    messageMap.put(messages.get(0), SendResponse.fromMessageId("test"));
+    messageMap.put(messages.get(1), SendResponse.fromException(TEST_EXCEPTION));
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageMap(messageMap);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response =  messaging.sendEachAsync(messages).get();
+
+    assertEquals(1, response.getFailureCount());
+    assertEquals(1, response.getSuccessCount());
+    assertEquals("test", response.getResponses().get(0).getMessageId());
+    assertEquals(TEST_EXCEPTION, response.getResponses().get(1).getException());
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachForMulticastWithNull() throws  FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId(null);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    try {
+      messaging.sendEachForMulticast(null);
+      fail("No error thrown for null multicast message");
+    } catch (NullPointerException expected) {
+      // expected
+    }
+
+    assertNull(client.lastMessage);
+  }
+
+  @Test
+  public void testSendEachForMulticast() throws FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId("test");
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEachForMulticast(TEST_MULTICAST_MESSAGE);
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals("test", response.getResponses().get(i).getMessageId());
+    }
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachForMulticastDryRun() throws FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId("test");
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEachForMulticast(TEST_MULTICAST_MESSAGE, true);
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals("test", response.getResponses().get(i).getMessageId());
+    }
+    assertTrue(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachForMulticastFailure() throws FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromException(TEST_EXCEPTION);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response =  messaging.sendEachForMulticast(TEST_MULTICAST_MESSAGE);
+
+    assertEquals(2, response.getFailureCount());
+    assertEquals(0, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals(TEST_EXCEPTION, response.getResponses().get(i).getException());
+    }
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachForMulticastAsync() throws Exception {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId("test");
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEachForMulticastAsync(TEST_MULTICAST_MESSAGE).get();
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals("test", response.getResponses().get(i).getMessageId());
+    }
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachForMulticastAsyncDryRun() throws Exception {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId("test");
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEachForMulticastAsync(
+        TEST_MULTICAST_MESSAGE, true).get();
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals("test", response.getResponses().get(i).getMessageId());
+    }
+    assertTrue(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachForMulticastAsyncFailure() throws Exception {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromException(TEST_EXCEPTION);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response =  messaging.sendEachForMulticastAsync(TEST_MULTICAST_MESSAGE).get();
+
+    assertEquals(2, response.getFailureCount());
+    assertEquals(0, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals(TEST_EXCEPTION, response.getResponses().get(i).getException());
+    }
     assertFalse(client.isLastDryRun);
   }
 
@@ -681,6 +965,7 @@ public class FirebaseMessagingTest {
     private Message lastMessage;
     private List<Message> lastBatch;
     private boolean isLastDryRun;
+    private ImmutableMap<Message, SendResponse> messageMap;
 
     private MockFirebaseMessagingClient(
         String messageId, BatchResponse batchResponse, FirebaseMessagingException exception) {
@@ -689,8 +974,18 @@ public class FirebaseMessagingTest {
       this.exception = exception;
     }
 
+    private MockFirebaseMessagingClient(
+        Map<Message, SendResponse> messageMap, FirebaseMessagingException exception) {
+      this.messageMap = ImmutableMap.copyOf(messageMap);
+      this.exception = exception;
+    }
+
     static MockFirebaseMessagingClient fromMessageId(String messageId) {
       return new MockFirebaseMessagingClient(messageId, null, null);
+    }
+
+    static MockFirebaseMessagingClient fromMessageMap(Map<Message, SendResponse> messageMap) {
+      return new MockFirebaseMessagingClient(messageMap, null);
     }
 
     static MockFirebaseMessagingClient fromBatchResponse(BatchResponse batchResponse) {
@@ -702,13 +997,23 @@ public class FirebaseMessagingTest {
     }
 
     @Override
+    @Nullable
     public String send(Message message, boolean dryRun) throws FirebaseMessagingException {
       lastMessage = message;
       isLastDryRun = dryRun;
       if (exception != null) {
         throw exception;
       }
-      return messageId;
+      if (messageMap == null) {
+        return messageId;
+      }
+      if (!messageMap.containsKey(message)) {
+        return null;
+      }
+      if (messageMap.get(message).getException() != null) {
+        throw messageMap.get(message).getException();
+      }
+      return messageMap.get(message).getMessageId();
     }
 
     @Override


### PR DESCRIPTION
1. Add `sendEach`, `sendEachAsync`, `sendEachForMulticast` and `sendEachForMulticastAsync`
2. Deprecate `sendAll`, `sendAllAsync`, `sendMulticast` and `sendMulticastAsync`

`sendEach` vs `sendAll`

 1. `sendEach` sends one HTTP request to V1 Send endpoint for each
      message in the array.
     `sendAll` sends only one HTTP request to V1 Batch Send endpoint
      to send all messages in the array.
 3. `sendEach` calls `messagingClient.send` to send each message
      and constructs a `SendResponse` with the returned `messageId`.
      If `messagingClient.send` throws out an exception, `sendEach`
      will catch the exception and also turn it into a `SendResponse`
      with the exception in it.
      `sendEach` calls `ApiFutures.allAsList().get()` to execute all
      `messagingClient.send` calls asynchronously and wait for all of
      them to complete and construct a `BatchResponse` with all
      `SendResponse`s.
      Therefore, unlike `sendAll`, `sendEach` does not always throw
      an error for a total failure. It can also return a `BatchResponse`
      with only errors in it.  

`sendEachForMulticast` calls `sendEach` under the hood.
`sendEachAsync` is the async version of `sendEach`.
`sendEachForMulticastAsync` is the async version of `sendEachForMulticast`.

Will send another PR for integration tests
