### PR TITLE
fix: use .equals() instead of == for strings

### DIFF
--- a/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
+++ b/src/main/java/com/google/firebase/auth/AbstractFirebaseAuth.java
@@ -600,9 +600,10 @@ public abstract class AbstractFirebaseAuth {
     // Although we don't really advertise it, we want to also handle
     // non-federated idps with this call. So if we detect one of them, we'll
     // reroute this request appropriately.
-    if (providerId == "phone") {
+    if ("phone".equals(providerId)) {
       return this.getUserByPhoneNumberOp(uid);
-    } else if (providerId == "email") {
+    }
+    if ("email".equals(providerId)) {
       return this.getUserByEmailOp(uid);
     }
 

--- a/src/main/java/com/google/firebase/auth/UserRecord.java
+++ b/src/main/java/com/google/firebase/auth/UserRecord.java
@@ -487,7 +487,7 @@ public class UserRecord implements UserInfo {
           // *and* by setting providersToUnlink to include 'phone', then we'll reject that. Though
           // it might also be reasonable to relax this restriction and just unlink it.
           for (String dp : deleteProviderIterable) {
-            if (dp == "phone") {
+            if ("phone".equals(dp)) {
               throw new IllegalArgumentException(
                   "Both UpdateRequest.setPhoneNumber(null) and "
                   + "UpdateRequest.setProvidersToUnlink(['phone']) were set. To unlink from a "
@@ -601,7 +601,7 @@ public class UserRecord implements UserInfo {
       for (String id : providerIds) {
         checkArgument(!Strings.isNullOrEmpty(id), "providerIds must not be null or empty");
 
-        if (id == "phone" && properties.containsKey("phoneNumber")
+        if ("phone".equals(id) && properties.containsKey("phoneNumber")
             && properties.get("phoneNumber") == null) {
           // If we've been told to unlink the phone provider both via setting phoneNumber to null
           // *and* by setting providersToUnlink to include 'phone', then we'll reject that. Though


### PR DESCRIPTION
Simple fix for string comparison.

From what I could see these changes are already covered by unit tests and I was not sure how to add new ones to test this specific scenario.