### PR TITLE
Move mockserver-junit-rule-no-dependencies to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -497,6 +497,7 @@
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-junit-rule-no-dependencies</artifactId>
             <version>5.14.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Fixes #1016 by defining mockserver-junit-rule-no-dependencies as a `test` scoped dependency.

