### PR TITLE
feat(appcheck): Add App Check token verification support with replay protection

### DIFF
--- a/src/main/java/com/google/firebase/appcheck/AppCheckErrorCode.java
+++ b/src/main/java/com/google/firebase/appcheck/AppCheckErrorCode.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck;
+
+/**
+ * Error codes that can be raised by the Firebase App Check APIs.
+ */
+public enum AppCheckErrorCode {
+
+  /**
+   * One or more arguments specified in the request were invalid.
+   */
+  INVALID_ARGUMENT,
+
+  /**
+   * The provided App Check token is invalid or malformed.
+   */
+  INVALID_APP_CHECK_TOKEN,
+
+  /**
+   * The provided App Check token has expired.
+   */
+  APP_CHECK_TOKEN_EXPIRED,
+
+  /**
+   * Internal error encountered during App Check token verification.
+   */
+  INTERNAL_ERROR,
+
+  /**
+   * App Check verification service is temporarily unavailable or returned an error.
+   */
+  SERVICE_ERROR,
+}

--- a/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
+++ b/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
@@ -81,9 +81,13 @@ public class DecodedAppCheckToken {
     if (audience instanceof String) {
       return ImmutableList.of((String) audience);
     } else if (audience instanceof List) {
-      @SuppressWarnings("unchecked")
-      List<String> audienceList = (List<String>) audience;
-      return ImmutableList.copyOf(audienceList);
+      ImmutableList.Builder<String> builder = ImmutableList.builder();
+      for (Object item : (List<?>) audience) {
+        if (item instanceof String) {
+          builder.add((String) item);
+        }
+      }
+      return builder.build();
     }
     return ImmutableList.of();
   }

--- a/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
+++ b/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
@@ -88,14 +88,14 @@ public class DecodedAppCheckToken {
   }
 
   /**
-   * Returns the expiration time as an {@link Instant}, or {@code null} if not present.
+   * Returns the expiration time as an {@link Instant}.
    */
   public Instant getExpirationTime() {
     return toInstant(claims.get("exp"));
   }
 
   /**
-   * Returns the issued-at time as an {@link Instant}, or {@code null} if not present.
+   * Returns the issued-at time as an {@link Instant}.
    */
   public Instant getIssuedAt() {
     return toInstant(claims.get("iat"));

--- a/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
+++ b/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
@@ -37,7 +37,7 @@ public class DecodedAppCheckToken {
    *
    * @param claims A map of JWT claims.
    */
-  DecodedAppCheckToken(Map<String, Object> claims) {
+  public DecodedAppCheckToken(Map<String, Object> claims) {
     checkNotNull(claims, "Claims map must not be null");
     checkArgument(claims.containsKey("sub"), "Claims map must contain sub");
     this.claims = ImmutableMap.copyOf(claims);

--- a/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
+++ b/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
@@ -59,6 +59,28 @@ public class DecodedAppCheckToken {
   }
 
   /**
+   * Returns the App ID for which this token was issued.
+   * This is an alias for {@link #getSubject()}.
+   */
+  public String getAppId() {
+    return getSubject();
+  }
+
+  /**
+   * Returns the JWT ID ('jti') of the token, or {@code null} if not present.
+   */
+  public String getJti() {
+    return (String) claims.get("jti");
+  }
+
+  /**
+   * Returns the attestation provider for this token, or {@code null} if not present.
+   */
+  public String getProvider() {
+    return (String) claims.get("provider");
+  }
+
+  /**
    * Returns the audience for which this token is intended.
    */
   public List<String> getAudience() {

--- a/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
+++ b/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a verified Firebase App Check token.
+ */
+public class DecodedAppCheckToken {
+
+  private final Map<String, Object> claims;
+
+  /**
+   * Creates an instance of {@link DecodedAppCheckToken} from a map of JWT claims.
+   *
+   * @param claims A map of JWT claims.
+   */
+  DecodedAppCheckToken(Map<String, Object> claims) {
+    checkNotNull(claims, "Claims map must not be null");
+    checkArgument(claims.containsKey("sub"), "Claims map must contain sub");
+    this.claims = ImmutableMap.copyOf(claims);
+  }
+
+  /**
+   * Returns the issuer identifier for the token.
+   */
+  public String getIssuer() {
+    return (String) claims.get("iss");
+  }
+
+  /**
+   * Returns the subject claim ('sub') of the token.
+   */
+  public String getSubject() {
+    return (String) claims.get("sub");
+  }
+
+  /**
+   * Returns the audience for which this token is intended.
+   */
+  public List<String> getAudience() {
+    Object audience = claims.get("aud");
+    if (audience instanceof String) {
+      return ImmutableList.of((String) audience);
+    } else if (audience instanceof List) {
+      @SuppressWarnings("unchecked")
+      List<String> audienceList = (List<String>) audience;
+      return ImmutableList.copyOf(audienceList);
+    }
+    return ImmutableList.of();
+  }
+
+  /**
+   * Returns the expiration time in seconds since the Unix epoch.
+   */
+  public long getExpirationTime() {
+    Object exp = claims.get("exp");
+    if (exp instanceof Date) {
+      return ((Date) exp).getTime() / 1000L;
+    }
+    return exp instanceof Number ? ((Number) exp).longValue() : 0L;
+  }
+
+  /**
+   * Returns the issued-at time in seconds since the Unix epoch.
+   */
+  public long getIssuedAt() {
+    Object iat = claims.get("iat");
+    if (iat instanceof Date) {
+      return ((Date) iat).getTime() / 1000L;
+    }
+    return iat instanceof Number ? ((Number) iat).longValue() : 0L;
+  }
+
+  /**
+   * Returns the entire map of claims.
+   */
+  public Map<String, Object> getClaims() {
+    return claims;
+  }
+}

--- a/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
+++ b/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
@@ -20,9 +20,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,7 +42,7 @@ public class DecodedAppCheckToken {
   public DecodedAppCheckToken(Map<String, Object> claims) {
     checkNotNull(claims, "Claims map must not be null");
     checkArgument(claims.containsKey("sub"), "Claims map must contain sub");
-    this.claims = ImmutableMap.copyOf(claims);
+    this.claims = Collections.unmodifiableMap(new HashMap<>(claims));
   }
 
   /**

--- a/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
+++ b/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
@@ -59,14 +59,6 @@ public class DecodedAppCheckToken {
   }
 
   /**
-   * Returns the App ID for which this token was issued.
-   * This is an alias for {@link #getSubject()}.
-   */
-  public String getAppId() {
-    return getSubject();
-  }
-
-  /**
    * Returns the JWT ID ('jti') of the token, or {@code null} if not present.
    */
   public String getJti() {

--- a/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
+++ b/src/main/java/com/google/firebase/appcheck/DecodedAppCheckToken.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -73,25 +74,17 @@ public class DecodedAppCheckToken {
   }
 
   /**
-   * Returns the expiration time in seconds since the Unix epoch.
+   * Returns the expiration time as an {@link Instant}, or {@code null} if not present.
    */
-  public long getExpirationTime() {
-    Object exp = claims.get("exp");
-    if (exp instanceof Date) {
-      return ((Date) exp).getTime() / 1000L;
-    }
-    return exp instanceof Number ? ((Number) exp).longValue() : 0L;
+  public Instant getExpirationTime() {
+    return toInstant(claims.get("exp"));
   }
 
   /**
-   * Returns the issued-at time in seconds since the Unix epoch.
+   * Returns the issued-at time as an {@link Instant}, or {@code null} if not present.
    */
-  public long getIssuedAt() {
-    Object iat = claims.get("iat");
-    if (iat instanceof Date) {
-      return ((Date) iat).getTime() / 1000L;
-    }
-    return iat instanceof Number ? ((Number) iat).longValue() : 0L;
+  public Instant getIssuedAt() {
+    return toInstant(claims.get("iat"));
   }
 
   /**
@@ -99,5 +92,15 @@ public class DecodedAppCheckToken {
    */
   public Map<String, Object> getClaims() {
     return claims;
+  }
+
+  private static Instant toInstant(Object timeObj) {
+    if (timeObj instanceof Date) {
+      return ((Date) timeObj).toInstant();
+    }
+    if (timeObj instanceof Number) {
+      return Instant.ofEpochSecond(((Number) timeObj).longValue());
+    }
+    return null;
   }
 }

--- a/src/main/java/com/google/firebase/appcheck/FirebaseAppCheck.java
+++ b/src/main/java/com/google/firebase/appcheck/FirebaseAppCheck.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.api.core.ApiFuture;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.ImplFirebaseTrampolines;
+import com.google.firebase.appcheck.internal.AppCheckTokenVerifier;
+import com.google.firebase.internal.CallableOperation;
+import com.google.firebase.internal.FirebaseService;
+
+/**
+ * This class is the entry point for the Firebase App Check service.
+ *
+ * <p>You can get an instance of {@link FirebaseAppCheck} via {@link #getInstance()}
+ * or {@link #getInstance(FirebaseApp)}.
+ */
+public final class FirebaseAppCheck {
+
+  private static final String SERVICE_ID = FirebaseAppCheck.class.getName();
+
+  private final FirebaseApp app;
+  private final AppCheckTokenVerifier tokenVerifier;
+
+  private FirebaseAppCheck(FirebaseApp app) {
+    this(app, new AppCheckTokenVerifier(app));
+  }
+
+  @VisibleForTesting
+  FirebaseAppCheck(FirebaseApp app, AppCheckTokenVerifier tokenVerifier) {
+    this.app = checkNotNull(app, "FirebaseApp must not be null");
+    this.tokenVerifier = checkNotNull(tokenVerifier, "AppCheckTokenVerifier must not be null");
+  }
+
+  /**
+   * Gets the {@link FirebaseAppCheck} instance for the default {@link FirebaseApp}.
+   *
+   * @return The {@link FirebaseAppCheck} instance for the default {@link FirebaseApp}.
+   */
+  public static FirebaseAppCheck getInstance() {
+    return getInstance(FirebaseApp.getInstance());
+  }
+
+  /**
+   * Gets the {@link FirebaseAppCheck} instance for the specified {@link FirebaseApp}.
+   *
+   * @param app The {@link FirebaseApp} instance.
+   * @return The {@link FirebaseAppCheck} instance for the specified {@link FirebaseApp}.
+   */
+  public static synchronized FirebaseAppCheck getInstance(FirebaseApp app) {
+    FirebaseAppCheckService service =
+        ImplFirebaseTrampolines.getService(app, SERVICE_ID, FirebaseAppCheckService.class);
+    if (service == null) {
+      service = ImplFirebaseTrampolines.addService(app, new FirebaseAppCheckService(app));
+    }
+    return service.getInstance();
+  }
+
+  /**
+   * Verifies an App Check token string.
+   *
+   * @param appCheckToken The App Check token string to verify.
+   * @return A {@link VerifyAppCheckTokenResponse} containing the decoded token.
+   * @throws FirebaseAppCheckException If verification fails.
+   */
+  public VerifyAppCheckTokenResponse verifyToken(String appCheckToken)
+      throws FirebaseAppCheckException {
+    return verifyToken(appCheckToken, null);
+  }
+
+  /**
+   * Verifies an App Check token string with options.
+   *
+   * @param appCheckToken The App Check token string to verify.
+   * @param options Verification options specified via {@link VerifyAppCheckTokenOptions}.
+   * @return A {@link VerifyAppCheckTokenResponse} containing the decoded token
+   *     and consumption status.
+   * @throws FirebaseAppCheckException If verification fails.
+   */
+  public VerifyAppCheckTokenResponse verifyToken(
+      String appCheckToken, VerifyAppCheckTokenOptions options) throws FirebaseAppCheckException {
+    return this.tokenVerifier.verifyToken(appCheckToken, options);
+  }
+
+  /**
+   * Asynchronously verifies an App Check token string.
+   *
+   * @param appCheckToken The App Check token string to verify.
+   * @return An {@link ApiFuture} containing the {@link VerifyAppCheckTokenResponse}.
+   */
+  public ApiFuture<VerifyAppCheckTokenResponse> verifyTokenAsync(String appCheckToken) {
+    return verifyTokenAsync(appCheckToken, null);
+  }
+
+  /**
+   * Asynchronously verifies an App Check token string with options.
+   *
+   * @param appCheckToken The App Check token string to verify.
+   * @param options Verification options specified via {@link VerifyAppCheckTokenOptions}.
+   * @return An {@link ApiFuture} containing the {@link VerifyAppCheckTokenResponse}.
+   */
+  public ApiFuture<VerifyAppCheckTokenResponse> verifyTokenAsync(
+      String appCheckToken, VerifyAppCheckTokenOptions options) {
+    return verifyTokenOp(appCheckToken, options).callAsync(this.app);
+  }
+
+  private CallableOperation<VerifyAppCheckTokenResponse, FirebaseAppCheckException> verifyTokenOp(
+      final String appCheckToken, final VerifyAppCheckTokenOptions options) {
+    return new CallableOperation<VerifyAppCheckTokenResponse, FirebaseAppCheckException>() {
+      @Override
+      protected VerifyAppCheckTokenResponse execute() throws FirebaseAppCheckException {
+        return verifyToken(appCheckToken, options);
+      }
+    };
+  }
+
+  private static class FirebaseAppCheckService extends FirebaseService<FirebaseAppCheck> {
+    FirebaseAppCheckService(FirebaseApp app) {
+      super(SERVICE_ID, new FirebaseAppCheck(app));
+    }
+  }
+}

--- a/src/main/java/com/google/firebase/appcheck/FirebaseAppCheckException.java
+++ b/src/main/java/com/google/firebase/appcheck/FirebaseAppCheckException.java
@@ -43,6 +43,12 @@ public class FirebaseAppCheckException extends FirebaseException {
     this(errorCode, message, cause, null);
   }
 
+  public FirebaseAppCheckException(
+      @NonNull ErrorCode errorCode,
+      @NonNull String message) {
+    this(errorCode, message, null, null);
+  }
+
   public FirebaseAppCheckException(@NonNull FirebaseException base) {
     this(base.getErrorCode(), base.getMessage(), base.getCause(), base.getHttpResponse());
   }

--- a/src/main/java/com/google/firebase/appcheck/FirebaseAppCheckException.java
+++ b/src/main/java/com/google/firebase/appcheck/FirebaseAppCheckException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck;
+
+import com.google.firebase.ErrorCode;
+import com.google.firebase.FirebaseException;
+import com.google.firebase.IncomingHttpResponse;
+import com.google.firebase.internal.NonNull;
+import com.google.firebase.internal.Nullable;
+
+/**
+ * Generic exception related to Firebase App Check. Check the error code and message for more
+ * details.
+ */
+public class FirebaseAppCheckException extends FirebaseException {
+
+  public FirebaseAppCheckException(
+      @NonNull ErrorCode errorCode,
+      @NonNull String message,
+      @Nullable Throwable cause,
+      @Nullable IncomingHttpResponse response) {
+    super(errorCode, message, cause, response);
+  }
+
+  public FirebaseAppCheckException(
+      @NonNull ErrorCode errorCode,
+      @NonNull String message,
+      @Nullable Throwable cause) {
+    this(errorCode, message, cause, null);
+  }
+
+  public FirebaseAppCheckException(@NonNull FirebaseException base) {
+    this(base.getErrorCode(), base.getMessage(), base.getCause(), base.getHttpResponse());
+  }
+}

--- a/src/main/java/com/google/firebase/appcheck/FirebaseAppCheckException.java
+++ b/src/main/java/com/google/firebase/appcheck/FirebaseAppCheckException.java
@@ -28,28 +28,45 @@ import com.google.firebase.internal.Nullable;
  */
 public class FirebaseAppCheckException extends FirebaseException {
 
+  private final AppCheckErrorCode errorCode;
+
+  public FirebaseAppCheckException(
+      @NonNull ErrorCode errorCode,
+      @NonNull String message,
+      @Nullable Throwable cause,
+      @Nullable IncomingHttpResponse response,
+      @Nullable AppCheckErrorCode appCheckErrorCode) {
+    super(errorCode, message, cause, response);
+    this.errorCode = appCheckErrorCode;
+  }
+
   public FirebaseAppCheckException(
       @NonNull ErrorCode errorCode,
       @NonNull String message,
       @Nullable Throwable cause,
       @Nullable IncomingHttpResponse response) {
-    super(errorCode, message, cause, response);
+    this(errorCode, message, cause, response, null);
   }
 
   public FirebaseAppCheckException(
       @NonNull ErrorCode errorCode,
       @NonNull String message,
       @Nullable Throwable cause) {
-    this(errorCode, message, cause, null);
+    this(errorCode, message, cause, null, null);
   }
 
   public FirebaseAppCheckException(
       @NonNull ErrorCode errorCode,
       @NonNull String message) {
-    this(errorCode, message, null, null);
+    this(errorCode, message, null, null, null);
   }
 
   public FirebaseAppCheckException(@NonNull FirebaseException base) {
-    this(base.getErrorCode(), base.getMessage(), base.getCause(), base.getHttpResponse());
+    this(base.getErrorCode(), base.getMessage(), base.getCause(), base.getHttpResponse(), null);
+  }
+
+  @Nullable
+  public AppCheckErrorCode getAppCheckErrorCode() {
+    return errorCode;
   }
 }

--- a/src/main/java/com/google/firebase/appcheck/VerifyAppCheckTokenOptions.java
+++ b/src/main/java/com/google/firebase/appcheck/VerifyAppCheckTokenOptions.java
@@ -16,6 +16,8 @@
 
 package com.google.firebase.appcheck;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.Optional;
 
 /**
@@ -60,11 +62,11 @@ public final class VerifyAppCheckTokenOptions {
     /**
      * Sets whether to consume the token during verification.
      *
-     * @param consume Optional boolean value.
+     * @param consume Optional boolean value. Must not be null.
      * @return This builder.
      */
     public Builder setConsume(Optional<Boolean> consume) {
-      this.consume = consume != null ? consume : Optional.<Boolean>empty();
+      this.consume = checkNotNull(consume, "consume must not be null");
       return this;
     }
 

--- a/src/main/java/com/google/firebase/appcheck/VerifyAppCheckTokenOptions.java
+++ b/src/main/java/com/google/firebase/appcheck/VerifyAppCheckTokenOptions.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck;
+
+import java.util.Optional;
+
+/**
+ * Options for verifying a Firebase App Check token.
+ */
+public final class VerifyAppCheckTokenOptions {
+
+  private final Optional<Boolean> consume;
+
+  private VerifyAppCheckTokenOptions(Builder builder) {
+    this.consume = builder.consume;
+  }
+
+  /**
+   * Returns whether to consume the App Check token during verification for replay protection.
+   */
+  public Optional<Boolean> getConsume() {
+    return consume;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+
+    private Optional<Boolean> consume = Optional.empty();
+
+    private Builder() {}
+
+    /**
+     * Sets whether to consume the token during verification.
+     *
+     * @param consume Set to true to consume the token.
+     * @return This builder.
+     */
+    public Builder setConsume(boolean consume) {
+      this.consume = Optional.of(consume);
+      return this;
+    }
+
+    /**
+     * Sets whether to consume the token during verification.
+     *
+     * @param consume Optional boolean value.
+     * @return This builder.
+     */
+    public Builder setConsume(Optional<Boolean> consume) {
+      this.consume = consume != null ? consume : Optional.<Boolean>empty();
+      return this;
+    }
+
+    /**
+     * Builds a new {@link VerifyAppCheckTokenOptions} instance.
+     */
+    public VerifyAppCheckTokenOptions build() {
+      return new VerifyAppCheckTokenOptions(this);
+    }
+  }
+}

--- a/src/main/java/com/google/firebase/appcheck/VerifyAppCheckTokenResponse.java
+++ b/src/main/java/com/google/firebase/appcheck/VerifyAppCheckTokenResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.firebase.internal.NonNull;
+import com.google.firebase.internal.Nullable;
+import java.util.Optional;
+
+/**
+ * Represents the response from verifying a Firebase App Check token.
+ */
+public final class VerifyAppCheckTokenResponse {
+
+  private final String appId;
+  private final DecodedAppCheckToken token;
+  private final Optional<Boolean> alreadyConsumed;
+
+  VerifyAppCheckTokenResponse(
+      @NonNull String appId,
+      @NonNull DecodedAppCheckToken token,
+      @Nullable Boolean alreadyConsumed) {
+    this.appId = checkNotNull(appId, "appId must not be null");
+    this.token = checkNotNull(token, "token must not be null");
+    this.alreadyConsumed = Optional.ofNullable(alreadyConsumed);
+  }
+
+  /**
+   * Returns the App ID associated with the App Check token.
+   */
+  public String getAppId() {
+    return appId;
+  }
+
+  /**
+   * Returns the decoded App Check token.
+   */
+  public DecodedAppCheckToken getToken() {
+    return token;
+  }
+
+  /**
+   * Returns whether the token was already consumed prior to verification, if consume option was requested.
+   */
+  public Optional<Boolean> isAlreadyConsumed() {
+    return alreadyConsumed;
+  }
+}

--- a/src/main/java/com/google/firebase/appcheck/VerifyAppCheckTokenResponse.java
+++ b/src/main/java/com/google/firebase/appcheck/VerifyAppCheckTokenResponse.java
@@ -31,7 +31,7 @@ public final class VerifyAppCheckTokenResponse {
   private final DecodedAppCheckToken token;
   private final Optional<Boolean> alreadyConsumed;
 
-  VerifyAppCheckTokenResponse(
+  public VerifyAppCheckTokenResponse(
       @NonNull String appId,
       @NonNull DecodedAppCheckToken token,
       @Nullable Boolean alreadyConsumed) {

--- a/src/main/java/com/google/firebase/appcheck/VerifyAppCheckTokenResponse.java
+++ b/src/main/java/com/google/firebase/appcheck/VerifyAppCheckTokenResponse.java
@@ -55,7 +55,8 @@ public final class VerifyAppCheckTokenResponse {
   }
 
   /**
-   * Returns whether the token was already consumed prior to verification, if consume option was requested.
+   * Returns whether the token was already consumed prior to verification,
+   * if consume option was requested.
    */
   public Optional<Boolean> isAlreadyConsumed() {
     return alreadyConsumed;

--- a/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
+++ b/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck.internal;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.json.JsonHttpContent;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonFactory;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.firebase.ErrorCode;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.ImplFirebaseTrampolines;
+import com.google.firebase.appcheck.DecodedAppCheckToken;
+import com.google.firebase.appcheck.FirebaseAppCheckException;
+import com.google.firebase.appcheck.VerifyAppCheckTokenOptions;
+import com.google.firebase.appcheck.VerifyAppCheckTokenResponse;
+import com.google.firebase.internal.ApiClientUtils;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import com.nimbusds.jwt.proc.ExpiredJWTException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.text.ParseException;
+
+/**
+ * Internal verifier for Firebase App Check tokens.
+ */
+public class AppCheckTokenVerifier {
+
+  private static final String JWKS_URL = "https://firebaseappcheck.googleapis.com/v1/jwks";
+  private static final String APP_CHECK_ISSUER = "https://firebaseappcheck.googleapis.com/";
+  private static final String APP_CHECK_AUDIENCE_PREFIX = "projects/";
+  private static final String VERIFY_TOKEN_URL_FORMAT =
+      "https://firebaseappcheck.googleapis.com/v1/projects/%s:verifyAppCheckToken";
+
+  private final FirebaseApp app;
+  private final String projectId;
+  private final HttpRequestFactory requestFactory;
+  private final JsonFactory jsonFactory;
+  private volatile DefaultJWTProcessor<SecurityContext> jwtProcessor;
+
+  public AppCheckTokenVerifier(FirebaseApp app) {
+    this(app, ApiClientUtils.newAuthorizedRequestFactory(app), ApiClientUtils.getDefaultJsonFactory(), null);
+  }
+
+  /**
+   * Package-private constructor designed explicitly for dependency injection
+   * of mock HTTP request factories, JSON factories, or mock JWT processors
+   * during isolated unit testing flows.
+   */
+  @VisibleForTesting
+  AppCheckTokenVerifier(
+      FirebaseApp app,
+      HttpRequestFactory requestFactory,
+      JsonFactory jsonFactory,
+      DefaultJWTProcessor<SecurityContext> jwtProcessor) {
+    this.app = checkNotNull(app, "FirebaseApp must not be null");
+    this.projectId = getProjectId(app);
+    this.requestFactory = checkNotNull(requestFactory, "HttpRequestFactory must not be null");
+    this.jsonFactory = checkNotNull(jsonFactory, "JsonFactory must not be null");
+    this.jwtProcessor = jwtProcessor;
+  }
+
+  private DefaultJWTProcessor<SecurityContext> getJwtProcessor() {
+    DefaultJWTProcessor<SecurityContext> processor = this.jwtProcessor;
+    if (processor == null) {
+      synchronized (this) {
+        processor = this.jwtProcessor;
+        if (processor == null) {
+          processor = createJwtProcessor();
+          this.jwtProcessor = processor;
+        }
+      }
+    }
+    return processor;
+  }
+
+  /**
+   * Verifies an App Check token string.
+   *
+   * @param token The App Check token string to verify.
+   * @return A {@link VerifyAppCheckTokenResponse} containing the decoded token.
+   * @throws FirebaseAppCheckException If verification fails.
+   */
+  public VerifyAppCheckTokenResponse verifyToken(String token) throws FirebaseAppCheckException {
+    return verifyToken(token, null);
+  }
+
+  /**
+   * Verifies an App Check token string with options.
+   *
+   * @param token The App Check token string to verify.
+   * @param options Verification options specified via {@link VerifyAppCheckTokenOptions}.
+   * @return A {@link VerifyAppCheckTokenResponse} containing the decoded token and consumption status.
+   * @throws FirebaseAppCheckException If verification fails.
+   */
+  public VerifyAppCheckTokenResponse verifyToken(
+      String token, VerifyAppCheckTokenOptions options) throws FirebaseAppCheckException {
+    checkArgument(
+        !Strings.isNullOrEmpty(token), "App Check token string must not be null or empty");
+
+    DecodedAppCheckToken decodedToken = verifyTokenLocally(token);
+    String appId = decodedToken.getSubject();
+
+    boolean consume = options != null && options.getConsume().orElse(false);
+    Boolean alreadyConsumed = null;
+
+    if (consume) {
+      alreadyConsumed = verifyOneTimeToken(token);
+    }
+
+    return new VerifyAppCheckTokenResponse(appId, decodedToken, alreadyConsumed);
+  }
+
+  /**
+   * Performs local JWT signature and claims verification.
+   */
+  private DecodedAppCheckToken verifyTokenLocally(String token) throws FirebaseAppCheckException {
+    try {
+      SignedJWT signedJwt = SignedJWT.parse(token);
+      verifyHeader(signedJwt.getHeader());
+      JWTClaimsSet claims = getJwtProcessor().process(signedJwt, null);
+      verifyClaims(claims);
+      return new DecodedAppCheckToken(claims.getClaims());
+    } catch (ParseException e) {
+      throw new FirebaseAppCheckException(
+          ErrorCode.INVALID_ARGUMENT, "Failed to parse App Check JWT token: " + e.getMessage(), e);
+    } catch (ExpiredJWTException e) {
+      throw new FirebaseAppCheckException(
+          ErrorCode.INVALID_ARGUMENT, "Firebase App Check token has expired.", e);
+    } catch (BadJOSEException e) {
+      throw new FirebaseAppCheckException(
+          ErrorCode.INVALID_ARGUMENT,
+          "Check your project: " + projectId + ". Firebase App Check token is invalid: "
+              + e.getMessage(),
+          e);
+    } catch (JOSEException e) {
+      throw new FirebaseAppCheckException(
+          ErrorCode.INTERNAL,
+          "Check your project: " + projectId + ". Failed to verify App Check token signature: "
+              + e.getMessage(),
+          e);
+    }
+  }
+
+  private void verifyHeader(JWSHeader header) throws FirebaseAppCheckException {
+    if (header.getAlgorithm() == null || !JWSAlgorithm.RS256.equals(header.getAlgorithm())) {
+      throw new FirebaseAppCheckException(
+          ErrorCode.INVALID_ARGUMENT,
+          "App Check token has incorrect algorithm. Expected "
+              + JWSAlgorithm.RS256.getName()
+              + " but got: "
+              + header.getAlgorithm());
+    }
+    if (Strings.isNullOrEmpty(header.getKeyID())) {
+      throw new FirebaseAppCheckException(
+          ErrorCode.INVALID_ARGUMENT, "App Check token has no 'kid' (key ID) header.");
+    }
+    if (header.getType() == null || !JOSEObjectType.JWT.equals(header.getType())) {
+      throw new FirebaseAppCheckException(
+          ErrorCode.INVALID_ARGUMENT,
+          "App Check token has incorrect 'typ' header. Expected JWT but got: "
+              + header.getType());
+    }
+  }
+
+  private void verifyClaims(JWTClaimsSet claims) throws FirebaseAppCheckException {
+    checkNotNull(claims, "JWTClaimsSet claims must not be null");
+    String issuer = claims.getIssuer();
+
+    if (Strings.isNullOrEmpty(issuer)) {
+      throw new FirebaseAppCheckException(
+          ErrorCode.INVALID_ARGUMENT, "App Check token has no 'iss' (issuer) claim.");
+    }
+
+    if (!issuer.startsWith(APP_CHECK_ISSUER)) {
+      throw new FirebaseAppCheckException(
+          ErrorCode.INVALID_ARGUMENT,
+          "App Check token has incorrect issuer. Expected to start with: "
+              + APP_CHECK_ISSUER
+              + " but got: "
+              + issuer);
+    }
+
+    String expectedAudience = APP_CHECK_AUDIENCE_PREFIX + this.projectId;
+    if (claims.getAudience().isEmpty() || !claims.getAudience().contains(expectedAudience)) {
+      throw new FirebaseAppCheckException(
+          ErrorCode.INVALID_ARGUMENT,
+          "App Check token has incorrect audience. Expected to contain: "
+              + expectedAudience
+              + " but got: "
+              + claims.getAudience());
+    }
+
+    if (Strings.isNullOrEmpty(claims.getSubject())) {
+      throw new FirebaseAppCheckException(
+          ErrorCode.INVALID_ARGUMENT, "App Check token has empty 'sub' (app ID) claim.");
+    }
+  }
+
+  /**
+   * Sends an RPC request to the Firebase App Check backend service to verify
+   * and consume a limited-use (one-time) App Check token.
+   *
+   * @param token The raw App Check token string to consume.
+   * @return {@code true} if the token was already consumed prior to this verification call;
+   *         {@code false} otherwise.
+   * @throws FirebaseAppCheckException If an HTTP error or backend service failure occurs.
+   */
+  private boolean verifyOneTimeToken(String token)
+      throws FirebaseAppCheckException {
+    String url = String.format(VERIFY_TOKEN_URL_FORMAT, this.projectId);
+    GenericUrl genericUrl = new GenericUrl(url);
+
+    GenericJson requestPayload = new GenericJson();
+    requestPayload.put("app_check_token", token);
+
+    try {
+      HttpRequest httpRequest =
+          requestFactory.buildPostRequest(
+              genericUrl, new JsonHttpContent(jsonFactory, requestPayload));
+      httpRequest.setParser(jsonFactory.createJsonObjectParser());
+      HttpResponse httpResponse = httpRequest.execute();
+
+      GenericJson response = httpResponse.parseAs(GenericJson.class);
+      Boolean alreadyConsumed = (Boolean) response.get("alreadyConsumed");
+      if (alreadyConsumed == null) {
+        alreadyConsumed = (Boolean) response.get("already_consumed");
+      }
+      return Boolean.TRUE.equals(alreadyConsumed);
+    } catch (IOException e) {
+      throw new FirebaseAppCheckException(
+          ErrorCode.INTERNAL, "Error verifying App Check token with backend: " + e.getMessage(), e);
+    }
+  }
+
+  private DefaultJWTProcessor<SecurityContext> createJwtProcessor() {
+    DefaultJWTProcessor<SecurityContext> processor = new DefaultJWTProcessor<>();
+    try {
+      JWKSource<SecurityContext> keySource = createKeySource();
+      JWSKeySelector<SecurityContext> keySelector =
+          new JWSVerificationKeySelector<>(JWSAlgorithm.RS256, keySource);
+      processor.setJWSKeySelector(keySelector);
+    } catch (MalformedURLException e) {
+      throw new IllegalStateException("Invalid JWKS URL", e);
+    }
+    return processor;
+  }
+
+  protected JWKSource<SecurityContext> createKeySource() throws MalformedURLException {
+    return JWKSourceBuilder.create(URI.create(JWKS_URL).toURL()).retrying(true).build();
+  }
+
+  private String getProjectId(FirebaseApp app) {
+    String projectId = ImplFirebaseTrampolines.getProjectId(app);
+    if (Strings.isNullOrEmpty(projectId)) {
+      throw new IllegalArgumentException("Project ID is required in FirebaseOptions.");
+    }
+    return projectId;
+  }
+}

--- a/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
+++ b/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
@@ -83,11 +83,6 @@ public class AppCheckTokenVerifier {
         null);
   }
 
-  /**
-   * Package-private constructor designed explicitly for dependency injection
-   * of mock HTTP request factories, JSON factories, or mock JWT processors
-   * during isolated unit testing flows.
-   */
   @VisibleForTesting
   AppCheckTokenVerifier(
       FirebaseApp app,

--- a/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
+++ b/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
@@ -31,6 +31,7 @@ import com.google.common.base.Strings;
 import com.google.firebase.ErrorCode;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.ImplFirebaseTrampolines;
+import com.google.firebase.appcheck.AppCheckErrorCode;
 import com.google.firebase.appcheck.DecodedAppCheckToken;
 import com.google.firebase.appcheck.FirebaseAppCheckException;
 import com.google.firebase.appcheck.VerifyAppCheckTokenOptions;
@@ -146,22 +147,34 @@ public class AppCheckTokenVerifier {
       return new DecodedAppCheckToken(claims.getClaims());
     } catch (ParseException e) {
       throw new FirebaseAppCheckException(
-          ErrorCode.INVALID_ARGUMENT, "Failed to parse App Check JWT token: " + e.getMessage(), e);
+          ErrorCode.INVALID_ARGUMENT,
+          "Failed to parse App Check JWT token: " + e.getMessage(),
+          e,
+          null,
+          AppCheckErrorCode.INVALID_APP_CHECK_TOKEN);
     } catch (ExpiredJWTException e) {
       throw new FirebaseAppCheckException(
-          ErrorCode.INVALID_ARGUMENT, "Firebase App Check token has expired.", e);
+          ErrorCode.INVALID_ARGUMENT,
+          "Firebase App Check token has expired.",
+          e,
+          null,
+          AppCheckErrorCode.APP_CHECK_TOKEN_EXPIRED);
     } catch (BadJOSEException e) {
       throw new FirebaseAppCheckException(
           ErrorCode.INVALID_ARGUMENT,
           "Check your project: " + projectId + ". Failed to verify App Check token signature: "
               + e.getMessage(),
-          e);
+          e,
+          null,
+          AppCheckErrorCode.INVALID_APP_CHECK_TOKEN);
     } catch (JOSEException e) {
       throw new FirebaseAppCheckException(
           ErrorCode.INTERNAL,
           "Check your project: " + projectId + ". Internal error processing App Check token: "
               + e.getMessage(),
-          e);
+          e,
+          null,
+          AppCheckErrorCode.INTERNAL_ERROR);
     }
   }
 
@@ -172,17 +185,27 @@ public class AppCheckTokenVerifier {
           "App Check token has incorrect algorithm. Expected "
               + JWSAlgorithm.RS256.getName()
               + " but got: "
-              + header.getAlgorithm());
+              + header.getAlgorithm(),
+          null,
+          null,
+          AppCheckErrorCode.INVALID_APP_CHECK_TOKEN);
     }
     if (Strings.isNullOrEmpty(header.getKeyID())) {
       throw new FirebaseAppCheckException(
-          ErrorCode.INVALID_ARGUMENT, "App Check token has no 'kid' (key ID) header.");
+          ErrorCode.INVALID_ARGUMENT,
+          "App Check token has no 'kid' (key ID) header.",
+          null,
+          null,
+          AppCheckErrorCode.INVALID_APP_CHECK_TOKEN);
     }
     if (header.getType() == null || !JOSEObjectType.JWT.equals(header.getType())) {
       throw new FirebaseAppCheckException(
           ErrorCode.INVALID_ARGUMENT,
           "App Check token has incorrect 'typ' header. Expected JWT but got: "
-              + header.getType());
+              + header.getType(),
+          null,
+          null,
+          AppCheckErrorCode.INVALID_APP_CHECK_TOKEN);
     }
   }
 
@@ -192,7 +215,11 @@ public class AppCheckTokenVerifier {
 
     if (Strings.isNullOrEmpty(issuer)) {
       throw new FirebaseAppCheckException(
-          ErrorCode.INVALID_ARGUMENT, "App Check token has no 'iss' (issuer) claim.");
+          ErrorCode.INVALID_ARGUMENT,
+          "App Check token has no 'iss' (issuer) claim.",
+          null,
+          null,
+          AppCheckErrorCode.INVALID_APP_CHECK_TOKEN);
     }
 
     // The issuer is of the form https://firebaseappcheck.googleapis.com/<project_number>.
@@ -207,7 +234,10 @@ public class AppCheckTokenVerifier {
           "App Check token has incorrect issuer. Expected to start with: "
               + APP_CHECK_ISSUER
               + " but got: "
-              + issuer);
+              + issuer,
+          null,
+          null,
+          AppCheckErrorCode.INVALID_APP_CHECK_TOKEN);
     }
 
     List<String> audience = claims.getAudience();
@@ -218,12 +248,19 @@ public class AppCheckTokenVerifier {
           "App Check token has incorrect audience. Expected to contain: "
               + expectedAudience
               + " but got: "
-              + audience);
+              + audience,
+          null,
+          null,
+          AppCheckErrorCode.INVALID_APP_CHECK_TOKEN);
     }
 
     if (Strings.isNullOrEmpty(claims.getSubject())) {
       throw new FirebaseAppCheckException(
-          ErrorCode.INVALID_ARGUMENT, "App Check token has empty 'sub' (app ID) claim.");
+          ErrorCode.INVALID_ARGUMENT,
+          "App Check token has empty 'sub' (app ID) claim.",
+          null,
+          null,
+          AppCheckErrorCode.INVALID_APP_CHECK_TOKEN);
     }
   }
 
@@ -260,7 +297,11 @@ public class AppCheckTokenVerifier {
       return Boolean.TRUE.equals(alreadyConsumed);
     } catch (IOException e) {
       throw new FirebaseAppCheckException(
-          ErrorCode.INTERNAL, "Error verifying App Check token with backend: " + e.getMessage(), e);
+          ErrorCode.INTERNAL,
+          "Error verifying App Check token with backend: " + e.getMessage(),
+          e,
+          null,
+          AppCheckErrorCode.SERVICE_ERROR);
     } finally {
       ApiClientUtils.disconnectQuietly(httpResponse);
     }

--- a/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
+++ b/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.text.ParseException;
+import java.util.List;
 
 /**
  * Internal verifier for Firebase App Check tokens.
@@ -220,14 +221,15 @@ public class AppCheckTokenVerifier {
               + issuer);
     }
 
+    List<String> audience = claims.getAudience();
     String expectedAudience = APP_CHECK_AUDIENCE_PREFIX + this.projectId;
-    if (claims.getAudience().isEmpty() || !claims.getAudience().contains(expectedAudience)) {
+    if (audience == null || audience.isEmpty() || !audience.contains(expectedAudience)) {
       throw new FirebaseAppCheckException(
           ErrorCode.INVALID_ARGUMENT,
           "App Check token has incorrect audience. Expected to contain: "
               + expectedAudience
               + " but got: "
-              + claims.getAudience());
+              + audience);
     }
 
     if (Strings.isNullOrEmpty(claims.getSubject())) {
@@ -253,12 +255,13 @@ public class AppCheckTokenVerifier {
     GenericJson requestPayload = new GenericJson();
     requestPayload.put("app_check_token", token);
 
+    HttpResponse httpResponse = null;
     try {
       HttpRequest httpRequest =
           requestFactory.buildPostRequest(
               genericUrl, new JsonHttpContent(jsonFactory, requestPayload));
       httpRequest.setParser(jsonFactory.createJsonObjectParser());
-      HttpResponse httpResponse = httpRequest.execute();
+      httpResponse = httpRequest.execute();
 
       GenericJson response = httpResponse.parseAs(GenericJson.class);
       Boolean alreadyConsumed = (Boolean) response.get("alreadyConsumed");
@@ -269,6 +272,8 @@ public class AppCheckTokenVerifier {
     } catch (IOException e) {
       throw new FirebaseAppCheckException(
           ErrorCode.INTERNAL, "Error verifying App Check token with backend: " + e.getMessage(), e);
+    } finally {
+      ApiClientUtils.disconnectQuietly(httpResponse);
     }
   }
 

--- a/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
+++ b/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
@@ -55,6 +55,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.text.ParseException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Internal verifier for Firebase App Check tokens.
@@ -66,6 +67,7 @@ public class AppCheckTokenVerifier {
   private static final String APP_CHECK_AUDIENCE_PREFIX = "projects/";
   private static final String VERIFY_TOKEN_URL_FORMAT =
       "https://firebaseappcheck.googleapis.com/v1/projects/%s:verifyAppCheckToken";
+  private static final long JWKS_CACHE_TTL_MILLIS = TimeUnit.HOURS.toMillis(6);
 
   private final FirebaseApp app;
   private final String projectId;
@@ -291,7 +293,10 @@ public class AppCheckTokenVerifier {
   }
 
   protected JWKSource<SecurityContext> createKeySource() throws MalformedURLException {
-    return JWKSourceBuilder.create(URI.create(JWKS_URL).toURL()).retrying(true).build();
+    return JWKSourceBuilder.create(URI.create(JWKS_URL).toURL())
+        .cache(JWKS_CACHE_TTL_MILLIS, JWKSourceBuilder.DEFAULT_CACHE_REFRESH_TIMEOUT)
+        .retrying(true)
+        .build();
   }
 
   private String getProjectId(FirebaseApp app) {

--- a/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
+++ b/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
@@ -290,6 +290,9 @@ public class AppCheckTokenVerifier {
       httpResponse = httpRequest.execute();
 
       GenericJson response = httpResponse.parseAs(GenericJson.class);
+      if (response == null) {
+        return false;
+      }
       Boolean alreadyConsumed = (Boolean) response.get("alreadyConsumed");
       if (alreadyConsumed == null) {
         alreadyConsumed = (Boolean) response.get("already_consumed");

--- a/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
+++ b/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
@@ -200,6 +200,12 @@ public class AppCheckTokenVerifier {
           ErrorCode.INVALID_ARGUMENT, "App Check token has no 'iss' (issuer) claim.");
     }
 
+    // The issuer is of the form https://firebaseappcheck.googleapis.com/<project_number>.
+    // Because the SDK currently only has access to the project ID (not the project number),
+    // the verifier checks the issuer prefix rather than strict equality. If the SDK is updated in
+    // the future to expose the project number (per https://google.aip.dev/cloud/2510), this check
+    // should be updated to verify strict equality against
+    // https://firebaseappcheck.googleapis.com/<project_number>.
     if (!issuer.startsWith(APP_CHECK_ISSUER)) {
       throw new FirebaseAppCheckException(
           ErrorCode.INVALID_ARGUMENT,

--- a/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
+++ b/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
@@ -158,13 +158,13 @@ public class AppCheckTokenVerifier {
     } catch (BadJOSEException e) {
       throw new FirebaseAppCheckException(
           ErrorCode.INVALID_ARGUMENT,
-          "Check your project: " + projectId + ". Firebase App Check token is invalid: "
+          "Check your project: " + projectId + ". Failed to verify App Check token signature: "
               + e.getMessage(),
           e);
     } catch (JOSEException e) {
       throw new FirebaseAppCheckException(
           ErrorCode.INTERNAL,
-          "Check your project: " + projectId + ". Failed to verify App Check token signature: "
+          "Check your project: " + projectId + ". Internal error processing App Check token: "
               + e.getMessage(),
           e);
     }

--- a/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
+++ b/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
@@ -73,7 +73,11 @@ public class AppCheckTokenVerifier {
   private volatile DefaultJWTProcessor<SecurityContext> jwtProcessor;
 
   public AppCheckTokenVerifier(FirebaseApp app) {
-    this(app, ApiClientUtils.newAuthorizedRequestFactory(app), ApiClientUtils.getDefaultJsonFactory(), null);
+    this(
+        app,
+        ApiClientUtils.newAuthorizedRequestFactory(app),
+        ApiClientUtils.getDefaultJsonFactory(),
+        null);
   }
 
   /**
@@ -124,7 +128,8 @@ public class AppCheckTokenVerifier {
    *
    * @param token The App Check token string to verify.
    * @param options Verification options specified via {@link VerifyAppCheckTokenOptions}.
-   * @return A {@link VerifyAppCheckTokenResponse} containing the decoded token and consumption status.
+   * @return A {@link VerifyAppCheckTokenResponse} containing the decoded token
+   *     and consumption status.
    * @throws FirebaseAppCheckException If verification fails.
    */
   public VerifyAppCheckTokenResponse verifyToken(

--- a/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
+++ b/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
@@ -23,6 +23,7 @@ import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.json.JsonHttpContent;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonFactory;
@@ -31,6 +32,7 @@ import com.google.common.base.Strings;
 import com.google.firebase.ErrorCode;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.ImplFirebaseTrampolines;
+import com.google.firebase.IncomingHttpResponse;
 import com.google.firebase.appcheck.AppCheckErrorCode;
 import com.google.firebase.appcheck.DecodedAppCheckToken;
 import com.google.firebase.appcheck.FirebaseAppCheckException;
@@ -281,9 +283,10 @@ public class AppCheckTokenVerifier {
     GenericJson requestPayload = new GenericJson();
     requestPayload.put("app_check_token", token);
 
+    HttpRequest httpRequest = null;
     HttpResponse httpResponse = null;
     try {
-      HttpRequest httpRequest =
+      httpRequest =
           requestFactory.buildPostRequest(
               genericUrl, new JsonHttpContent(jsonFactory, requestPayload));
       httpRequest.setParser(jsonFactory.createJsonObjectParser());
@@ -298,6 +301,15 @@ public class AppCheckTokenVerifier {
         alreadyConsumed = (Boolean) response.get("already_consumed");
       }
       return Boolean.TRUE.equals(alreadyConsumed);
+    } catch (HttpResponseException e) {
+      IncomingHttpResponse response =
+          httpRequest != null ? new IncomingHttpResponse(e, httpRequest) : null;
+      throw new FirebaseAppCheckException(
+          ErrorCode.INTERNAL,
+          "Error verifying App Check token with backend: " + e.getMessage(),
+          e,
+          response,
+          AppCheckErrorCode.SERVICE_ERROR);
     } catch (IOException e) {
       throw new FirebaseAppCheckException(
           ErrorCode.INTERNAL,

--- a/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
+++ b/src/main/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifier.java
@@ -73,7 +73,7 @@ public class AppCheckTokenVerifier {
   private final String projectId;
   private final HttpRequestFactory requestFactory;
   private final JsonFactory jsonFactory;
-  private volatile DefaultJWTProcessor<SecurityContext> jwtProcessor;
+  private final DefaultJWTProcessor<SecurityContext> jwtProcessor;
 
   public AppCheckTokenVerifier(FirebaseApp app) {
     this(
@@ -98,21 +98,7 @@ public class AppCheckTokenVerifier {
     this.projectId = getProjectId(app);
     this.requestFactory = checkNotNull(requestFactory, "HttpRequestFactory must not be null");
     this.jsonFactory = checkNotNull(jsonFactory, "JsonFactory must not be null");
-    this.jwtProcessor = jwtProcessor;
-  }
-
-  private DefaultJWTProcessor<SecurityContext> getJwtProcessor() {
-    DefaultJWTProcessor<SecurityContext> processor = this.jwtProcessor;
-    if (processor == null) {
-      synchronized (this) {
-        processor = this.jwtProcessor;
-        if (processor == null) {
-          processor = createJwtProcessor();
-          this.jwtProcessor = processor;
-        }
-      }
-    }
-    return processor;
+    this.jwtProcessor = jwtProcessor != null ? jwtProcessor : createJwtProcessor();
   }
 
   /**
@@ -160,7 +146,7 @@ public class AppCheckTokenVerifier {
     try {
       SignedJWT signedJwt = SignedJWT.parse(token);
       verifyHeader(signedJwt.getHeader());
-      JWTClaimsSet claims = getJwtProcessor().process(signedJwt, null);
+      JWTClaimsSet claims = this.jwtProcessor.process(signedJwt, null);
       verifyClaims(claims);
       return new DecodedAppCheckToken(claims.getClaims());
     } catch (ParseException e) {

--- a/src/test/java/com/google/firebase/appcheck/AppCheckErrorCodeTest.java
+++ b/src/test/java/com/google/firebase/appcheck/AppCheckErrorCodeTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+public class AppCheckErrorCodeTest {
+
+  @Test
+  public void testEnum() {
+    assertNotNull(AppCheckErrorCode.valueOf("INVALID_ARGUMENT"));
+    assertNotNull(AppCheckErrorCode.valueOf("INVALID_APP_CHECK_TOKEN"));
+    assertNotNull(AppCheckErrorCode.valueOf("APP_CHECK_TOKEN_EXPIRED"));
+    assertNotNull(AppCheckErrorCode.valueOf("INTERNAL_ERROR"));
+    assertNotNull(AppCheckErrorCode.valueOf("SERVICE_ERROR"));
+    assertEquals(5, AppCheckErrorCode.values().length);
+  }
+}

--- a/src/test/java/com/google/firebase/appcheck/DecodedAppCheckTokenTest.java
+++ b/src/test/java/com/google/firebase/appcheck/DecodedAppCheckTokenTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
 import com.google.firebase.internal.FirebaseProcessEnvironment;
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -81,8 +82,8 @@ public class DecodedAppCheckTokenTest {
     assertEquals(APP_ID, token.getSubject());
     assertEquals(ISSUER, token.getIssuer());
     assertEquals(ImmutableList.of(AUDIENCE), token.getAudience());
-    assertEquals(1600000000L, token.getIssuedAt());
-    assertEquals(1600003600L, token.getExpirationTime());
+    assertEquals(Instant.ofEpochMilli(1600000000000L), token.getIssuedAt());
+    assertEquals(Instant.ofEpochMilli(1600003600000L), token.getExpirationTime());
     assertEquals(claims, token.getClaims());
   }
 
@@ -98,8 +99,8 @@ public class DecodedAppCheckTokenTest {
     DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
 
     assertNotNull(token);
-    assertEquals(1600000000L, token.getIssuedAt());
-    assertEquals(1600003600L, token.getExpirationTime());
+    assertEquals(Instant.ofEpochSecond(1600000000L), token.getIssuedAt());
+    assertEquals(Instant.ofEpochSecond(1600003600L), token.getExpirationTime());
   }
 
   @Test
@@ -146,10 +147,10 @@ public class DecodedAppCheckTokenTest {
   }
 
   @Test
-  public void testTimestamps_ZeroWhenMissingOrUnknownType() {
+  public void testTimestamps_NullWhenMissingOrUnknownType() {
     Map<String, Object> claims = ImmutableMap.<String, Object>of("sub", APP_ID);
     DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
-    assertEquals(0L, token.getIssuedAt());
-    assertEquals(0L, token.getExpirationTime());
+    assertNull(token.getIssuedAt());
+    assertNull(token.getExpirationTime());
   }
 }

--- a/src/test/java/com/google/firebase/appcheck/DecodedAppCheckTokenTest.java
+++ b/src/test/java/com/google/firebase/appcheck/DecodedAppCheckTokenTest.java
@@ -74,13 +74,18 @@ public class DecodedAppCheckTokenTest {
             .put("aud", AUDIENCE)
             .put("iat", iat)
             .put("exp", exp)
+            .put("jti", "test-jwt-id")
+            .put("provider", "play_integrity")
             .build();
 
     DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
 
     assertNotNull(token);
     assertEquals(APP_ID, token.getSubject());
+    assertEquals(APP_ID, token.getAppId());
     assertEquals(ISSUER, token.getIssuer());
+    assertEquals("test-jwt-id", token.getJti());
+    assertEquals("play_integrity", token.getProvider());
     assertEquals(ImmutableList.of(AUDIENCE), token.getAudience());
     assertEquals(Instant.ofEpochMilli(1600000000000L), token.getIssuedAt());
     assertEquals(Instant.ofEpochMilli(1600003600000L), token.getExpirationTime());
@@ -99,6 +104,9 @@ public class DecodedAppCheckTokenTest {
     DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
 
     assertNotNull(token);
+    assertEquals(APP_ID, token.getAppId());
+    assertNull(token.getJti());
+    assertNull(token.getProvider());
     assertEquals(Instant.ofEpochSecond(1600000000L), token.getIssuedAt());
     assertEquals(Instant.ofEpochSecond(1600003600L), token.getExpirationTime());
   }

--- a/src/test/java/com/google/firebase/appcheck/DecodedAppCheckTokenTest.java
+++ b/src/test/java/com/google/firebase/appcheck/DecodedAppCheckTokenTest.java
@@ -82,7 +82,6 @@ public class DecodedAppCheckTokenTest {
 
     assertNotNull(token);
     assertEquals(APP_ID, token.getSubject());
-    assertEquals(APP_ID, token.getAppId());
     assertEquals(ISSUER, token.getIssuer());
     assertEquals("test-jwt-id", token.getJti());
     assertEquals("play_integrity", token.getProvider());
@@ -104,7 +103,7 @@ public class DecodedAppCheckTokenTest {
     DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
 
     assertNotNull(token);
-    assertEquals(APP_ID, token.getAppId());
+    assertEquals(APP_ID, token.getSubject());
     assertNull(token.getJti());
     assertNull(token.getProvider());
     assertEquals(Instant.ofEpochSecond(1600000000L), token.getIssuedAt());

--- a/src/test/java/com/google/firebase/appcheck/DecodedAppCheckTokenTest.java
+++ b/src/test/java/com/google/firebase/appcheck/DecodedAppCheckTokenTest.java
@@ -160,4 +160,27 @@ public class DecodedAppCheckTokenTest {
     assertNull(token.getIssuedAt());
     assertNull(token.getExpirationTime());
   }
+
+  @Test
+  public void testClaims_WithNullValues_DoesNotThrow() {
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("sub", APP_ID);
+    claims.put("custom_null_claim", null);
+
+    DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
+    assertNotNull(token);
+    assertEquals(APP_ID, token.getSubject());
+    assertTrue(token.getClaims().containsKey("custom_null_claim"));
+    assertNull(token.getClaims().get("custom_null_claim"));
+  }
+
+  @Test
+  public void testClaims_Unmodifiable() {
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("sub", APP_ID);
+
+    DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
+    assertThrows(
+        UnsupportedOperationException.class, () -> token.getClaims().put("new_key", "value"));
+  }
 }

--- a/src/test/java/com/google/firebase/appcheck/DecodedAppCheckTokenTest.java
+++ b/src/test/java/com/google/firebase/appcheck/DecodedAppCheckTokenTest.java
@@ -154,6 +154,22 @@ public class DecodedAppCheckTokenTest {
   }
 
   @Test
+  public void testGetAudience_WithMixedAndNullElements_FiltersOnlyStrings() {
+    java.util.List<Object> rawAudience = new java.util.ArrayList<>();
+    rawAudience.add("aud1");
+    rawAudience.add(12345);
+    rawAudience.add(null);
+    rawAudience.add("aud2");
+
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("sub", APP_ID);
+    claims.put("aud", rawAudience);
+
+    DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
+    assertEquals(ImmutableList.of("aud1", "aud2"), token.getAudience());
+  }
+
+  @Test
   public void testTimestamps_NullWhenMissingOrUnknownType() {
     Map<String, Object> claims = ImmutableMap.<String, Object>of("sub", APP_ID);
     DecodedAppCheckToken token = new DecodedAppCheckToken(claims);

--- a/src/test/java/com/google/firebase/appcheck/DecodedAppCheckTokenTest.java
+++ b/src/test/java/com/google/firebase/appcheck/DecodedAppCheckTokenTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.firebase.TestOnlyImplFirebaseTrampolines;
+import com.google.firebase.internal.FirebaseProcessEnvironment;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Test;
+
+public class DecodedAppCheckTokenTest {
+
+  private static final String APP_ID = "test-app-id";
+  private static final String ISSUER = "https://firebaseappcheck.googleapis.com/";
+  private static final String AUDIENCE = "projects/test-project-id";
+
+  @After
+  public void tearDown() {
+    FirebaseProcessEnvironment.clearCache();
+    TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
+  }
+
+  @Test
+  public void testNullClaims_ThrowsException() {
+    NullPointerException e =
+        assertThrows(NullPointerException.class, () -> new DecodedAppCheckToken(null));
+    assertTrue(e.getMessage().contains("Claims map must not be null"));
+  }
+
+  @Test
+  public void testMissingSub_ThrowsException() {
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("iss", ISSUER);
+
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> new DecodedAppCheckToken(claims));
+    assertTrue(e.getMessage().contains("Claims map must contain sub"));
+  }
+
+  @Test
+  public void testGetters_WithDateTimestamps() {
+    Date iat = new Date(1600000000000L);
+    Date exp = new Date(1600003600000L);
+
+    Map<String, Object> claims =
+        ImmutableMap.<String, Object>builder()
+            .put("sub", APP_ID)
+            .put("iss", ISSUER)
+            .put("aud", AUDIENCE)
+            .put("iat", iat)
+            .put("exp", exp)
+            .build();
+
+    DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
+
+    assertNotNull(token);
+    assertEquals(APP_ID, token.getSubject());
+    assertEquals(ISSUER, token.getIssuer());
+    assertEquals(ImmutableList.of(AUDIENCE), token.getAudience());
+    assertEquals(1600000000L, token.getIssuedAt());
+    assertEquals(1600003600L, token.getExpirationTime());
+    assertEquals(claims, token.getClaims());
+  }
+
+  @Test
+  public void testGetters_WithNumericTimestamps() {
+    Map<String, Object> claims =
+        ImmutableMap.<String, Object>builder()
+            .put("sub", APP_ID)
+            .put("iat", 1600000000L)
+            .put("exp", 1600003600L)
+            .build();
+
+    DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
+
+    assertNotNull(token);
+    assertEquals(1600000000L, token.getIssuedAt());
+    assertEquals(1600003600L, token.getExpirationTime());
+  }
+
+  @Test
+  public void testGetAudience_ListFormat() {
+    Map<String, Object> claims =
+        ImmutableMap.<String, Object>of(
+            "sub", APP_ID,
+            "aud", ImmutableList.of("aud1", "aud2"));
+
+    DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
+
+    assertEquals(ImmutableList.of("aud1", "aud2"), token.getAudience());
+  }
+
+  @Test
+  public void testGetAudience_StringFormat() {
+    Map<String, Object> claims =
+        ImmutableMap.<String, Object>of(
+            "sub", APP_ID,
+            "aud", AUDIENCE);
+
+    DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
+
+    assertEquals(ImmutableList.of(AUDIENCE), token.getAudience());
+  }
+
+  @Test
+  public void testGetAudience_EmptyList() {
+    Map<String, Object> claims =
+        ImmutableMap.<String, Object>of(
+            "sub", APP_ID,
+            "aud", ImmutableList.of());
+
+    DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
+
+    assertEquals(ImmutableList.of(), token.getAudience());
+  }
+
+  @Test
+  public void testGetAudience_EmptyWhenMissingOrUnknownType() {
+    Map<String, Object> claims = ImmutableMap.<String, Object>of("sub", APP_ID);
+    DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
+    assertEquals(ImmutableList.of(), token.getAudience());
+  }
+
+  @Test
+  public void testTimestamps_ZeroWhenMissingOrUnknownType() {
+    Map<String, Object> claims = ImmutableMap.<String, Object>of("sub", APP_ID);
+    DecodedAppCheckToken token = new DecodedAppCheckToken(claims);
+    assertEquals(0L, token.getIssuedAt());
+    assertEquals(0L, token.getExpirationTime());
+  }
+}

--- a/src/test/java/com/google/firebase/appcheck/FirebaseAppCheckExceptionTest.java
+++ b/src/test/java/com/google/firebase/appcheck/FirebaseAppCheckExceptionTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import com.google.firebase.ErrorCode;
+import com.google.firebase.FirebaseException;
+import org.junit.Test;
+
+public class FirebaseAppCheckExceptionTest {
+
+  @Test
+  public void testConstructorWithAppCheckErrorCode() {
+    Exception cause = new Exception("cause");
+    FirebaseAppCheckException exception =
+        new FirebaseAppCheckException(
+            ErrorCode.INVALID_ARGUMENT,
+            "Invalid token",
+            cause,
+            null,
+            AppCheckErrorCode.APP_CHECK_TOKEN_EXPIRED);
+
+    assertEquals(ErrorCode.INVALID_ARGUMENT, exception.getErrorCode());
+    assertEquals("Invalid token", exception.getMessage());
+    assertSame(cause, exception.getCause());
+    assertNull(exception.getHttpResponse());
+    assertEquals(AppCheckErrorCode.APP_CHECK_TOKEN_EXPIRED, exception.getAppCheckErrorCode());
+  }
+
+  @Test
+  public void testConstructorWithoutAppCheckErrorCode() {
+    FirebaseAppCheckException exception =
+        new FirebaseAppCheckException(ErrorCode.INTERNAL, "Internal error");
+
+    assertEquals(ErrorCode.INTERNAL, exception.getErrorCode());
+    assertEquals("Internal error", exception.getMessage());
+    assertNull(exception.getCause());
+    assertNull(exception.getHttpResponse());
+    assertNull(exception.getAppCheckErrorCode());
+  }
+
+  @Test
+  public void testConstructorWithCause() {
+    Exception cause = new Exception("cause");
+    FirebaseAppCheckException exception =
+        new FirebaseAppCheckException(ErrorCode.UNKNOWN, "Unknown error", cause);
+
+    assertEquals(ErrorCode.UNKNOWN, exception.getErrorCode());
+    assertEquals("Unknown error", exception.getMessage());
+    assertSame(cause, exception.getCause());
+    assertNull(exception.getAppCheckErrorCode());
+  }
+
+  @Test
+  public void testConstructorFromFirebaseException() {
+    FirebaseException base =
+        new FirebaseException(ErrorCode.UNAVAILABLE, "Service unavailable", null);
+    FirebaseAppCheckException exception = new FirebaseAppCheckException(base);
+
+    assertEquals(ErrorCode.UNAVAILABLE, exception.getErrorCode());
+    assertEquals("Service unavailable", exception.getMessage());
+    assertNull(exception.getAppCheckErrorCode());
+  }
+}

--- a/src/test/java/com/google/firebase/appcheck/FirebaseAppCheckTest.java
+++ b/src/test/java/com/google/firebase/appcheck/FirebaseAppCheckTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFuture;
+import com.google.common.collect.ImmutableMap;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.TestOnlyImplFirebaseTrampolines;
+import com.google.firebase.appcheck.internal.AppCheckTokenVerifier;
+import com.google.firebase.internal.FirebaseProcessEnvironment;
+import com.google.firebase.testing.ServiceAccount;
+import com.google.firebase.testing.TestUtils;
+import java.lang.reflect.Field;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class FirebaseAppCheckTest {
+
+  private static final FirebaseOptions firebaseOptions =
+      FirebaseOptions.builder()
+          .setCredentials(TestUtils.getCertCredential(ServiceAccount.OWNER.asStream()))
+          .setProjectId("test-project-id")
+          .build();
+
+  @Mock private AppCheckTokenVerifier mockVerifier;
+
+  private FirebaseAppCheck firebaseAppCheck;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+
+    FirebaseApp.initializeApp(firebaseOptions);
+    firebaseAppCheck = FirebaseAppCheck.getInstance();
+
+    Field verifierField = FirebaseAppCheck.class.getDeclaredField("tokenVerifier");
+    verifierField.setAccessible(true);
+    verifierField.set(firebaseAppCheck, mockVerifier);
+  }
+
+  @After
+  public void tearDown() {
+    FirebaseProcessEnvironment.clearCache();
+    TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
+  }
+
+  @Test
+  public void testGetInstance() {
+    FirebaseAppCheck instance = FirebaseAppCheck.getInstance();
+    assertNotNull(instance);
+    assertSame(instance, FirebaseAppCheck.getInstance());
+  }
+
+  @Test
+  public void testGetInstanceForApp() {
+    FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "testGetInstanceForApp");
+    FirebaseAppCheck instance = FirebaseAppCheck.getInstance(app);
+    assertNotNull(instance);
+    assertSame(instance, FirebaseAppCheck.getInstance(app));
+  }
+
+  @Test
+  public void testVerifyToken_DelegatesToVerifier() throws FirebaseAppCheckException {
+    String testToken = "test.token";
+    DecodedAppCheckToken decodedToken =
+        new DecodedAppCheckToken(ImmutableMap.<String, Object>of("sub", "app-id"));
+    VerifyAppCheckTokenResponse expectedResponse =
+        new VerifyAppCheckTokenResponse("app-id", decodedToken, null);
+
+    when(mockVerifier.verifyToken(testToken, null)).thenReturn(expectedResponse);
+
+    VerifyAppCheckTokenResponse result = firebaseAppCheck.verifyToken(testToken);
+
+    assertEquals(expectedResponse, result);
+    verify(mockVerifier, times(1)).verifyToken(testToken, null);
+  }
+
+  @Test
+  public void testVerifyTokenWithOptions_DelegatesToVerifier() throws FirebaseAppCheckException {
+    String testToken = "test.token";
+    VerifyAppCheckTokenOptions options =
+        VerifyAppCheckTokenOptions.builder().setConsume(true).build();
+    DecodedAppCheckToken decodedToken =
+        new DecodedAppCheckToken(ImmutableMap.<String, Object>of("sub", "app-id"));
+    VerifyAppCheckTokenResponse expectedResponse =
+        new VerifyAppCheckTokenResponse("app-id", decodedToken, true);
+
+    when(mockVerifier.verifyToken(testToken, options)).thenReturn(expectedResponse);
+
+    VerifyAppCheckTokenResponse result = firebaseAppCheck.verifyToken(testToken, options);
+
+    assertEquals(expectedResponse, result);
+    verify(mockVerifier, times(1)).verifyToken(testToken, options);
+  }
+
+  @Test
+  public void testVerifyTokenAsync_DelegatesToVerifier() throws Exception {
+    String testToken = "test.token";
+    DecodedAppCheckToken decodedToken =
+        new DecodedAppCheckToken(ImmutableMap.<String, Object>of("sub", "app-id"));
+    VerifyAppCheckTokenResponse expectedResponse =
+        new VerifyAppCheckTokenResponse("app-id", decodedToken, null);
+
+    when(mockVerifier.verifyToken(testToken, null)).thenReturn(expectedResponse);
+
+    ApiFuture<VerifyAppCheckTokenResponse> future = firebaseAppCheck.verifyTokenAsync(testToken);
+
+    assertEquals(expectedResponse, future.get());
+    verify(mockVerifier, times(1)).verifyToken(testToken, null);
+  }
+
+  @Test
+  public void testVerifyTokenAsyncWithOptions_DelegatesToVerifier() throws Exception {
+    String testToken = "test.token";
+    VerifyAppCheckTokenOptions options =
+        VerifyAppCheckTokenOptions.builder().setConsume(true).build();
+    DecodedAppCheckToken decodedToken =
+        new DecodedAppCheckToken(ImmutableMap.<String, Object>of("sub", "app-id"));
+    VerifyAppCheckTokenResponse expectedResponse =
+        new VerifyAppCheckTokenResponse("app-id", decodedToken, true);
+
+    when(mockVerifier.verifyToken(testToken, options)).thenReturn(expectedResponse);
+
+    ApiFuture<VerifyAppCheckTokenResponse> future =
+        firebaseAppCheck.verifyTokenAsync(testToken, options);
+
+    assertEquals(expectedResponse, future.get());
+    verify(mockVerifier, times(1)).verifyToken(testToken, options);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNullApp_ThrowsException() {
+    new FirebaseAppCheck(null, mockVerifier);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNullVerifier_ThrowsException() {
+    FirebaseApp app = FirebaseApp.getInstance();
+    new FirebaseAppCheck(app, null);
+  }
+}

--- a/src/test/java/com/google/firebase/appcheck/VerifyAppCheckTokenOptionsTest.java
+++ b/src/test/java/com/google/firebase/appcheck/VerifyAppCheckTokenOptionsTest.java
@@ -16,10 +16,13 @@
 
 package com.google.firebase.appcheck;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Optional;
 import org.junit.Test;
 
 public class VerifyAppCheckTokenOptionsTest {
@@ -47,5 +50,31 @@ public class VerifyAppCheckTokenOptionsTest {
     assertNotNull(options);
     assertTrue(options.getConsume().isPresent());
     assertFalse(options.getConsume().get());
+  }
+
+  @Test
+  public void testBuilder_SetConsumeOptional_Present() {
+    VerifyAppCheckTokenOptions options =
+        VerifyAppCheckTokenOptions.builder().setConsume(Optional.of(true)).build();
+    assertNotNull(options);
+    assertTrue(options.getConsume().isPresent());
+    assertTrue(options.getConsume().get());
+  }
+
+  @Test
+  public void testBuilder_SetConsumeOptional_Empty() {
+    VerifyAppCheckTokenOptions options =
+        VerifyAppCheckTokenOptions.builder().setConsume(Optional.empty()).build();
+    assertNotNull(options);
+    assertFalse(options.getConsume().isPresent());
+  }
+
+  @Test
+  public void testBuilder_SetConsumeOptionalNull_ThrowsException() {
+    NullPointerException e =
+        assertThrows(
+            NullPointerException.class,
+            () -> VerifyAppCheckTokenOptions.builder().setConsume((Optional<Boolean>) null));
+    assertEquals("consume must not be null", e.getMessage());
   }
 }

--- a/src/test/java/com/google/firebase/appcheck/VerifyAppCheckTokenOptionsTest.java
+++ b/src/test/java/com/google/firebase/appcheck/VerifyAppCheckTokenOptionsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class VerifyAppCheckTokenOptionsTest {
+
+  @Test
+  public void testDefaultBuilder_EmptyConsume() {
+    VerifyAppCheckTokenOptions options = VerifyAppCheckTokenOptions.builder().build();
+    assertNotNull(options);
+    assertFalse(options.getConsume().isPresent());
+  }
+
+  @Test
+  public void testBuilder_SetConsumeTrue() {
+    VerifyAppCheckTokenOptions options =
+        VerifyAppCheckTokenOptions.builder().setConsume(true).build();
+    assertNotNull(options);
+    assertTrue(options.getConsume().isPresent());
+    assertTrue(options.getConsume().get());
+  }
+
+  @Test
+  public void testBuilder_SetConsumeFalse() {
+    VerifyAppCheckTokenOptions options =
+        VerifyAppCheckTokenOptions.builder().setConsume(false).build();
+    assertNotNull(options);
+    assertTrue(options.getConsume().isPresent());
+    assertFalse(options.getConsume().get());
+  }
+}

--- a/src/test/java/com/google/firebase/appcheck/VerifyAppCheckTokenResponseTest.java
+++ b/src/test/java/com/google/firebase/appcheck/VerifyAppCheckTokenResponseTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+public class VerifyAppCheckTokenResponseTest {
+
+  private static final String APP_ID = "test-app-id";
+  private static final DecodedAppCheckToken DECODED_TOKEN =
+      new DecodedAppCheckToken(ImmutableMap.<String, Object>of("sub", APP_ID));
+
+  @Test
+  public void testNullAppId_ThrowsException() {
+    NullPointerException e =
+        assertThrows(
+            NullPointerException.class,
+            () -> new VerifyAppCheckTokenResponse(null, DECODED_TOKEN, null));
+    assertTrue(e.getMessage().contains("appId must not be null"));
+  }
+
+  @Test
+  public void testNullToken_ThrowsException() {
+    NullPointerException e =
+        assertThrows(
+            NullPointerException.class,
+            () -> new VerifyAppCheckTokenResponse(APP_ID, null, null));
+    assertTrue(e.getMessage().contains("token must not be null"));
+  }
+
+  @Test
+  public void testGetters_WithoutAlreadyConsumed() {
+    VerifyAppCheckTokenResponse response =
+        new VerifyAppCheckTokenResponse(APP_ID, DECODED_TOKEN, null);
+
+    assertNotNull(response);
+    assertEquals(APP_ID, response.getAppId());
+    assertEquals(DECODED_TOKEN, response.getToken());
+    assertFalse(response.isAlreadyConsumed().isPresent());
+  }
+
+  @Test
+  public void testGetters_WithAlreadyConsumedTrue() {
+    VerifyAppCheckTokenResponse response =
+        new VerifyAppCheckTokenResponse(APP_ID, DECODED_TOKEN, true);
+
+    assertNotNull(response);
+    assertEquals(APP_ID, response.getAppId());
+    assertEquals(DECODED_TOKEN, response.getToken());
+    assertTrue(response.isAlreadyConsumed().isPresent());
+    assertTrue(response.isAlreadyConsumed().get());
+  }
+
+  @Test
+  public void testGetters_WithAlreadyConsumedFalse() {
+    VerifyAppCheckTokenResponse response =
+        new VerifyAppCheckTokenResponse(APP_ID, DECODED_TOKEN, false);
+
+    assertNotNull(response);
+    assertEquals(APP_ID, response.getAppId());
+    assertEquals(DECODED_TOKEN, response.getToken());
+    assertTrue(response.isAlreadyConsumed().isPresent());
+    assertFalse(response.isAlreadyConsumed().get());
+  }
+}

--- a/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
+++ b/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
@@ -1,0 +1,441 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.http.LowLevelHttpResponse;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.ErrorCode;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.TestOnlyImplFirebaseTrampolines;
+import com.google.firebase.appcheck.DecodedAppCheckToken;
+import com.google.firebase.appcheck.FirebaseAppCheckException;
+import com.google.firebase.appcheck.VerifyAppCheckTokenOptions;
+import com.google.firebase.appcheck.VerifyAppCheckTokenResponse;
+import com.google.firebase.internal.ApiClientUtils;
+import com.google.firebase.internal.FirebaseProcessEnvironment;
+import com.google.firebase.testing.ServiceAccount;
+import com.google.firebase.testing.TestUtils;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import com.nimbusds.jwt.proc.ExpiredJWTException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Collections;
+import java.util.Date;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class AppCheckTokenVerifierTest {
+
+  private static final String PROJECT_ID = "test-project-id";
+  private static final FirebaseOptions firebaseOptions =
+      FirebaseOptions.builder()
+          .setProjectId(PROJECT_ID)
+          .setCredentials(TestUtils.getCertCredential(ServiceAccount.OWNER.asStream()))
+          .build();
+  private static final String ISSUER = "https://firebaseappcheck.googleapis.com/";
+  private static final String AUDIENCE = "projects/" + PROJECT_ID;
+  private static final String APP_ID = "test-app-id";
+  private static final String KEY_ID = "key-id-1";
+
+  @Mock private DefaultJWTProcessor<SecurityContext> mockJwtProcessor;
+
+  private AppCheckTokenVerifier verifier;
+  private KeyPair rsaKeyPair;
+  private JWSHeader header;
+  private JWTClaimsSet claims;
+  private Date issueTime;
+  private Date expirationTime;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+
+    issueTime = new Date();
+    expirationTime = new Date(System.currentTimeMillis() + 10000);
+
+    KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+    gen.initialize(2048);
+    rsaKeyPair = gen.generateKeyPair();
+
+    FirebaseApp firebaseApp = FirebaseApp.initializeApp(firebaseOptions);
+
+    HttpRequestFactory requestFactory = ApiClientUtils.newAuthorizedRequestFactory(firebaseApp);
+    JsonFactory jsonFactory = ApiClientUtils.getDefaultJsonFactory();
+
+    verifier =
+        new AppCheckTokenVerifier(firebaseApp, requestFactory, jsonFactory, mockJwtProcessor);
+
+    header =
+        new JWSHeader.Builder(JWSAlgorithm.RS256)
+            .keyID(KEY_ID)
+            .type(JOSEObjectType.JWT)
+            .build();
+
+    claims =
+        new JWTClaimsSet.Builder()
+            .issuer(ISSUER)
+            .audience(AUDIENCE)
+            .subject(APP_ID)
+            .issueTime(issueTime)
+            .expirationTime(expirationTime)
+            .build();
+  }
+
+  @After
+  public void tearDown() {
+    FirebaseProcessEnvironment.clearCache();
+    TestOnlyImplFirebaseTrampolines.clearInstancesForTest();
+  }
+
+  private String createToken(JWSHeader header, JWTClaimsSet claims) throws Exception {
+    SignedJWT jwt = new SignedJWT(header, claims);
+
+    if (JWSAlgorithm.RS256.equals(header.getAlgorithm())
+        || JWSAlgorithm.RS384.equals(header.getAlgorithm())
+        || JWSAlgorithm.RS512.equals(header.getAlgorithm())) {
+      jwt.sign(new RSASSASigner(rsaKeyPair.getPrivate()));
+    } else if (JWSAlgorithm.HS256.equals(header.getAlgorithm())) {
+      jwt.sign(new com.nimbusds.jose.crypto.MACSigner("12345678901234567890123456789012"));
+    }
+
+    return jwt.serialize();
+  }
+
+  @Test
+  public void testVerifyToken_Success() throws Exception {
+    String token = createToken(header, claims);
+    when(mockJwtProcessor.process(any(SignedJWT.class), any())).thenReturn(claims);
+
+    VerifyAppCheckTokenResponse response = verifier.verifyToken(token);
+
+    assertNotNull(response);
+    assertEquals(APP_ID, response.getAppId());
+    assertNotNull(response.getToken());
+    assertFalse(response.isAlreadyConsumed().isPresent());
+
+    DecodedAppCheckToken decodedToken = response.getToken();
+    assertEquals(APP_ID, decodedToken.getSubject());
+    assertEquals(ISSUER, decodedToken.getIssuer());
+    assertEquals(Collections.singletonList(AUDIENCE), decodedToken.getAudience());
+    assertEquals(issueTime.getTime() / 1000L, decodedToken.getIssuedAt());
+    assertEquals(expirationTime.getTime() / 1000L, decodedToken.getExpirationTime());
+    assertEquals(ISSUER, decodedToken.getClaims().get("iss"));
+    assertEquals(APP_ID, decodedToken.getClaims().get("sub"));
+  }
+
+  @Test
+  public void testVerifyToken_WithConsumeOption_CallsBackend() throws Exception {
+    when(mockJwtProcessor.process(any(SignedJWT.class), any())).thenReturn(claims);
+
+    MockLowLevelHttpResponse mockResponse = new MockLowLevelHttpResponse();
+    mockResponse.setContentType("application/json");
+    mockResponse.setContent("{\"alreadyConsumed\": true}");
+
+    MockHttpTransport transport =
+        new MockHttpTransport.Builder().setLowLevelHttpResponse(mockResponse).build();
+
+    HttpRequestFactory mockRequestFactory = transport.createRequestFactory();
+    JsonFactory jsonFactory = ApiClientUtils.getDefaultJsonFactory();
+
+    FirebaseApp app = FirebaseApp.getInstance();
+    AppCheckTokenVerifier customVerifier =
+        new AppCheckTokenVerifier(app, mockRequestFactory, jsonFactory, mockJwtProcessor);
+
+    String token = createToken(header, claims);
+    VerifyAppCheckTokenOptions options =
+        VerifyAppCheckTokenOptions.builder().setConsume(true).build();
+    VerifyAppCheckTokenResponse response = customVerifier.verifyToken(token, options);
+
+    assertNotNull(response);
+    assertEquals(APP_ID, response.getAppId());
+    assertTrue(response.isAlreadyConsumed().isPresent());
+    assertTrue(response.isAlreadyConsumed().get());
+  }
+
+  @Test
+  public void testVerifyToken_NullOrEmptyToken_ThrowsException() {
+    IllegalArgumentException ex1 =
+        assertThrows(IllegalArgumentException.class, () -> verifier.verifyToken(null));
+    assertTrue(ex1.getMessage().contains("must not be null or empty"));
+
+    IllegalArgumentException ex2 =
+        assertThrows(IllegalArgumentException.class, () -> verifier.verifyToken(""));
+    assertTrue(ex2.getMessage().contains("must not be null or empty"));
+  }
+
+  @Test
+  public void testVerifyHeader_IncorrectAlgorithm_ThrowsException() throws Exception {
+    JWSHeader badHeader =
+        new JWSHeader.Builder(JWSAlgorithm.RS384)
+            .keyID(KEY_ID)
+            .type(JOSEObjectType.JWT)
+            .build();
+    final String token = createToken(badHeader, claims);
+
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(token));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("incorrect algorithm"));
+  }
+
+  @Test
+  public void testVerifyHeader_MissingKid_ThrowsException() throws Exception {
+    JWSHeader badHeader =
+        new JWSHeader.Builder(JWSAlgorithm.RS256).type(JOSEObjectType.JWT).build();
+    final String token = createToken(badHeader, claims);
+
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(token));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("no 'kid'"));
+  }
+
+  @Test
+  public void testVerifyHeader_IncorrectType_ThrowsException() throws Exception {
+    JWSHeader badHeader =
+        new JWSHeader.Builder(JWSAlgorithm.RS256)
+            .keyID(KEY_ID)
+            .type(JOSEObjectType.JOSE)
+            .build();
+    String token = createToken(badHeader, claims);
+
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(token));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("incorrect 'typ'"));
+  }
+
+  @Test
+  public void testVerifyClaims_MissingIssuer_ThrowsException() throws Exception {
+    JWTClaimsSet badClaims =
+        new JWTClaimsSet.Builder()
+            .audience(AUDIENCE)
+            .subject(APP_ID)
+            .expirationTime(new Date(System.currentTimeMillis() + 10000))
+            .build();
+    String token = createToken(header, badClaims);
+    when(mockJwtProcessor.process(any(SignedJWT.class), any())).thenReturn(badClaims);
+
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(token));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("no 'iss'"));
+  }
+
+  @Test
+  public void testVerifyClaims_IncorrectIssuer_ThrowsException() throws Exception {
+    JWTClaimsSet badClaims =
+        new JWTClaimsSet.Builder()
+            .issuer("https://invalid-issuer.com")
+            .audience(AUDIENCE)
+            .subject(APP_ID)
+            .expirationTime(new Date(System.currentTimeMillis() + 10000))
+            .build();
+    String token = createToken(header, badClaims);
+    when(mockJwtProcessor.process(any(SignedJWT.class), any())).thenReturn(badClaims);
+
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(token));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("incorrect issuer"));
+  }
+
+  @Test
+  public void testVerifyClaims_MissingAudience_ThrowsException() throws Exception {
+    JWTClaimsSet badClaims =
+        new JWTClaimsSet.Builder()
+            .issuer(ISSUER)
+            .subject(APP_ID)
+            .expirationTime(new Date(System.currentTimeMillis() + 10000))
+            .build();
+    String token = createToken(header, badClaims);
+    when(mockJwtProcessor.process(any(SignedJWT.class), any())).thenReturn(badClaims);
+
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(token));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("incorrect audience"));
+  }
+
+  @Test
+  public void testVerifyClaims_IncorrectAudience_ThrowsException() throws Exception {
+    JWTClaimsSet badClaims =
+        new JWTClaimsSet.Builder()
+            .issuer(ISSUER)
+            .audience("projects/wrong-project-id")
+            .subject(APP_ID)
+            .expirationTime(new Date(System.currentTimeMillis() + 10000))
+            .build();
+    String token = createToken(header, badClaims);
+    when(mockJwtProcessor.process(any(SignedJWT.class), any())).thenReturn(badClaims);
+
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(token));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("incorrect audience"));
+  }
+
+  @Test
+  public void testVerifyClaims_MissingSubject_ThrowsException() throws Exception {
+    JWTClaimsSet badClaims =
+        new JWTClaimsSet.Builder()
+            .issuer(ISSUER)
+            .audience(AUDIENCE)
+            .expirationTime(new Date(System.currentTimeMillis() + 10000))
+            .build();
+    String token = createToken(header, badClaims);
+    when(mockJwtProcessor.process(any(SignedJWT.class), any())).thenReturn(badClaims);
+
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(token));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("empty 'sub'"));
+  }
+
+  @Test
+  public void testVerifyToken_ExpiredToken_ThrowsException() throws Exception {
+    String token = createToken(header, claims);
+    when(mockJwtProcessor.process(any(SignedJWT.class), any()))
+        .thenThrow(new ExpiredJWTException("Expired token"));
+
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(token));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("has expired"));
+  }
+
+  @Test
+  public void testVerifyToken_BadJOSEException_ThrowsException() throws Exception {
+    String token = createToken(header, claims);
+    when(mockJwtProcessor.process(any(SignedJWT.class), any()))
+        .thenThrow(new BadJOSEException("Bad signature"));
+
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(token));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("token is invalid"));
+  }
+
+  @Test
+  public void testVerifyToken_JOSEException_ThrowsException() throws Exception {
+    String token = createToken(header, claims);
+    when(mockJwtProcessor.process(any(SignedJWT.class), any()))
+        .thenThrow(new JOSEException("Key error"));
+
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(token));
+    assertEquals(ErrorCode.INTERNAL, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("Failed to verify App Check token signature"));
+  }
+
+  @Test
+  public void testVerifyToken_ParseException_ThrowsException() {
+    String invalidToken = "invalid-token-string";
+
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(invalidToken));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("Failed to parse App Check JWT token"));
+  }
+
+  @Test
+  public void testVerifyToken_Claims_Null() throws Exception {
+    JWTClaimsSet noSubClaims = new JWTClaimsSet.Builder().build();
+    String tokenString = createToken(header, noSubClaims);
+    when(mockJwtProcessor.process(any(SignedJWT.class), any())).thenReturn(null);
+
+    NullPointerException e =
+        assertThrows(NullPointerException.class, () -> verifier.verifyToken(tokenString));
+    assertTrue(e.getMessage().contains("JWTClaimsSet claims must not be null"));
+  }
+
+  @Test
+  public void testVerifierWithoutProjectId() {
+    FirebaseOptions localFirebaseOptions =
+        FirebaseOptions.builder()
+            .setCredentials(GoogleCredentials.create(null))
+            .build();
+
+    FirebaseApp localApp =
+        FirebaseApp.initializeApp(localFirebaseOptions, "no-project-id-app");
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> new AppCheckTokenVerifier(localApp));
+    assertEquals("Project ID is required in FirebaseOptions.", e.getMessage());
+  }
+
+  @Test
+  public void testCreateJwtProcessor_HandlesException() throws Exception {
+    FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "third");
+    AppCheckTokenVerifier original = new AppCheckTokenVerifier(app);
+    AppCheckTokenVerifier spyClass = spy(original);
+
+    doThrow(new MalformedURLException("Simulated bad URL"))
+        .when(spyClass)
+        .createKeySource();
+
+    Method method = AppCheckTokenVerifier.class.getDeclaredMethod("createJwtProcessor");
+    method.setAccessible(true);
+
+    try {
+      method.invoke(spyClass);
+    } catch (Exception e) {
+      Throwable cause = e.getCause();
+      assertEquals(IllegalStateException.class, cause.getClass());
+      assertEquals("Invalid JWKS URL", cause.getMessage());
+      assertTrue(cause.getCause() instanceof MalformedURLException);
+    }
+  }
+}

--- a/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
+++ b/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
@@ -364,7 +364,7 @@ public class AppCheckTokenVerifierTest {
     FirebaseAppCheckException ex =
         assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(token));
     assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
-    assertTrue(ex.getMessage().contains("token is invalid"));
+    assertTrue(ex.getMessage().contains("Failed to verify App Check token signature"));
   }
 
   @Test
@@ -376,7 +376,7 @@ public class AppCheckTokenVerifierTest {
     FirebaseAppCheckException ex =
         assertThrows(FirebaseAppCheckException.class, () -> verifier.verifyToken(token));
     assertEquals(ErrorCode.INTERNAL, ex.getErrorCode());
-    assertTrue(ex.getMessage().contains("Failed to verify App Check token signature"));
+    assertTrue(ex.getMessage().contains("Internal error processing App Check token"));
   }
 
   @Test

--- a/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
+++ b/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
@@ -210,6 +210,36 @@ public class AppCheckTokenVerifierTest {
   }
 
   @Test
+  public void testVerifyToken_WithConsumeOption_EmptyBackendResponse_DoesNotThrow()
+      throws Exception {
+    when(mockJwtProcessor.process(any(SignedJWT.class), any())).thenReturn(claims);
+
+    MockLowLevelHttpResponse mockResponse = new MockLowLevelHttpResponse();
+    mockResponse.setStatusCode(204);
+    mockResponse.setContent("");
+
+    MockHttpTransport transport =
+        new MockHttpTransport.Builder().setLowLevelHttpResponse(mockResponse).build();
+
+    HttpRequestFactory mockRequestFactory = transport.createRequestFactory();
+    JsonFactory jsonFactory = ApiClientUtils.getDefaultJsonFactory();
+
+    FirebaseApp app = FirebaseApp.getInstance();
+    AppCheckTokenVerifier customVerifier =
+        new AppCheckTokenVerifier(app, mockRequestFactory, jsonFactory, mockJwtProcessor);
+
+    String token = createToken(header, claims);
+    VerifyAppCheckTokenOptions options =
+        VerifyAppCheckTokenOptions.builder().setConsume(true).build();
+    VerifyAppCheckTokenResponse response = customVerifier.verifyToken(token, options);
+
+    assertNotNull(response);
+    assertEquals(APP_ID, response.getAppId());
+    assertTrue(response.isAlreadyConsumed().isPresent());
+    assertFalse(response.isAlreadyConsumed().get());
+  }
+
+  @Test
   public void testVerifyToken_NullOrEmptyToken_ThrowsException() {
     IllegalArgumentException ex1 =
         assertThrows(IllegalArgumentException.class, () -> verifier.verifyToken(null));

--- a/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
+++ b/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
@@ -44,6 +44,7 @@ import com.google.firebase.ErrorCode;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.TestOnlyImplFirebaseTrampolines;
+import com.google.firebase.appcheck.AppCheckErrorCode;
 import com.google.firebase.appcheck.DecodedAppCheckToken;
 import com.google.firebase.appcheck.FirebaseAppCheckException;
 import com.google.firebase.appcheck.VerifyAppCheckTokenOptions;
@@ -506,6 +507,7 @@ public class AppCheckTokenVerifierTest {
     FirebaseAppCheckException ex =
         assertThrows(FirebaseAppCheckException.class, () -> realVerifier.verifyToken(token));
     assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertEquals(AppCheckErrorCode.INVALID_APP_CHECK_TOKEN, ex.getAppCheckErrorCode());
     assertTrue(ex.getMessage().contains("Failed to verify App Check token signature"));
   }
 
@@ -546,6 +548,7 @@ public class AppCheckTokenVerifierTest {
     FirebaseAppCheckException ex =
         assertThrows(FirebaseAppCheckException.class, () -> realVerifier.verifyToken(token));
     assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertEquals(AppCheckErrorCode.APP_CHECK_TOKEN_EXPIRED, ex.getAppCheckErrorCode());
     assertTrue(ex.getMessage().contains("Firebase App Check token has expired."));
   }
 }

--- a/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
+++ b/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
@@ -240,6 +240,40 @@ public class AppCheckTokenVerifierTest {
   }
 
   @Test
+  public void testVerifyToken_WithConsumeOption_HttpResponseException_AttachesHttpResponse()
+      throws Exception {
+    when(mockJwtProcessor.process(any(SignedJWT.class), any())).thenReturn(claims);
+
+    MockLowLevelHttpResponse mockResponse = new MockLowLevelHttpResponse();
+    mockResponse.setStatusCode(403);
+    mockResponse.setContentType("application/json");
+    mockResponse.setContent("{\"error\": \"Forbidden\"}");
+
+    MockHttpTransport transport =
+        new MockHttpTransport.Builder().setLowLevelHttpResponse(mockResponse).build();
+
+    HttpRequestFactory mockRequestFactory = transport.createRequestFactory();
+    JsonFactory jsonFactory = ApiClientUtils.getDefaultJsonFactory();
+
+    FirebaseApp app = FirebaseApp.getInstance();
+    AppCheckTokenVerifier customVerifier =
+        new AppCheckTokenVerifier(app, mockRequestFactory, jsonFactory, mockJwtProcessor);
+
+    String token = createToken(header, claims);
+    VerifyAppCheckTokenOptions options =
+        VerifyAppCheckTokenOptions.builder().setConsume(true).build();
+    FirebaseAppCheckException ex =
+        assertThrows(
+            FirebaseAppCheckException.class, () -> customVerifier.verifyToken(token, options));
+
+    assertEquals(ErrorCode.INTERNAL, ex.getErrorCode());
+    assertEquals(AppCheckErrorCode.SERVICE_ERROR, ex.getAppCheckErrorCode());
+    assertNotNull(ex.getHttpResponse());
+    assertEquals(403, ex.getHttpResponse().getStatusCode());
+    assertEquals("{\"error\": \"Forbidden\"}", ex.getHttpResponse().getContent());
+  }
+
+  @Test
   public void testVerifyToken_NullOrEmptyToken_ThrowsException() {
     IllegalArgumentException ex1 =
         assertThrows(IllegalArgumentException.class, () -> verifier.verifyToken(null));

--- a/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
+++ b/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
@@ -57,6 +57,10 @@ import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.BadJOSEException;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -67,6 +71,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPublicKey;
 import java.util.Collections;
 import java.util.Date;
 import org.junit.After;
@@ -437,5 +442,110 @@ public class AppCheckTokenVerifierTest {
       assertEquals("Invalid JWKS URL", cause.getMessage());
       assertTrue(cause.getCause() instanceof MalformedURLException);
     }
+  }
+
+  @Test
+  public void testVerifyToken_RealJwtProcessor_Success() throws Exception {
+    RSAKey jwk =
+        new RSAKey.Builder((RSAPublicKey) rsaKeyPair.getPublic())
+            .keyID(KEY_ID)
+            .algorithm(JWSAlgorithm.RS256)
+            .build();
+    final JWKSource<SecurityContext> keySource = new ImmutableJWKSet<>(new JWKSet(jwk));
+
+    FirebaseApp realApp = FirebaseApp.initializeApp(firebaseOptions, "real-crypto-app");
+    AppCheckTokenVerifier realVerifier =
+        new AppCheckTokenVerifier(
+            realApp,
+            ApiClientUtils.newAuthorizedRequestFactory(realApp),
+            ApiClientUtils.getDefaultJsonFactory(),
+            null) {
+          @Override
+          protected JWKSource<SecurityContext> createKeySource() {
+            return keySource;
+          }
+        };
+
+    String token = createToken(header, claims);
+    VerifyAppCheckTokenResponse response = realVerifier.verifyToken(token);
+
+    assertNotNull(response);
+    assertEquals(APP_ID, response.getAppId());
+    assertEquals(APP_ID, response.getToken().getSubject());
+    assertEquals(ISSUER, response.getToken().getIssuer());
+    assertEquals(Collections.singletonList(AUDIENCE), response.getToken().getAudience());
+  }
+
+  @Test
+  public void testVerifyToken_RealJwtProcessor_InvalidSignature_ThrowsException() throws Exception {
+    KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+    gen.initialize(2048);
+    KeyPair otherKeyPair = gen.generateKeyPair();
+
+    RSAKey wrongJwk =
+        new RSAKey.Builder((RSAPublicKey) otherKeyPair.getPublic())
+            .keyID(KEY_ID)
+            .algorithm(JWSAlgorithm.RS256)
+            .build();
+    final JWKSource<SecurityContext> keySource = new ImmutableJWKSet<>(new JWKSet(wrongJwk));
+
+    FirebaseApp realApp = FirebaseApp.initializeApp(firebaseOptions, "bad-sig-app");
+    AppCheckTokenVerifier realVerifier =
+        new AppCheckTokenVerifier(
+            realApp,
+            ApiClientUtils.newAuthorizedRequestFactory(realApp),
+            ApiClientUtils.getDefaultJsonFactory(),
+            null) {
+          @Override
+          protected JWKSource<SecurityContext> createKeySource() {
+            return keySource;
+          }
+        };
+
+    String token = createToken(header, claims);
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> realVerifier.verifyToken(token));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("Failed to verify App Check token signature"));
+  }
+
+  @Test
+  public void testVerifyToken_RealJwtProcessor_ExpiredToken_ThrowsException() throws Exception {
+    RSAKey jwk =
+        new RSAKey.Builder((RSAPublicKey) rsaKeyPair.getPublic())
+            .keyID(KEY_ID)
+            .algorithm(JWSAlgorithm.RS256)
+            .build();
+    final JWKSource<SecurityContext> keySource = new ImmutableJWKSet<>(new JWKSet(jwk));
+
+    FirebaseApp realApp = FirebaseApp.initializeApp(firebaseOptions, "expired-token-app");
+    AppCheckTokenVerifier realVerifier =
+        new AppCheckTokenVerifier(
+            realApp,
+            ApiClientUtils.newAuthorizedRequestFactory(realApp),
+            ApiClientUtils.getDefaultJsonFactory(),
+            null) {
+          @Override
+          protected JWKSource<SecurityContext> createKeySource() {
+            return keySource;
+          }
+        };
+
+    Date pastIssueTime = new Date(System.currentTimeMillis() - 600000);
+    Date pastExpirationTime = new Date(System.currentTimeMillis() - 300000);
+    JWTClaimsSet expiredClaims =
+        new JWTClaimsSet.Builder()
+            .issuer(ISSUER)
+            .audience(AUDIENCE)
+            .subject(APP_ID)
+            .issueTime(pastIssueTime)
+            .expirationTime(pastExpirationTime)
+            .build();
+
+    String token = createToken(header, expiredClaims);
+    FirebaseAppCheckException ex =
+        assertThrows(FirebaseAppCheckException.class, () -> realVerifier.verifyToken(token));
+    assertEquals(ErrorCode.INVALID_ARGUMENT, ex.getErrorCode());
+    assertTrue(ex.getMessage().contains("Firebase App Check token has expired."));
   }
 }

--- a/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
+++ b/src/test/java/com/google/firebase/appcheck/internal/AppCheckTokenVerifierTest.java
@@ -168,8 +168,8 @@ public class AppCheckTokenVerifierTest {
     assertEquals(APP_ID, decodedToken.getSubject());
     assertEquals(ISSUER, decodedToken.getIssuer());
     assertEquals(Collections.singletonList(AUDIENCE), decodedToken.getAudience());
-    assertEquals(issueTime.getTime() / 1000L, decodedToken.getIssuedAt());
-    assertEquals(expirationTime.getTime() / 1000L, decodedToken.getExpirationTime());
+    assertEquals(issueTime.toInstant(), decodedToken.getIssuedAt());
+    assertEquals(expirationTime.toInstant(), decodedToken.getExpirationTime());
     assertEquals(ISSUER, decodedToken.getClaims().get("iss"));
     assertEquals(APP_ID, decodedToken.getClaims().get("sub"));
   }


### PR DESCRIPTION
This PR adds support for App Check standard token verification and one-time token verification for replay protection. This enables backend servers to verify standard App Check JWTs locally and optionally verify/consume limited-use (replay-protected) tokens via backend RPC.

- Adds the `FirebaseAppCheck` service entry point with synchronous and asynchronous `verifyToken` methods.
- Creates the data models and options (`DecodedAppCheckToken`, `VerifyAppCheckTokenResponse`, `VerifyAppCheckTokenOptions`, `FirebaseAppCheckException`) for token verification results and options.
- Verifies tokens locally using App Check public keys and calls the backend to consume one-time tokens.
- Adds full unit test suites