### PR TITLE
chore: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+######################################################################################################
+#
+#  Team structure and memberships
+#
+#######################################################################################################
+
+# These owners will be the default owners for everything in the repo.
+*       @lahirumaramba @firebase/jssdk-global-approvers


### PR DESCRIPTION
Adding a CODEOWNERS to the repo. We only have a default owners section for now and no separate owners for different components.

