### PR TITLE
Added FCM Root URL in FirebaseOptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <skipUTs>${skipTests}</skipUTs>
-        <netty.version>4.1.90.Final</netty.version>
+        <netty.version>4.1.91.Final</netty.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
             <!-- Test Phase -->
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0</version>
                 <configuration>
                     <skipTests>${skipUTs}</skipTests>
                 </configuration>

--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -74,6 +74,7 @@ public final class FirebaseOptions {
       };
 
   private final String databaseUrl;
+  private final String fcmRootUrl;
   private final String storageBucket;
   private final Supplier<GoogleCredentials> credentialsSupplier;
   private final Map<String, Object> databaseAuthVariableOverride;
@@ -101,6 +102,11 @@ public final class FirebaseOptions {
     } else {
       this.serviceAccountId = null;
     }
+    if (!Strings.isNullOrEmpty(builder.fcmRootUrl)) {
+      this.fcmRootUrl = builder.fcmRootUrl;
+    } else {
+      this.fcmRootUrl = null;
+    }
     this.storageBucket = builder.storageBucket;
     this.httpTransport = builder.httpTransport != null ? builder.httpTransport
       : ApiClientUtils.getDefaultTransport();
@@ -122,6 +128,15 @@ public final class FirebaseOptions {
    */
   public String getDatabaseUrl() {
     return databaseUrl;
+  }
+
+  /**
+   * Returns the Fcm Root URL that is used for Fcm Messaging.
+   *
+   * @return The Fcm Messaging URL supplied via {@link Builder#setFcmRootUrl}.
+   */
+  public String getFcmRootUrl() {
+    return fcmRootUrl;
   }
 
   /**
@@ -260,6 +275,7 @@ public final class FirebaseOptions {
     private ThreadManager threadManager;
     private int connectTimeout;
     private int readTimeout;
+    private String fcmRootUrl;
 
     /**
      * Constructs an empty builder.
@@ -290,6 +306,7 @@ public final class FirebaseOptions {
       connectTimeout = options.connectTimeout;
       readTimeout = options.readTimeout;
       firestoreOptions = options.firestoreOptions;
+      fcmRootUrl = options.fcmRootUrl;
     }
 
     /**
@@ -303,6 +320,20 @@ public final class FirebaseOptions {
      */
     public Builder setDatabaseUrl(@Nullable String databaseUrl) {
       this.databaseUrl = databaseUrl;
+      return this;
+    }
+
+    /**
+     * Sets the Fcm Root URL to use for Fcm Messaging.
+     *
+     * <p>See <a href="https://firebase.google.com/docs/admin/setup#initialize_the_sdk">
+     * Initialize the SDK</a> for code samples and detailed documentation.
+     *
+     * @param fcmRootUrl The Fcm Root URL to use for Fcm Messaging.
+     * @return This <code>Builder</code> instance is returned so subsequent calls can be chained.
+     */
+    public Builder setFcmRootUrl(@Nullable String fcmRootUrl) {
+      this.fcmRootUrl = fcmRootUrl;
       return this;
     }
 

--- a/src/main/java/com/google/firebase/messaging/FirebaseMessagingClientImpl.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessagingClientImpl.java
@@ -80,7 +80,8 @@ final class FirebaseMessagingClientImpl implements FirebaseMessagingClient {
 
   private FirebaseMessagingClientImpl(Builder builder) {
     checkArgument(!Strings.isNullOrEmpty(builder.projectId));
-    String fcmRootUrl = Strings.isNullOrEmpty(builder.fcmRootUrl) ? FCM_ROOT_URL : builder.fcmRootUrl;
+    String fcmRootUrl = Strings.isNullOrEmpty(builder.fcmRootUrl) ? FCM_ROOT_URL :
+            builder.fcmRootUrl;
     this.fcmSendUrl = String.format(String.format(
                     "%s/%s", fcmRootUrl, FCM_SEND_PATH),
             builder.projectId);
@@ -92,7 +93,8 @@ final class FirebaseMessagingClientImpl implements FirebaseMessagingClient {
     this.errorHandler = new MessagingErrorHandler(this.jsonFactory);
     this.httpClient = new ErrorHandlingHttpClient<>(requestFactory, jsonFactory, errorHandler)
       .setInterceptor(responseInterceptor);
-    this.batchClient = new MessagingBatchClient(requestFactory.getTransport(), jsonFactory, fcmRootUrl);
+    this.batchClient = new MessagingBatchClient(requestFactory.getTransport(),
+            jsonFactory, fcmRootUrl);
   }
 
   @VisibleForTesting

--- a/src/test/java/com/google/firebase/FirebaseOptionsTest.java
+++ b/src/test/java/com/google/firebase/FirebaseOptionsTest.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 public class FirebaseOptionsTest {
 
   private static final String FIREBASE_DB_URL = "https://mock-project.firebaseio.com";
+  private static final String FIREBASE_FCM_URL = "https://localhost";
   private static final String FIREBASE_STORAGE_BUCKET = "mock-storage-bucket";
   private static final String FIREBASE_PROJECT_ID = "explicit-project-id";
 
@@ -53,6 +54,7 @@ public class FirebaseOptionsTest {
           .setStorageBucket(FIREBASE_STORAGE_BUCKET)
           .setProjectId(FIREBASE_PROJECT_ID)
           .setCredentials(TestUtils.getCertCredential(ServiceAccount.EDITOR.asStream()))
+          .setFcmRootUrl(FIREBASE_FCM_URL)
           .build();
 
   private static final ThreadManager MOCK_THREAD_MANAGER = new ThreadManager() {
@@ -88,8 +90,10 @@ public class FirebaseOptionsTest {
             .setConnectTimeout(30000)
             .setReadTimeout(60000)
             .setFirestoreOptions(firestoreOptions)
+            .setFcmRootUrl(FIREBASE_FCM_URL)
             .build();
     assertEquals(FIREBASE_DB_URL, firebaseOptions.getDatabaseUrl());
+    assertEquals(FIREBASE_FCM_URL, firebaseOptions.getFcmRootUrl());
     assertEquals(FIREBASE_STORAGE_BUCKET, firebaseOptions.getStorageBucket());
     assertEquals(FIREBASE_PROJECT_ID, firebaseOptions.getProjectId());
     assertSame(jsonFactory, firebaseOptions.getJsonFactory());
@@ -183,6 +187,7 @@ public class FirebaseOptionsTest {
     assertNotSame(ALL_VALUES_OPTIONS, allValuesOptionsCopy);
     assertEquals(ALL_VALUES_OPTIONS.getCredentials(), allValuesOptionsCopy.getCredentials());
     assertEquals(ALL_VALUES_OPTIONS.getDatabaseUrl(), allValuesOptionsCopy.getDatabaseUrl());
+    assertEquals(ALL_VALUES_OPTIONS.getFcmRootUrl(), allValuesOptionsCopy.getFcmRootUrl());
     assertEquals(ALL_VALUES_OPTIONS.getProjectId(), allValuesOptionsCopy.getProjectId());
     assertEquals(ALL_VALUES_OPTIONS.getJsonFactory(), allValuesOptionsCopy.getJsonFactory());
     assertEquals(ALL_VALUES_OPTIONS.getHttpTransport(), allValuesOptionsCopy.getHttpTransport());

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingClientImplTest.java
@@ -62,7 +62,8 @@ import org.junit.Test;
 public class FirebaseMessagingClientImplTest {
 
   private static final String TEST_FCM_URL =
-      "https://fcm.googleapis.com/v1/projects/test-project/messages:send";
+          "https://fcm.googleapis.com/v1/projects/test-project/messages:send";
+  private static final String TEST_FCM_BATCH_URL = "https://fcm.googleapis.com/batch";
 
   private static final List<Integer> HTTP_ERRORS = ImmutableList.of(401, 404, 500);
 
@@ -534,6 +535,7 @@ public class FirebaseMessagingClientImplTest {
       FirebaseMessagingClientImpl client = FirebaseMessagingClientImpl.fromApp(app);
 
       assertEquals(TEST_FCM_URL, client.getFcmSendUrl());
+      assertEquals(TEST_FCM_BATCH_URL, client.getFcmBatchUrl());
       assertSame(options.getJsonFactory(), client.getJsonFactory());
 
       HttpRequest request = client.getRequestFactory().buildGetRequest(


### PR DESCRIPTION
### Summary

Added FCM root URL in `FirebaseOptions` so that while constructing the `FirebaseApp` object, `fcmRootUrl` can be passed. This will help in changing the base URL to localhost while writing FTs(Functional Tests).


**Open Issue**: https://github.com/firebase/firebase-admin-java/issues/802