### PR TITLE
chore: Rearrange firebase admin pom deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,18 +389,15 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>com.google.api-client</groupId>
-                <artifactId>google-api-client-bom</artifactId>
-                <version>2.7.2</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
         <!-- Google Cloud Platform dependencies -->
+        <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-oauth2-http</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.google.api-client</groupId>
             <artifactId>google-api-client</artifactId>
@@ -416,10 +413,6 @@
         <dependency>
             <groupId>com.google.api</groupId>
             <artifactId>api-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.auth</groupId>
-            <artifactId>google-auth-library-oauth2-http</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
Following https://github.com/firebase/firebase-admin-java/issues/1045

Changes:
- Remove the duplicate google-api-client-bom as it is already part of libaries-bom
- Move google-auth-library-oauth2-http in front of google-api-client. This is to help ensure that the two auth modules (oauth2 and credentials) have the versions match. Maven's dep resolution strategy searches the path of the first deps it sees if the possible deps have the same number of layers away (https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Transitive_Dependencies)