### PR TITLE
Add equals() and hashCode() to CreateRequest

### DIFF
--- a/src/main/java/com/google/firebase/auth/UserRecord.java
+++ b/src/main/java/com/google/firebase/auth/UserRecord.java
@@ -426,6 +426,24 @@ public class UserRecord implements UserInfo {
     Map<String, Object> getProperties() {
       return ImmutableMap.copyOf(properties);
     }
+
+    @Override
+public boolean equals(Object o) {
+  if (this == o) {
+    return true;
+  }
+  if (!(o instanceof CreateRequest)) {
+    return false;
+  }
+
+  CreateRequest that = (CreateRequest) o;
+  return properties.equals(that.properties);
+}
+
+@Override
+public int hashCode() {
+  return properties.hashCode();
+}
   }
 
   /**


### PR DESCRIPTION

This PR adds equals() and hashCode() implementations to the CreateRequest class in UserRecord.

This allows proper comparison between CreateRequest objects and resolves the issue where CreateRequest did not override equals().

Implements equals() and hashCode() for the CreateRequest class to allow proper object comparison.

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
