### PR TITLE
feat(fcm): Implement `sendEach`, `sendEachAsync`, `sendEachForMulticast` and `sendEachForMulticastAsync` (#785)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -482,5 +482,11 @@
             <version>2.1.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
@@ -155,7 +155,7 @@ public class FirebaseMessaging {
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
    *     delivery. An exception here or a {@link BatchResponse} with all failures indicates a total
-   *     failure -- i.e. none of the messages in the list could be sent. Partial failures or no
+   *     failure, meaning that none of the messages in the list could be sent. Partial failures or no
    *     failures are only indicated by a {@link BatchResponse}.
    */
   public BatchResponse sendEach(@NonNull List<Message> messages) throws FirebaseMessagingException {
@@ -181,7 +181,7 @@ public class FirebaseMessaging {
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
    *     delivery. An exception here or a {@link BatchResponse} with all failures indicates a total
-   *     failure -- i.e. none of the messages in the list could be sent. Partial failures or no
+   *     failure, meaning that none of the messages in the list could be sent. Partial failures or no
    *     failures are only indicated by a {@link BatchResponse}.
    */
   public BatchResponse sendEach(
@@ -266,7 +266,7 @@ public class FirebaseMessaging {
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
    *     delivery. An exception here or a {@link BatchResponse} with all failures indicates a total
-   *     failure -- i.e. none of the messages in the list could be sent. Partial failures or no
+   *     failure, meaning that none of the messages in the list could be sent. Partial failures or no
    *     failures are only indicated by a {@link BatchResponse}.
    */
   public BatchResponse sendEachForMulticast(
@@ -292,7 +292,7 @@ public class FirebaseMessaging {
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
    *     delivery. An exception here or a {@link BatchResponse} with all failures indicates a total
-   *     failure -- i.e. none of the messages in the list could be sent. Partial failures or no
+   *     failure, meaning that none of the messages in the list could be sent. Partial failures or no
    *     failures are only indicated by a {@link BatchResponse}.
    */
   public BatchResponse sendEachForMulticast(@NonNull MulticastMessage message, boolean dryRun)
@@ -339,8 +339,9 @@ public class FirebaseMessaging {
    * @param messages A non-null, non-empty list containing up to 500 messages.
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
-   *     delivery. An exception here indicates a total failure -- i.e. none of the messages in the
-   *     list could be sent. Partial failures are indicated by a {@link BatchResponse} return value.
+   *     delivery. An exception here indicates a total failure, meaning that none of the messages in
+   *     the list could be sent. Partial failures are indicated by a {@link BatchResponse} return
+   *     value.
    * @deprecated Use {@link #sendEach(List)} instead.
    */
   public BatchResponse sendAll(
@@ -365,8 +366,9 @@ public class FirebaseMessaging {
    * @param dryRun A boolean indicating whether to perform a dry run (validation only) of the send.
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
-   *     delivery. An exception here indicates a total failure -- i.e. none of the messages in the
-   *     list could be sent. Partial failures are indicated by a {@link BatchResponse} return value.
+   *     delivery. An exception here indicates a total failure, meaning that none of the messages in
+   *     the list could be sent. Partial failures are indicated by a {@link BatchResponse} return
+   *     value.
    * @deprecated Use {@link #sendEach(List, boolean)} instead.
    */
   public BatchResponse sendAll(
@@ -411,8 +413,8 @@ public class FirebaseMessaging {
    * @param message A non-null {@link MulticastMessage}
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
-   *     delivery. An exception here indicates a total failure -- i.e. the messages could not be
-   *     delivered to any recipient. Partial failures are indicated by a {@link BatchResponse}
+   *     delivery. An exception here indicates a total failure, meaning that the messages could not
+   *     be delivered to any recipient. Partial failures are indicated by a {@link BatchResponse}
    *     return value.
    * @deprecated Use {@link #sendEachForMulticast(MulticastMessage)} instead.
    */
@@ -438,8 +440,8 @@ public class FirebaseMessaging {
    * @param dryRun A boolean indicating whether to perform a dry run (validation only) of the send.
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
-   *     delivery. An exception here indicates a total failure -- i.e. the messages could not be
-   *     delivered to any recipient. Partial failures are indicated by a {@link BatchResponse}
+   *     delivery. An exception here indicates a total failure, meaning that the messages could not
+   *     be delivered to any recipient. Partial failures are indicated by a {@link BatchResponse}
    *     return value.
    * @deprecated Use {@link #sendEachForMulticast(MulticastMessage, boolean)} instead.
    */

--- a/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
@@ -155,8 +155,8 @@ public class FirebaseMessaging {
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
    *     delivery. An exception here or a {@link BatchResponse} with all failures indicates a total
-   *     failure, meaning that none of the messages in the list could be sent. Partial failures or no
-   *     failures are only indicated by a {@link BatchResponse}.
+   *     failure, meaning that none of the messages in the list could be sent. Partial failures or
+   *     no failures are only indicated by a {@link BatchResponse}.
    */
   public BatchResponse sendEach(@NonNull List<Message> messages) throws FirebaseMessagingException {
     return sendEachOp(messages, false).call();
@@ -181,8 +181,8 @@ public class FirebaseMessaging {
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
    *     delivery. An exception here or a {@link BatchResponse} with all failures indicates a total
-   *     failure, meaning that none of the messages in the list could be sent. Partial failures or no
-   *     failures are only indicated by a {@link BatchResponse}.
+   *     failure, meaning that none of the messages in the list could be sent. Partial failures or
+   *     no failures are only indicated by a {@link BatchResponse}.
    */
   public BatchResponse sendEach(
       @NonNull List<Message> messages, boolean dryRun) throws FirebaseMessagingException {
@@ -266,8 +266,8 @@ public class FirebaseMessaging {
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
    *     delivery. An exception here or a {@link BatchResponse} with all failures indicates a total
-   *     failure, meaning that none of the messages in the list could be sent. Partial failures or no
-   *     failures are only indicated by a {@link BatchResponse}.
+   *     failure, meaning that none of the messages in the list could be sent. Partial failures or
+   *     no failures are only indicated by a {@link BatchResponse}.
    */
   public BatchResponse sendEachForMulticast(
       @NonNull MulticastMessage message) throws FirebaseMessagingException {
@@ -292,8 +292,8 @@ public class FirebaseMessaging {
    * @return A {@link BatchResponse} indicating the result of the operation.
    * @throws FirebaseMessagingException If an error occurs while handing the messages off to FCM for
    *     delivery. An exception here or a {@link BatchResponse} with all failures indicates a total
-   *     failure, meaning that none of the messages in the list could be sent. Partial failures or no
-   *     failures are only indicated by a {@link BatchResponse}.
+   *     failure, meaning that none of the messages in the list could be sent. Partial failures or
+   *     no failures are only indicated by a {@link BatchResponse}.
    */
   public BatchResponse sendEachForMulticast(@NonNull MulticastMessage message, boolean dryRun)
     throws FirebaseMessagingException {

--- a/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
+++ b/src/main/java/com/google/firebase/messaging/FirebaseMessaging.java
@@ -145,11 +145,11 @@ public class FirebaseMessaging {
 
   /**
    * Sends each message in the given list via Firebase Cloud Messaging.
-   * Unlike {@link #sendAll(List)}, this method makes a single HTTP call for each message in the
+   * Unlike {@link #sendAll(List)}, this method makes an HTTP call for each message in the
    * given array.
    *
-   * <p>The responses list obtained by calling {@link BatchResponse#getResponses()} on the return
-   * value corresponds to the order of input messages.
+   * <p>The list of responses obtained by calling {@link BatchResponse#getResponses()} on the return
+   * value is in the same order as the input list.
    *
    * @param messages A non-null, non-empty list containing up to 500 messages.
    * @return A {@link BatchResponse} indicating the result of the operation.
@@ -165,7 +165,7 @@ public class FirebaseMessaging {
 
   /**
    * Sends each message in the given list via Firebase Cloud Messaging.
-   * Unlike {@link #sendAll(List)}, this method makes a single HTTP call for each message in the
+   * Unlike {@link #sendAll(List)}, this method makes an HTTP call for each message in the
    * given array.
    *
    * <p>If the {@code dryRun} option is set to true, the message will not be actually sent. Instead
@@ -173,8 +173,8 @@ public class FirebaseMessaging {
    * option is useful for determining whether an FCM registration has been deleted. But it cannot be
    * used to validate APNs tokens.
    *
-   * <p>The responses list obtained by calling {@link BatchResponse#getResponses()} on the return
-   * value corresponds to the order of input messages.
+   * <p>The list of responses obtained by calling {@link BatchResponse#getResponses()} on the return
+   * value is in the same order as the input list.
    *
    * @param messages A non-null, non-empty list containing up to 500 messages.
    * @param dryRun A boolean indicating whether to perform a dry run (validation only) of the send.
@@ -258,9 +258,9 @@ public class FirebaseMessaging {
    * Sends the given multicast message to all the FCM registration tokens specified in it.
    *
    * <p>This method uses the {@link #sendEach(List)} API under the hood to send the given
-   * message to all the target recipients. The responses list obtained by calling
-   * {@link BatchResponse#getResponses()} on the return value corresponds to the order of tokens
-   * in the {@link MulticastMessage}.
+   * message to all the target recipients. The list of responses obtained by calling
+   * {@link BatchResponse#getResponses()} on the return value is in the same order as the
+   * tokens in the {@link MulticastMessage}.
    *
    * @param message A non-null {@link MulticastMessage}
    * @return A {@link BatchResponse} indicating the result of the operation.
@@ -283,9 +283,9 @@ public class FirebaseMessaging {
    * used to validate APNs tokens.
    *
    * <p>This method uses the {@link #sendEach(List)} API under the hood to send the given
-   * message to all the target recipients. The responses list obtained by calling
-   * {@link BatchResponse#getResponses()} on the return value corresponds to the order of tokens
-   * in the {@link MulticastMessage}.
+   * message to all the target recipients. The list of responses obtained by calling
+   * {@link BatchResponse#getResponses()} on the return value is in the same order as the
+   * tokens in the {@link MulticastMessage}.
    *
    * @param message A non-null {@link MulticastMessage}.
    * @param dryRun A boolean indicating whether to perform a dry run (validation only) of the send.

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingTest.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import autovalue.shaded.org.jetbrains.annotations.Nullable;
 import com.google.api.client.json.GenericJson;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -37,8 +36,8 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.auth.MockGoogleCredentials;
+import com.google.firebase.internal.Nullable;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/com/google/firebase/messaging/FirebaseMessagingTest.java
+++ b/src/test/java/com/google/firebase/messaging/FirebaseMessagingTest.java
@@ -16,6 +16,9 @@
 
 package com.google.firebase.messaging;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -23,17 +26,24 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import autovalue.shaded.org.jetbrains.annotations.Nullable;
 import com.google.api.client.json.GenericJson;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.firebase.ErrorCode;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.auth.MockGoogleCredentials;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
+
 import org.junit.After;
 import org.junit.Test;
 
@@ -45,6 +55,9 @@ public class FirebaseMessagingTest {
       .build();
   private static final Message EMPTY_MESSAGE = Message.builder()
       .setTopic("test-topic")
+      .build();
+  private static final Message EMPTY_MESSAGE_2 = Message.builder()
+      .setTopic("test-topic2")
       .build();
   private static final MulticastMessage TEST_MULTICAST_MESSAGE = MulticastMessage.builder()
       .addToken("test-fcm-token1")
@@ -259,6 +272,277 @@ public class FirebaseMessagingTest {
     }
 
     assertSame(EMPTY_MESSAGE, client.lastMessage);
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachWithNull() throws  FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId(null);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    try {
+      messaging.sendEach(null);
+      fail("No error thrown for null message list");
+    } catch (NullPointerException expected) {
+      // expected
+    }
+
+    assertNull(client.lastMessage);
+  }
+
+  @Test
+  public void testSendEachWithEmptyList() throws FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId(null);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    try {
+      messaging.sendEach(ImmutableList.<Message>of());
+      fail("No error thrown for empty message list");
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+
+    assertNull(client.lastMessage);
+  }
+
+  @Test
+  public void testSendEachWithTooManyMessages() throws FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId(null);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+    ImmutableList.Builder<Message> listBuilder = ImmutableList.builder();
+    for (int i = 0; i < 501; i++) {
+      listBuilder.add(Message.builder().setTopic("topic").build());
+    }
+
+    try {
+      messaging.sendEach(listBuilder.build(), false);
+      fail("No error thrown for too many messages in the list");
+    } catch (IllegalArgumentException expected) {
+      // expected
+    }
+
+    assertNull(client.lastMessage);
+  }
+
+  @Test
+  public void testSendEach() throws FirebaseMessagingException {
+    ImmutableList<Message> messages = ImmutableList.of(EMPTY_MESSAGE, EMPTY_MESSAGE_2);
+    ImmutableList<String> messageIds = ImmutableList.of("test1", "test2");
+    Map<Message, SendResponse> messageMap = new HashMap<>();
+    for (int i = 0; i < 2; i++) {
+      messageMap.put(messages.get(i), SendResponse.fromMessageId(messageIds.get(i)));
+    }
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageMap(messageMap);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEach(messages);
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals(messageIds.get(i), response.getResponses().get(i).getMessageId());
+    }
+    assertThat(client.lastMessage, anyOf(is(EMPTY_MESSAGE), is(EMPTY_MESSAGE_2)));
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachDryRun() throws FirebaseMessagingException {
+    ImmutableList<Message> messages = ImmutableList.of(EMPTY_MESSAGE, EMPTY_MESSAGE_2);
+    ImmutableList<String> messageIds = ImmutableList.of("test1", "test2");
+    Map<Message, SendResponse> messageMap = new HashMap<>();
+    for (int i = 0; i < 2; i++) {
+      messageMap.put(messages.get(i), SendResponse.fromMessageId(messageIds.get(i)));
+    }
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageMap(messageMap);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEach(messages, true);
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals(messageIds.get(i), response.getResponses().get(i).getMessageId());
+    }
+    assertThat(client.lastMessage, anyOf(is(EMPTY_MESSAGE), is(EMPTY_MESSAGE_2)));
+    assertTrue(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachFailure() throws FirebaseMessagingException {
+    ImmutableList<Message> messages = ImmutableList.of(EMPTY_MESSAGE, EMPTY_MESSAGE_2);
+    Map<Message, SendResponse> messageMap = new HashMap<>();
+    messageMap.put(messages.get(0), SendResponse.fromMessageId("test"));
+    messageMap.put(messages.get(1), SendResponse.fromException(TEST_EXCEPTION));
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageMap(messageMap);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response =  messaging.sendEach(messages);
+
+    assertEquals(1, response.getFailureCount());
+    assertEquals(1, response.getSuccessCount());
+    assertEquals("test", response.getResponses().get(0).getMessageId());
+    assertEquals(TEST_EXCEPTION, response.getResponses().get(1).getException());
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachAsync() throws Exception {
+    ImmutableList<Message> messages = ImmutableList.of(EMPTY_MESSAGE, EMPTY_MESSAGE_2);
+    ImmutableList<String> messageIds = ImmutableList.of("test1", "test2");
+    Map<Message, SendResponse> messageMap = new HashMap<>();
+    for (int i = 0; i < 2; i++) {
+      messageMap.put(messages.get(i), SendResponse.fromMessageId(messageIds.get(i)));
+    }
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageMap(messageMap);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEachAsync(messages).get();
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals(messageIds.get(i), response.getResponses().get(i).getMessageId());
+    }
+    assertThat(client.lastMessage, anyOf(is(EMPTY_MESSAGE), is(EMPTY_MESSAGE_2)));
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachAsyncDryRun() throws Exception {
+    ImmutableList<Message> messages = ImmutableList.of(EMPTY_MESSAGE, EMPTY_MESSAGE_2);
+    ImmutableList<String> messageIds = ImmutableList.of("test1", "test2");
+    Map<Message, SendResponse> messageMap = new HashMap<>();
+    for (int i = 0; i < 2; i++) {
+      messageMap.put(messages.get(i), SendResponse.fromMessageId(messageIds.get(i)));
+    }
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageMap(messageMap);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEachAsync(messages, true).get();
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals(messageIds.get(i), response.getResponses().get(i).getMessageId());
+    }
+    assertThat(client.lastMessage, anyOf(is(EMPTY_MESSAGE), is(EMPTY_MESSAGE_2)));
+    assertTrue(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachAsyncFailure() throws Exception {
+    ImmutableList<Message> messages = ImmutableList.of(EMPTY_MESSAGE, EMPTY_MESSAGE_2);
+    Map<Message, SendResponse> messageMap = new HashMap<>();
+    messageMap.put(messages.get(0), SendResponse.fromMessageId("test"));
+    messageMap.put(messages.get(1), SendResponse.fromException(TEST_EXCEPTION));
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageMap(messageMap);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response =  messaging.sendEachAsync(messages).get();
+
+    assertEquals(1, response.getFailureCount());
+    assertEquals(1, response.getSuccessCount());
+    assertEquals("test", response.getResponses().get(0).getMessageId());
+    assertEquals(TEST_EXCEPTION, response.getResponses().get(1).getException());
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachForMulticastWithNull() throws  FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId(null);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    try {
+      messaging.sendEachForMulticast(null);
+      fail("No error thrown for null multicast message");
+    } catch (NullPointerException expected) {
+      // expected
+    }
+
+    assertNull(client.lastMessage);
+  }
+
+  @Test
+  public void testSendEachForMulticast() throws FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId("test");
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEachForMulticast(TEST_MULTICAST_MESSAGE);
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals("test", response.getResponses().get(i).getMessageId());
+    }
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachForMulticastDryRun() throws FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId("test");
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEachForMulticast(TEST_MULTICAST_MESSAGE, true);
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals("test", response.getResponses().get(i).getMessageId());
+    }
+    assertTrue(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachForMulticastFailure() throws FirebaseMessagingException {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromException(TEST_EXCEPTION);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response =  messaging.sendEachForMulticast(TEST_MULTICAST_MESSAGE);
+
+    assertEquals(2, response.getFailureCount());
+    assertEquals(0, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals(TEST_EXCEPTION, response.getResponses().get(i).getException());
+    }
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachForMulticastAsync() throws Exception {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId("test");
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEachForMulticastAsync(TEST_MULTICAST_MESSAGE).get();
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals("test", response.getResponses().get(i).getMessageId());
+    }
+    assertFalse(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachForMulticastAsyncDryRun() throws Exception {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromMessageId("test");
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response = messaging.sendEachForMulticastAsync(
+        TEST_MULTICAST_MESSAGE, true).get();
+
+    assertEquals(2, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals("test", response.getResponses().get(i).getMessageId());
+    }
+    assertTrue(client.isLastDryRun);
+  }
+
+  @Test
+  public void testSendEachForMulticastAsyncFailure() throws Exception {
+    MockFirebaseMessagingClient client = MockFirebaseMessagingClient.fromException(TEST_EXCEPTION);
+    FirebaseMessaging messaging = getMessagingForSend(Suppliers.ofInstance(client));
+
+    BatchResponse response =  messaging.sendEachForMulticastAsync(TEST_MULTICAST_MESSAGE).get();
+
+    assertEquals(2, response.getFailureCount());
+    assertEquals(0, response.getSuccessCount());
+    for (int i = 0; i < 2; i++) {
+      assertEquals(TEST_EXCEPTION, response.getResponses().get(i).getException());
+    }
     assertFalse(client.isLastDryRun);
   }
 
@@ -681,6 +965,7 @@ public class FirebaseMessagingTest {
     private Message lastMessage;
     private List<Message> lastBatch;
     private boolean isLastDryRun;
+    private ImmutableMap<Message, SendResponse> messageMap;
 
     private MockFirebaseMessagingClient(
         String messageId, BatchResponse batchResponse, FirebaseMessagingException exception) {
@@ -689,8 +974,18 @@ public class FirebaseMessagingTest {
       this.exception = exception;
     }
 
+    private MockFirebaseMessagingClient(
+        Map<Message, SendResponse> messageMap, FirebaseMessagingException exception) {
+      this.messageMap = ImmutableMap.copyOf(messageMap);
+      this.exception = exception;
+    }
+
     static MockFirebaseMessagingClient fromMessageId(String messageId) {
       return new MockFirebaseMessagingClient(messageId, null, null);
+    }
+
+    static MockFirebaseMessagingClient fromMessageMap(Map<Message, SendResponse> messageMap) {
+      return new MockFirebaseMessagingClient(messageMap, null);
     }
 
     static MockFirebaseMessagingClient fromBatchResponse(BatchResponse batchResponse) {
@@ -702,13 +997,23 @@ public class FirebaseMessagingTest {
     }
 
     @Override
+    @Nullable
     public String send(Message message, boolean dryRun) throws FirebaseMessagingException {
       lastMessage = message;
       isLastDryRun = dryRun;
       if (exception != null) {
         throw exception;
       }
-      return messageId;
+      if (messageMap == null) {
+        return messageId;
+      }
+      if (!messageMap.containsKey(message)) {
+        return null;
+      }
+      if (messageMap.get(message).getException() != null) {
+        throw messageMap.get(message).getException();
+      }
+      return messageMap.get(message).getMessageId();
     }
 
     @Override


### PR DESCRIPTION
* Add org.hamcrest as dependency for unit tests

* Implement sendEach, sendEachAsync, sendEachForMulticast and sendEachForMulticastAsync

`sendEach` vs `sendAll`
1. `sendEach` sends one HTTP request to V1 Send endpoint for each message in the array. `sendAll` sends only one HTTP request to V1 Batch Send endpoint to send all messages in the array.
2. `sendEach` calls `messagingClient.send` to send each message and constructs a `SendResponse` with the returned `messageId`. If `messagingClient.send` throws out an exception, `sendEach` will catch the exception and also turn it into a `SendResponse` with the exception in it. `sendEach` calls `ApiFutures.allAsList().get()` to execute all `messagingClient.send` calls asynchronously and wait for all of them to complete and construct a `BatchResponse` with all `SendResponse`s. Therefore, unlike `sendAll`, `sendEach` does not always throw an error for a total failure. It can also return a `BatchResponse` with only errors in it.

`sendEachForMulticast` calls `sendEach` under the hood. `sendEachAsync` is the async version of `sendEach`. `sendEachForMulticastAsync` is the async version of `sendEachForMulticast`.

* Add integration tests for batch-send re-implementation: testSendEach(), testSendFiveHundredWithSendEach(), testSendEachForMulticast()
