### PR TITLE
chore: Fix issue in the new RC unit tests

### DIFF
--- a/src/main/java/com/google/firebase/remoteconfig/ServerTemplateImpl.java
+++ b/src/main/java/com/google/firebase/remoteconfig/ServerTemplateImpl.java
@@ -75,7 +75,7 @@ public final class ServerTemplateImpl implements ServerTemplate {
     try {
       this.cache.set(ServerTemplateData.fromJSON(initialTemplate));
     } catch (FirebaseRemoteConfigException e) {
-        throw new IllegalArgumentException("Unable to parse JSON string.", e);
+      throw new IllegalArgumentException("Unable to parse JSON string.", e);
     }
   }
 

--- a/src/main/java/com/google/firebase/remoteconfig/ServerTemplateImpl.java
+++ b/src/main/java/com/google/firebase/remoteconfig/ServerTemplateImpl.java
@@ -75,7 +75,7 @@ public final class ServerTemplateImpl implements ServerTemplate {
     try {
       this.cache.set(ServerTemplateData.fromJSON(initialTemplate));
     } catch (FirebaseRemoteConfigException e) {
-      e.printStackTrace();
+        throw new IllegalArgumentException("Unable to parse JSON string.", e);
     }
   }
 

--- a/src/test/java/com/google/firebase/remoteconfig/ServerTemplateImplTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ServerTemplateImplTest.java
@@ -200,7 +200,7 @@ public class ServerTemplateImplTest {
     assertEquals("Unable to parse JSON string.", error.getMessage());
     // Verify the cause is the original FirebaseRemoteConfigException
     assertTrue(error.getCause() instanceof FirebaseRemoteConfigException);
- }
+  }
 
   @Test
   public void testEvaluateWithInAppDefaultReturnsEmptyString() throws Exception {

--- a/src/test/java/com/google/firebase/remoteconfig/ServerTemplateImplTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ServerTemplateImplTest.java
@@ -191,15 +191,15 @@ public class ServerTemplateImplTest {
     KeysAndValues defaultConfig = new KeysAndValues.Builder().build();
     String invalidJsonString = "abc";
     IllegalArgumentException error = assertThrows(
-       IllegalArgumentException.class,
-       () -> new ServerTemplateImpl.Builder(null)
+        IllegalArgumentException.class,
+        () -> new ServerTemplateImpl.Builder(null)
            .defaultConfig(defaultConfig)
            .cachedTemplate(invalidJsonString)
            .build());
 
-   assertEquals("Unable to parse JSON string.", error.getMessage());
-   // Verify the cause is the original FirebaseRemoteConfigException
-   assertTrue(error.getCause() instanceof FirebaseRemoteConfigException);
+    assertEquals("Unable to parse JSON string.", error.getMessage());
+    // Verify the cause is the original FirebaseRemoteConfigException
+    assertTrue(error.getCause() instanceof FirebaseRemoteConfigException);
  }
 
   @Test

--- a/src/test/java/com/google/firebase/remoteconfig/ServerTemplateImplTest.java
+++ b/src/test/java/com/google/firebase/remoteconfig/ServerTemplateImplTest.java
@@ -18,6 +18,7 @@ package com.google.firebase.remoteconfig;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.google.api.core.ApiFuture;
 import com.google.firebase.FirebaseApp;
@@ -188,21 +189,18 @@ public class ServerTemplateImplTest {
   public void testEvaluateWithInvalidCacheValueThrowsException()
       throws FirebaseRemoteConfigException {
     KeysAndValues defaultConfig = new KeysAndValues.Builder().build();
-    KeysAndValues context = new KeysAndValues.Builder().build();
     String invalidJsonString = "abc";
-    ServerTemplate template =
-        new ServerTemplateImpl.Builder(null)
-            .defaultConfig(defaultConfig)
-            .cachedTemplate(invalidJsonString)
-            .build();
+    IllegalArgumentException error = assertThrows(
+       IllegalArgumentException.class,
+       () -> new ServerTemplateImpl.Builder(null)
+           .defaultConfig(defaultConfig)
+           .cachedTemplate(invalidJsonString)
+           .build());
 
-    FirebaseRemoteConfigException error =
-        assertThrows(FirebaseRemoteConfigException.class, () -> template.evaluate(context));
-
-    assertEquals(
-        "No Remote Config Server template in cache. Call load() before " + "calling evaluate().",
-        error.getMessage());
-  }
+   assertEquals("Unable to parse JSON string.", error.getMessage());
+   // Verify the cause is the original FirebaseRemoteConfigException
+   assertTrue(error.getCause() instanceof FirebaseRemoteConfigException);
+ }
 
   @Test
   public void testEvaluateWithInAppDefaultReturnsEmptyString() throws Exception {


### PR DESCRIPTION
fix(rc): Throw IllegalArgumentException for invalid template JSON

The `ServerTemplateImpl` constructor was catching template parsing 
exceptions and only printing the stack trace to stderr. This resulted 
in noisy console output during unit tests, even when the tests passed. 

This change updates the constructor to throw an `IllegalArgumentException` 
when a provided `cachedTemplate` fails to parse. 

Updated `testEvaluateWithInvalidCacheValueThrowsException` to assert 
this new behavior.
