### PR TITLE
Update `github.ref` value in `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
     #   3. with the label 'release:publish', and
     #   4. the title prefix '[chore] Release '.
     if: github.event.pull_request.merged &&
-      github.ref == 'master' &&
+      github.ref == 'refs/heads/master' &&
       contains(github.event.pull_request.labels.*.name, 'release:publish') &&
       startsWith(github.event.pull_request.title, '[chore] Release ')
 


### PR DESCRIPTION
- Fixes the release workflow to match the updates to `github.ref`
- `github.ref` now returns a fully-formed value `refs/heads/...`
 - See https://github.blog/changelog/2023-09-13-github-actions-updates-to-github_ref-and-github-ref/

