### PR TITLE
Allow StorageOptions to override storage host

### DIFF
--- a/src/main/java/com/google/firebase/FirebaseOptions.java
+++ b/src/main/java/com/google/firebase/FirebaseOptions.java
@@ -24,6 +24,7 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.util.Key;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.firestore.FirestoreOptions;
+import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -86,6 +87,8 @@ public final class FirebaseOptions {
   private final ThreadManager threadManager;
   private final FirestoreOptions firestoreOptions;
 
+  private final StorageOptions storageOptions;
+
   private FirebaseOptions(@NonNull final FirebaseOptions.Builder builder) {
     this.databaseUrl = builder.databaseUrl;
     this.credentialsSupplier = checkNotNull(
@@ -113,6 +116,7 @@ public final class FirebaseOptions {
     checkArgument(builder.readTimeout >= 0);
     this.readTimeout = builder.readTimeout;
     this.firestoreOptions = builder.firestoreOptions;
+    this.storageOptions = builder.storageOptions;
   }
 
   /**
@@ -216,6 +220,10 @@ public final class FirebaseOptions {
     return firestoreOptions;
   }
 
+  public StorageOptions getStorageOptions() {
+    return storageOptions;
+  }
+
   /**
    * Creates an empty builder.
    *
@@ -250,6 +258,8 @@ public final class FirebaseOptions {
 
     @Key("storageBucket")
     private String storageBucket;
+
+    private StorageOptions storageOptions;
 
     @Key("serviceAccountId")
     private String serviceAccountId;
@@ -290,6 +300,7 @@ public final class FirebaseOptions {
       connectTimeout = options.connectTimeout;
       readTimeout = options.readTimeout;
       firestoreOptions = options.firestoreOptions;
+      storageOptions = options.storageOptions;
     }
 
     /**
@@ -492,6 +503,11 @@ public final class FirebaseOptions {
      */
     public Builder setReadTimeout(int readTimeout) {
       this.readTimeout = readTimeout;
+      return this;
+    }
+
+    public Builder setStorageOptions(StorageOptions storageOptions) {
+      this.storageOptions = storageOptions;
       return this;
     }
 

--- a/src/main/java/com/google/firebase/cloud/StorageClient.java
+++ b/src/main/java/com/google/firebase/cloud/StorageClient.java
@@ -19,6 +19,8 @@ package com.google.firebase.cloud;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.FirestoreOptions;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
@@ -27,6 +29,7 @@ import com.google.common.base.Strings;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.ImplFirebaseTrampolines;
 import com.google.firebase.internal.FirebaseService;
+import com.google.firebase.internal.NonNull;
 
 /**
  * StorageClient provides access to Google Cloud Storage APIs. You can specify a default cloud
@@ -56,14 +59,28 @@ public class StorageClient {
     StorageClientService service = ImplFirebaseTrampolines.getService(app, SERVICE_ID,
         StorageClientService.class);
     if (service == null) {
-      Storage storage = StorageOptions.newBuilder()
+      StorageOptions userOptions =  app.getOptions().getStorageOptions();
+      StorageOptions.Builder builder = userOptions != null ? userOptions.toBuilder() :
+          StorageOptions.newBuilder();
+      Storage storage = builder
           .setCredentials(ImplFirebaseTrampolines.getCredentials(app))
+          .setProjectId(ImplFirebaseTrampolines.getProjectId(app))
           .build()
           .getService();
       StorageClient client = new StorageClient(app, storage);
       service = ImplFirebaseTrampolines.addService(app, new StorageClientService(client));
     }
     return service.getInstance();
+  }
+
+  @NonNull
+  public static Storage getStorage(FirebaseApp app) {
+    return getInstance(app).storage;
+  }
+
+  @NonNull
+  public static Storage getStorage() {
+    return getStorage(FirebaseApp.getInstance());
   }
 
   /**

--- a/src/test/java/com/google/firebase/cloud/StorageClientIT.java
+++ b/src/test/java/com/google/firebase/cloud/StorageClientIT.java
@@ -21,10 +21,16 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import com.google.common.io.CharStreams;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
 import com.google.firebase.testing.IntegrationTestUtils;
+import com.google.firebase.testing.ServiceAccount;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -87,5 +93,4 @@ public class StorageClientIT {
     String fileName = "data_" + System.currentTimeMillis() + ".txt";
     return bucket.create(fileName, contents.getBytes(), "text/plain");
   }
-
 }


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
To be able to use Firebase emulator and Firebase storage. I need to be able to override host.

**Describe the solution you'd like**
Allow us to pass StorageOption to FirebaseOption, to allow manually setting project id and host

This is discussed in https://github.com/firebase/firebase-admin-java/issues/874 and would solve that issue by allowing us to set the host directly instead of trying to use a non-standard env variable that doesn't even work

@regine-chan submitted this commit in a PR https://github.com/firebase/firebase-admin-java/pull/826 but it was abandoned, so I'm reviving the fix since we have a need
