### PR TITLE
added efficient assertions into the setIssuer

### DIFF
--- a/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
+++ b/src/main/java/com/google/firebase/auth/OidcProviderConfig.java
@@ -148,11 +148,12 @@ public final class OidcProviderConfig extends ProviderConfig {
      *     invalid.
      */
     public CreateRequest setIssuer(String issuer) {
-      checkArgument(!Strings.isNullOrEmpty(issuer), "Issuer must not be null or empty.");
+      assert issuer != null && !issuer.isEmpty() : "Issuer must not be null or empty.";
       assertValidUrl(issuer);
       properties.put("issuer", issuer);
       return this;
     }
+
 
     /**
      * Sets whether to enable the code response flow for the new provider. By default, this is not


### PR DESCRIPTION
added new assertion:
      assert issuer != null && !issuer.isEmpty() : "Issuer must not be null or empty.";

to the method "setIssuer" located at \src\main\java\com\google\firebase\auth\OidcProviderConfig.java

This assertion would prevent the application from running when the issuer variable is null or empty.

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
