### PR TITLE
Use HTTPS for license link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Java 11 and Java 17 are the best choices for new development.
 ## License and Terms
 
 Firebase Admin Java SDK is licensed under the
-[Apache License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+[Apache License, version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 Your use of Firebase is governed by the
 [Terms of Service for Firebase Services](https://firebase.google.com/terms/).


### PR DESCRIPTION
This PR changes to use HTTPS for license link in the `README.md` file.