### PR TITLE
chore: Updated release GHA to have write permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,8 @@ jobs:
       startsWith(github.event.pull_request.title, '[chore] Release ')
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout source for publish


### PR DESCRIPTION
Preemptively fixing release issue similar to https://github.com/firebase/firebase-admin-node/pull/2867