### PR TITLE
[chore] Update Github action workflows to fix node version and `set-output` deprecation warnings

### DIFF
--- a/.github/scripts/publish_preflight_check.sh
+++ b/.github/scripts/publish_preflight_check.sh
@@ -69,7 +69,7 @@ if [[ ! "${RELEASE_VERSION}" =~ ^([0-9]*)\.([0-9]*)\.([0-9]*)$ ]]; then
 fi
 
 echo_info "Extracted release version: ${RELEASE_VERSION}"
-echo "::set-output name=version::v${RELEASE_VERSION}"
+echo "version=v${RELEASE_VERSION}" >> $GITHUB_OUTPUT
 
 
 echo_info ""
@@ -132,12 +132,13 @@ readonly CHANGELOG=`${CURRENT_DIR}/generate_changelog.sh`
 echo "$CHANGELOG"
 
 # Parse and preformat the text to handle multi-line output.
-# See https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870
+# See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+# and https://github.com/github/docs/issues/21529#issue-1418590935
 FILTERED_CHANGELOG=`echo "$CHANGELOG" | grep -v "\\[INFO\\]"`
-FILTERED_CHANGELOG="${FILTERED_CHANGELOG//'%'/'%25'}"
-FILTERED_CHANGELOG="${FILTERED_CHANGELOG//$'\n'/'%0A'}"
-FILTERED_CHANGELOG="${FILTERED_CHANGELOG//$'\r'/'%0D'}"
-echo "::set-output name=changelog::${FILTERED_CHANGELOG}"
+FILTERED_CHANGELOG="${FILTERED_CHANGELOG//$'\''/'"'}"
+echo "changelog<<CHANGELOGEOF" >> $GITHUB_OUTPUT
+echo -e "$FILTERED_CHANGELOG" >> $GITHUB_OUTPUT
+echo "CHANGELOGEOF" >> $GITHUB_OUTPUT
 
 
 echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,12 @@ jobs:
         java-version: [8, 11, 17]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
 
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
+        distribution: 'zulu'
         java-version: ${{ matrix.java-version }}
 
     # Does the following:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,13 +29,14 @@ jobs:
 
     steps:
     - name: Checkout source for staging
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
 
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
+        distribution: 'zulu'
         java-version: 1.8
 
     - name: Compile, test and package
@@ -47,7 +48,7 @@ jobs:
     # Attach the packaged artifacts to the workflow output. These can be manually
     # downloaded for later inspection if necessary.
     - name: Archive artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
     # Attach the packaged artifacts to the workflow output. These can be manually
     # downloaded for later inspection if necessary.
     - name: Archive artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v1
       with:
         name: dist
         path: dist

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,11 +33,11 @@ jobs:
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
 
-    - name: Set up JDK 1.8
+    - name: Set up JDK 8
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: 1.8
+        java-version: 8
 
     - name: Compile, test and package
       run: ./.github/scripts/package_artifacts.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,11 @@ jobs:
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
 
-    - name: Set up JDK 1.8
+    - name: Set up JDK 8
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: 1.8
+        java-version: 8
 
     - name: Compile, test and package
       run: ./.github/scripts/package_artifacts.sh
@@ -83,11 +83,11 @@ jobs:
     - name: Checkout source for publish
       uses: actions/checkout@v4
 
-    - name: Set up JDK 1.8
+    - name: Set up JDK 8
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: 1.8
+        java-version: 8
 
     - name: Publish preflight check
       id: preflight

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,13 +40,14 @@ jobs:
     # via the 'ref' client parameter.
     steps:
     - name: Checkout source for staging
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
 
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
+        distribution: 'zulu'
         java-version: 1.8
 
     - name: Compile, test and package
@@ -58,7 +59,7 @@ jobs:
     # Attach the packaged artifacts to the workflow output. These can be manually
     # downloaded for later inspection if necessary.
     - name: Archive artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist
@@ -80,11 +81,12 @@ jobs:
 
     steps:
     - name: Checkout source for publish
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
+        distribution: 'zulu'
         java-version: 1.8
 
     - name: Publish preflight check
@@ -99,19 +101,13 @@ jobs:
         NEXUS_OSSRH_USERNAME: ${{ secrets.NEXUS_OSSRH_USERNAME }}
         NEXUS_OSSRH_PASSWORD: ${{ secrets.NEXUS_OSSRH_PASSWORD }}
 
-    # We pull this action from a custom fork of a contributor until
-    # https://github.com/actions/create-release/pull/32 is merged. Also note that v1 of
-    # this action does not support the "body" parameter.
+    # See: https://cli.github.com/manual/gh_release_create
     - name: Create release tag
-      uses: fleskesvor/create-release@1a72e235c178bf2ae6c51a8ae36febc24568c5fe
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.preflight.outputs.version }}
-        release_name: Firebase Admin Java SDK ${{ steps.preflight.outputs.version }}
-        body: ${{ steps.preflight.outputs.changelog }}
-        draft: false
-        prerelease: false
+      run: gh release create ${{ steps.preflight.outputs.version }}
+            --title "Firebase Admin Java SDK ${{ steps.preflight.outputs.version }}"
+            --notes '${{ steps.preflight.outputs.changelog }}'
 
     # Post to Twitter if explicitly opted-in by adding the label 'release:tweet'.
     - name: Post to Twitter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     # Attach the packaged artifacts to the workflow output. These can be manually
     # downloaded for later inspection if necessary.
     - name: Archive artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v1
       with:
         name: dist
         path: dist


### PR DESCRIPTION
- Swapped to Github CLI to create release tag
- `actions/checkout` v1 -> v4
- `actions/setup-java` v1 -> v4
- Replaced set-output with GITHUB_OUTPUT