### PR TITLE
feat(fcm): Support `proxy` field in FCM `AndroidNotification`

### DIFF
--- a/src/main/java/com/google/firebase/messaging/AndroidNotification.java
+++ b/src/main/java/com/google/firebase/messaging/AndroidNotification.java
@@ -112,6 +112,9 @@ public class AndroidNotification {
   @Key("notification_count")
   private final Integer notificationCount;
 
+  @Key("proxy")
+  private final String proxy;
+
   private static final Map<Priority, String> PRIORITY_MAP = 
       ImmutableMap.<Priority, String>builder()
           .put(Priority.MIN, "PRIORITY_MIN")
@@ -179,6 +182,11 @@ public class AndroidNotification {
       checkArgument(builder.notificationCount >= 0, 
           "notificationCount if specified must be zero or positive valued");
     }
+    if (builder.proxy != null) {
+      this.proxy = builder.proxy.name();
+    } else {
+      this.proxy = null;
+    }
     this.notificationCount = builder.notificationCount;
   }
 
@@ -194,11 +202,18 @@ public class AndroidNotification {
       return PRIORITY_MAP.get(this);
     }
   }
-  
+
   public enum Visibility {
     PRIVATE,
     PUBLIC,
     SECRET,
+  }
+
+  public enum Proxy {
+    PROXY_UNSPECIFIED,
+    ALLOW,
+    DENY,
+    IF_PRIORITY_LOWERED
   }
 
   /**
@@ -237,6 +252,7 @@ public class AndroidNotification {
     private LightSettings lightSettings;
     private Boolean defaultLightSettings;
     private Visibility visibility;
+    private Proxy proxy;
 
     private Builder() {}
 
@@ -599,6 +615,19 @@ public class AndroidNotification {
      */
     public Builder setNotificationCount(int notificationCount) {
       this.notificationCount = notificationCount;
+      return this;
+    }
+
+    /**
+     * Sets the proxy of this notification.
+     *
+     * @param proxy The proxy value. one of the values in
+     * {PROXY_UNSPECIFIED, ALLOW, DENY, IF_PRIORITY_LOWERED}
+     *
+     * @return This builder.
+     */
+    public Builder setProxy(Proxy proxy) {
+      this.proxy = proxy;
       return this;
     }
 

--- a/src/main/java/com/google/firebase/messaging/AndroidNotification.java
+++ b/src/main/java/com/google/firebase/messaging/AndroidNotification.java
@@ -620,8 +620,7 @@ public class AndroidNotification {
     /**
      * Sets the proxy of this notification.
      *
-     * @param proxy The proxy value. one of the values in
-     * {PROXY_UNSPECIFIED, ALLOW, DENY, IF_PRIORITY_LOWERED}
+     * @param proxy The proxy value, one of the values in {ALLOW, DENY, IF_PRIORITY_LOWERED}
      *
      * @return This builder.
      */

--- a/src/main/java/com/google/firebase/messaging/AndroidNotification.java
+++ b/src/main/java/com/google/firebase/messaging/AndroidNotification.java
@@ -210,7 +210,6 @@ public class AndroidNotification {
   }
 
   public enum Proxy {
-    PROXY_UNSPECIFIED,
     ALLOW,
     DENY,
     IF_PRIORITY_LOWERED

--- a/src/test/java/com/google/firebase/messaging/MessageTest.java
+++ b/src/test/java/com/google/firebase/messaging/MessageTest.java
@@ -890,6 +890,7 @@ public class MessageTest {
                 .setDefaultLightSettings(false)
                 .setVisibility(AndroidNotification.Visibility.PUBLIC)
                 .setNotificationCount(10)
+                .setProxy(AndroidNotification.Proxy.DENY)
                 .build())
             .build())
         .setTopic("test-topic")
@@ -923,6 +924,7 @@ public class MessageTest {
             .put("default_light_settings", false)
             .put("visibility", "public")
             .put("notification_count", new BigDecimal(10))
+            .put("proxy", "DENY")
             .build())
         .build();
     assertJsonEquals(ImmutableMap.of(


### PR DESCRIPTION
added proxy field that described on page:
https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#androidnotification